### PR TITLE
No 1527:Fix duplicate changelogs appearing in a single image cell table/collection

### DIFF
--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -35,8 +35,8 @@ struct DateTimeView: View {
                     Button(action: {
                         isDatePickerPresented = false
                         let event = FieldChangeData(fieldIdentifier: dateTimeDataModel.fieldIdentifier, updateValue: ValueUnion.null)
-                        eventHandler.onChange(event: event)
                         eventHandler.onFocus(event: dateTimeDataModel.fieldIdentifier)
+                        eventHandler.onChange(event: event)
                     }, label: {
                         Image(systemName: "xmark.circle.fill")
                             .imageScale(.large)
@@ -78,8 +78,8 @@ struct DateTimeView: View {
             let convertDateToInt = dateToTimestampMilliseconds(date: selectedDate)
             let newDateValue = ValueUnion.double(convertDateToInt)
             let event = FieldChangeData(fieldIdentifier: dateTimeDataModel.fieldIdentifier, updateValue: newDateValue)
-            eventHandler.onChange(event: event)
             eventHandler.onFocus(event: dateTimeDataModel.fieldIdentifier)
+            eventHandler.onChange(event: event)
         }
         .onAppear {
             lastModelValue = dateTimeDataModel.value

--- a/Sources/JoyfillUI/View/Fields/TableView/TableImageView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableImageView.swift
@@ -128,7 +128,6 @@ import JoyfillModel
                  self.valueElements.append(valueElement)
                  cellModel.data.valueElements.append(valueElement)
              }
-             cellModel.didChange?(cellModel.data)
          }
          cellModel.documentEditor?.onUpload(event: uploadEvent)
      }


### PR DESCRIPTION
1. Fix duplicate changeLogs appearing in a single image cell table/collection
2. Fix date field on focus changeLog - was coming after onChange 