### PR TITLE
NO-1555: Handle empty color value so block field is still displayed

### DIFF
--- a/Sources/JoyfillUI/View/Fields/DisplayTextView.swift
+++ b/Sources/JoyfillUI/View/Fields/DisplayTextView.swift
@@ -35,7 +35,7 @@ struct DisplayTextView: View {
         }
         
         // Font color
-        if let colorString = displayTextDataModel.fontColor {
+        if let colorString = displayTextDataModel.fontColor, !colorString.isEmpty {
             self.fontColor = Color(hex: colorString)
         } else {
             self.fontColor = .primary
@@ -77,14 +77,14 @@ struct DisplayTextView: View {
         }
         
         // Background color
-        if let bgColorString = displayTextDataModel.backgroundColor {
+        if let bgColorString = displayTextDataModel.backgroundColor, !bgColorString.isEmpty {
             self.backgroundColor = Color(hex: bgColorString)
         } else {
             self.backgroundColor = .clear
         }
         
         // Border color
-        if let borderColorString = displayTextDataModel.borderColor {
+        if let borderColorString = displayTextDataModel.borderColor, !borderColorString.isEmpty {
             self.borderColor = Color(hex: borderColorString)
         } else {
             self.borderColor = .clear


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/Block-field-doesn-t-appear-if-color-is-empty-string-281def37c9a080e3ba79e52708f96fb5?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)