### PR TITLE
NO-1679: Align Clear and Save buttons to the same height

### DIFF
--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -312,9 +312,14 @@ struct CanvasSignatureView: View {
                         presentationMode.wrappedValue.dismiss()
                     }, label: {
                         Text("Save")
+                            .foregroundColor(.white)
                             .frame(minWidth: 100, maxWidth: .infinity)
+                            .frame(height: 40)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.accentColor)
+                            )
                     })
-                    .buttonStyle(.borderedProminent)
                     .accessibilityIdentifier("SaveSignatureIdentifier")
                     Spacer()
                 }


### PR DESCRIPTION
[Ticket link](https://www.notion.so/joyfill/Signature-Clear-button-and-save-button-must-be-off-the-same-height-2a9def37c9a080c9a870c3f7b93a9561?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)