### PR TITLE
Fix crash when tapping the Single-Click Row Edit button

### DIFF
--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -113,9 +113,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                     rowCellModels.append(cellModel)
                 }
             }
-            if !rowCellModels.isEmpty {
-                cellModels.append(RowDataModel(rowID: rowID, cells: rowCellModels, rowType: .row(index: cellModels.count)))
-            }
+            cellModels.append(RowDataModel(rowID: rowID, cells: rowCellModels, rowType: .row(index: cellModels.count)))
         }
         tableDataModel.cellModels = cellModels
         tableDataModel.filteredcellModels = cellModels

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -113,7 +113,9 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                     rowCellModels.append(cellModel)
                 }
             }
-            cellModels.append(RowDataModel(rowID: rowID, cells: rowCellModels, rowType: .row(index: cellModels.count)))
+            if !rowCellModels.isEmpty {
+                cellModels.append(RowDataModel(rowID: rowID, cells: rowCellModels, rowType: .row(index: cellModels.count)))
+            }
         }
         tableDataModel.cellModels = cellModels
         tableDataModel.filteredcellModels = cellModels

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -207,7 +207,7 @@ struct TableDataModel {
         self.fieldPositionTableColumns = fieldPosition.tableColumns
         self.fieldType = fieldData.fieldType
         self.singleClickRowEdit = documentEditor.singleClickRowEdit
-                
+        self.cleanUpRowOrder()
         if fieldData.fieldType == .collection {
             self.schema = fieldData.schema ?? [:]
             buildFullSchemaChainMap()
@@ -262,6 +262,17 @@ struct TableDataModel {
         for (key, value) in schema where value.root == true {
             dfs(currentKey: key, currentPath: [], map: &schemaChainMap)
         }
+    }
+    
+    mutating func cleanUpRowOrder() {
+        // Keep only ids that still exist in valueToValueElements (non-deleted)
+        let existingRowIds = Set(
+            (valueToValueElements ?? [])
+                .filter { ($0.deleted ?? false) == false }
+                .compactMap { $0.id }
+        )
+
+        rowOrder = rowOrder.filter { existingRowIds.contains($0) }
     }
     
     func shouldShowSchemaAccToFilters(schemaID: String) -> Bool {
@@ -773,16 +784,29 @@ struct TableDataModel {
     }
     
     func getDummyNestedCell(col: Int, isBulkEdit: Bool, rowID: String) -> CellDataModel? {
-        let selectedRow = filteredcellModels.first(where: { $0.rowID == rowID })
-        var cell = selectedRow?.cells[col].data
-        if isBulkEdit {
-            cell?.title = ""
-            cell?.defaultDropdownSelectedId = nil
-            cell?.valueElements = []
-            cell?.number = nil
-            cell?.date = nil
-            cell?.multiSelectValues = nil
+        // Find the selected row
+        guard let selectedRow = filteredcellModels.first(where: { $0.rowID == rowID }) else {
+            Log("getDummyNestedCell: Row not found with ID \(rowID)", type: .warning)
+            return nil
         }
+        
+        // Validate column index to prevent crash
+        guard col >= 0, col < selectedRow.cells.count else {
+            Log("getDummyNestedCell: Invalid column index \(col) for row \(rowID). Row has \(selectedRow.cells.count) cells but tried to access index \(col)", type: .error)
+            return nil
+        }
+        
+        var cell = selectedRow.cells[col].data
+        
+        if isBulkEdit {
+            cell.title = ""
+            cell.defaultDropdownSelectedId = nil
+            cell.valueElements = []
+            cell.number = nil
+            cell.date = nil
+            cell.multiSelectValues = nil
+        }
+        
         return cell
     }
     

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -265,13 +265,20 @@ struct TableDataModel {
     }
     
     mutating func cleanUpRowOrder() {
-        // Keep only ids that still exist in valueToValueElements (non-deleted)
-        let existingRowIds = Set(
-            (valueToValueElements ?? [])
-                .filter { ($0.deleted ?? false) == false }
-                .compactMap { $0.id }
-        )
-
+        guard let elements = valueToValueElements, !elements.isEmpty else {
+            rowOrder.removeAll()
+            return
+        }
+        
+        var existingRowIds = Set<String>()
+        existingRowIds.reserveCapacity(elements.count)
+        
+        for element in elements {
+            if element.deleted != true, let id = element.id {
+                existingRowIds.insert(id)
+            }
+        }
+        
         rowOrder = rowOrder.filter { existingRowIds.contains($0) }
     }
     


### PR DESCRIPTION
The crash occurred because of inconsistent table data: some rowIds existed in rowOrder but were missing from valueToValueElements.
Fix: removed invalid/missing rowIds from rowOrder to prevent corrupted state and crashes.
[Ticket link](https://www.notion.so/JF-260-iOS-Crash-after-row-tab-to-edit-button-is-clicked-2efdef37c9a080fabe74dbec8f9387e6?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes during Single-Click Row Edit by sanitizing table data and hardening nested cell access.
> 
> - Adds `cleanUpRowOrder()` to remove missing/deleted row IDs from `rowOrder`, invoked during `TableDataModel` init
> - Strengthens `getDummyNestedCell` with row lookup and column bounds validation plus logging; simplifies bulk-edit by resetting fields on a non-optional `CellDataModel`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad4288122bbe091e1a7e0d5690b6ad20f5100d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->