### PR TITLE
NO-1491: Crash at collection initialization

### DIFF
--- a/Sources/JoyfillUI/View/Fields/TableView/TableImageView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableImageView.swift
@@ -26,6 +26,17 @@ import JoyfillModel
      }
     
     var body: some View {
+        if cellModel.viewMode == .quickView {
+            HStack(spacing: 2) {
+                Image(systemName: "photo")
+                    .grayLightThemeColor()
+                Text(cellModel.data.valueElements.count == 0 ? "" : "+\(cellModel.data.valueElements.count)")
+                    .darkLightThemeColor()
+            }
+            .font(.system(size: 15))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .contentShape(Rectangle())
+        } else {
         if #available(iOS 16, *) {
             Button(action: {
                 showMoreImages = Int.random(in: 0...100)
@@ -55,8 +66,7 @@ import JoyfillModel
                 cellModel.data = data
                 cellModel.didChange?(cellModel.data)
             }
-        }
-        else {
+        } else {
             Button(action: {
                 showMoreImages = Int.random(in: 0...100)
             }, label: {
@@ -85,6 +95,7 @@ import JoyfillModel
                 cellModel.data = data
                 cellModel.didChange?(cellModel.data)
             }
+        }
         }
     }
      

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -16,11 +16,9 @@ struct TableRowView : View {
                     TableViewCellBuilder(viewModel: viewModel, cellModel: $cellModel)
                 }
                 .frame(minWidth: Utility.getCellWidth(type: cellModel.data.type ?? .unknown,
-                                                      format: cellModel.data.format ?? .empty,
-                                                      text: cellModel.data.type == .block ? longestBlockText : ""),
+                                                      format: cellModel.data.format ?? .empty),
                        maxWidth: Utility.getCellWidth(type: cellModel.data.type ?? .unknown,
-                                                      format: cellModel.data.format ?? .empty,
-                                                      text: cellModel.data.type == .block ? longestBlockText : ""),
+                                                      format: cellModel.data.format ?? .empty),
                        minHeight: 50,
                        maxHeight: .infinity)
             }
@@ -251,8 +249,7 @@ struct TableModalView : View {
                     .padding(.all, 4)
                     .font(.system(size: 15))
                     .frame(width: Utility.getCellWidth(type: viewModel.tableDataModel.getColumnType(columnId: column.id ?? "") ?? .unknown,
-                                                       format: viewModel.tableDataModel.getColumnFormat(columnId: column.id ?? "") ?? .empty,
-                                                       text: longestBlockText))
+                                                       format: viewModel.tableDataModel.getColumnFormat(columnId: column.id ?? "") ?? .empty))
                     .frame(minHeight: textHeight)
                     .overlay(
                         Rectangle()

--- a/Sources/JoyfillUI/View/Utility.swift
+++ b/Sources/JoyfillUI/View/Utility.swift
@@ -13,7 +13,7 @@ class Utility {
     static let DEBOUNCE_TIME_IN_NANOSECONDS: UInt64 = 00
     static let singleColumnWidth: CGFloat = 200
     
-    static func getCellWidth(type: ColumnTypes, format: DateFormatType, text: String) -> CGFloat {
+    static func getCellWidth(type: ColumnTypes, format: DateFormatType) -> CGFloat {
         switch type {
 //        case .block:
 //            let measuredWidth = measureTextWidth(text: text, font: UIFont.systemFont(ofSize: 15)) + 20
@@ -26,13 +26,12 @@ class Utility {
         }
     }
     
-    static func getWidthForExpanderRow(columns: [FieldTableColumn], showSelector: Bool, text: String) -> CGFloat {
+    static func getWidthForExpanderRow(columns: [FieldTableColumn], showSelector: Bool) -> CGFloat {
         let totalWidth = columns.reduce(0) { accumulator, column in
             // Get width based on column type and format
             let columnWidth = Utility.getCellWidth(
                 type: column.type ?? .unknown,
-                format: DateFormatType(rawValue: column.format ?? "") ?? .empty,
-                text: text
+                format: DateFormatType(rawValue: column.format ?? "") ?? .empty
             )
             return accumulator + columnWidth
         }


### PR DESCRIPTION
Add dispatchQueue for background task
Prevent crash in initializeAsync by passing tableDataModel into background thread
Remove all the unwanted methods previously used for cell width calculation