### PR TITLE
Fix on change handler crash

### DIFF
--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -210,6 +210,18 @@ enum FieldListModelType: Equatable {
     case none
 }
 
+extension FieldListModelType {
+    var tableDataModel: TableDataModel? {
+        if case .table(let model) = self {
+            return model
+        }
+        if case .collection(let model) = self {
+            return model
+        }
+        return nil
+    }
+}
+
 struct FormView: View {
     @Binding var listModels: [FieldListModel]
     @State var currentFocusedFieldsID: String = ""

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -193,11 +193,14 @@ public class DocumentEditor: ObservableObject {
         }
         switch field.fieldType {
         case .table, .collection:
-            DispatchQueue.main.async(execute: {
-                self.delegateMap[fieldID]?.value?.applyRowEditChanges(change: change)
+            DispatchQueue.main.async {
+                guard let valueDelegate = self.valueDelegate(for: fieldID, fieldType: field.fieldType) else {
+                    return
+                }
+                valueDelegate.applyRowEditChanges(change: change)
                 self.refreshField(fieldId: fieldID)
                 self.refreshDependent(for: fieldID)
-            })
+            }
         default:
             break
         }
@@ -212,12 +215,42 @@ public class DocumentEditor: ObservableObject {
         }
         switch field.fieldType {
         case  .table, .collection:
-            delegateMap[fieldID]?.value?.insertRow(for: change)
-            refreshField(fieldId: fieldID)
-            refreshDependent(for: fieldID)
+            if let valueDelegate = valueDelegate(for: fieldID, fieldType: field.fieldType) {
+                valueDelegate.insertRow(for: change)
+                refreshField(fieldId: fieldID)
+                refreshDependent(for: fieldID)
+            }
         default:
             break
         }
+    }
+    
+    private func createViewModel(for fieldID: String, fieldType: FieldTypes) -> DocumentEditorDelegate? {
+        if let fieldPosition = fieldPosition(fieldID: fieldID) {
+            let fieldIdentifier = getFieldIdentifier(for: fieldID)
+            if let tableDataModel = getFieldModel(fieldPosition: fieldPosition, fieldIdentifier: fieldIdentifier).tableDataModel {
+                switch fieldType {
+                case .table:
+                    return TableViewModel(tableDataModel: tableDataModel)
+                case .collection:
+                    return CollectionViewModel(tableDataModel: tableDataModel)
+                default:
+                    break
+                }
+            }
+        }
+        return nil
+    }
+
+    private func valueDelegate(for fieldID: String, fieldType: FieldTypes) -> DocumentEditorDelegate? {
+        if let delegate = delegateMap[fieldID]?.value {
+            return delegate
+        }
+        guard let newDelegate = createViewModel(for: fieldID, fieldType: fieldType) else {
+            return nil
+        }
+        delegateMap[fieldID] = WeakDocumentEditorDelegate(newDelegate)
+        return newDelegate
     }
 
     private func handleFieldValueRowDelete(for change: Change) {
@@ -229,9 +262,11 @@ public class DocumentEditor: ObservableObject {
         }
         switch field.fieldType {
         case .table, .collection:
-            delegateMap[fieldID]?.value?.deleteRow(for: change)
-            refreshField(fieldId: fieldID)
-            refreshDependent(for: fieldID)
+            if let valueDelegate = valueDelegate(for: fieldID, fieldType: field.fieldType) {
+                valueDelegate.deleteRow(for: change)
+                refreshField(fieldId: fieldID)
+                refreshDependent(for: fieldID)
+            }
         default:
             break
         }
@@ -245,9 +280,11 @@ public class DocumentEditor: ObservableObject {
         }
         switch field.fieldType {
         case .table, .collection:
-            delegateMap[fieldID]?.value?.moveRow(for: change)
-            refreshField(fieldId: fieldID)
-            refreshDependent(for: fieldID)
+            if let valueDelegate = valueDelegate(for: fieldID, fieldType: field.fieldType) {
+                valueDelegate.moveRow(for: change)
+                refreshField(fieldId: fieldID)
+                refreshDependent(for: fieldID)
+            }
         default:
             break
         }


### PR DESCRIPTION
Fix on change handler crash by creating viewModel when found nil in delegate map
Here is [Notion ticket ](https://www.notion.so/joyfill/On-change-handler-crash-2a9def37c9a0803ebed7fc274db8abd8?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)