### PR TITLE
Support RGBA format color

### DIFF
--- a/Sources/JoyfillUI/Extensions/Color+Extension.swift
+++ b/Sources/JoyfillUI/Extensions/Color+Extension.swift
@@ -30,8 +30,8 @@ extension Color {
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
         case 6: // RGB (24-bit)
             (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
-            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // RGBA (32-bit)
+            (a, r, g, b) = (int & 0xFF, int >> 24 & 0xFF, int >> 16 & 0xFF, int >> 8 & 0xFF)
         default:
             (a, r, g, b) = (1, 1, 1, 0)
         }


### PR DESCRIPTION
Added support for RGBA color format. Earlier, we were expecting ARGB, but our web implementation only supports RGBA. Hence, we made the same change on the iOS side.

https://www.notion.so/joyfill/Uptick-heading-colour-issue-2c5def37c9a080858f33d6c75afda22a?v=136def37c9a080c98eac000c50ab34c2&source=copy_link
