### PR TITLE
Fix: collection search 

### DIFF
--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionFilterModal.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionFilterModal.swift
@@ -41,7 +41,11 @@ struct CollectionFilterModal: View {
                             viewModel.tableDataModel.sortModel.order = order
                             
                             await MainActor.run {
-                                viewModel.setupAllCellModels(targetSchema: selectedSchemaKey)
+                                if viewModel.tableDataModel.filterModels.noFilterApplied && viewModel.tableDataModel.sortModel.order == .none {
+                                    viewModel.setupAllCellModels(targetSchema: viewModel.rootSchemaKey)
+                                } else {
+                                    viewModel.setupAllCellModels(targetSchema: selectedSchemaKey)
+                                }
                                 viewModel.sortRowsIfNeeded()
                                 viewModel.isSearching = false
                                 presentationMode.wrappedValue.dismiss()


### PR DESCRIPTION
Fix: if there are empty filters but there is a schema selected, dont need to expand the rows like we do in filters