### PR TITLE
No-1651: Auto-scroll to selected row when navigating with arrows in table/collection

### DIFF
--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -193,6 +193,14 @@ struct CollectionModalView : View {
                         cellProxy.scrollTo(0, anchor: .leading)
                     })
                 }
+                .onChange(of: viewModel.tableDataModel.selectedRows) { selectedRows in
+                    // Scroll to keep selected row in view when navigating with arrows
+                    if let selectedRowID = selectedRows.first, selectedRows.count == 1 {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            cellProxy.scrollTo(selectedRowID, anchor: .leading)
+                        }
+                    }
+                }
                 .simultaneousGesture(DragGesture().onChanged({ _ in
                     dismissKeyboard()
                 }))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -298,7 +298,7 @@ struct TableModalView : View {
                 if #available(iOS 16, *) {
                     ScrollView([.vertical, .horizontal], showsIndicators: false) {
                         LazyVStack(alignment: .leading, spacing: 0) {
-                            ForEach($viewModel.tableDataModel.filteredcellModels, id: \.self) { $rowCellModels in
+                            ForEach($viewModel.tableDataModel.filteredcellModels, id: \.rowID) { $rowCellModels in
                                 let isRowSelected = viewModel.tableDataModel.selectedRows.contains(rowCellModels.rowID)
                                 TableRowView(viewModel: viewModel, rowDataModel: $rowCellModels, longestBlockText: longestBlockText, isSelected: isRowSelected)
                                     .frame(height: 60)
@@ -319,6 +319,14 @@ struct TableModalView : View {
                         DispatchQueue.main.asyncAfter(deadline: .now()+0.01, execute: {
                             cellProxy.scrollTo(0, anchor: .leading)
                         })
+                    }
+                    .onChange(of: viewModel.tableDataModel.selectedRows) { selectedRows in
+                        // Scroll to keep selected row in view when navigating with arrows
+                        if let selectedRowID = selectedRows.first, selectedRows.count == 1 {
+                            withAnimation(.easeInOut(duration: 0.3)) {
+                                cellProxy.scrollTo(selectedRowID, anchor: .leading)
+                            }
+                        }
                     }
                     .gesture(DragGesture().onChanged({ _ in
                         dismissKeyboard()
@@ -326,7 +334,7 @@ struct TableModalView : View {
                 } else {
                     ScrollView([.vertical, .horizontal], showsIndicators: false) {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach($viewModel.tableDataModel.filteredcellModels, id: \.self) { $rowCellModels in
+                            ForEach($viewModel.tableDataModel.filteredcellModels, id: \.rowID) { $rowCellModels in
                                 let isRowSelected = viewModel.tableDataModel.selectedRows.contains(rowCellModels.rowID)
                                 TableRowView(viewModel: viewModel, rowDataModel: $rowCellModels, longestBlockText: longestBlockText, isSelected: isRowSelected)
                                     .frame(height: 60)
@@ -347,6 +355,14 @@ struct TableModalView : View {
                         DispatchQueue.main.asyncAfter(deadline: .now()+0.01, execute: {
                             cellProxy.scrollTo(0, anchor: .leading)
                         })
+                    }
+                    .onChange(of: viewModel.tableDataModel.selectedRows) { selectedRows in
+                        // Scroll to keep selected row in view when navigating with arrows
+                        if let selectedRowID = selectedRows.first, selectedRows.count == 1 {
+                            withAnimation(.easeInOut(duration: 0.3)) {
+                                cellProxy.scrollTo(selectedRowID, anchor: .leading)
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/joyfill/JF-223-Navigating-in-collection-field-and-table-field-should-auto-scroll-to-keep-selected-row-in-vi-2a0def37c9a0804f8fa1fa584e0b6af9?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)