### PR TITLE
Fix duplicate page functionality

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -339,6 +339,9 @@
 		E28D10AD2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
 		E28D10AE2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
 		E28D10AF2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
+		E29FF87F2F2527540079A614 /* TestMobileViewDuplicateLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = E29FF87E2F2527540079A614 /* TestMobileViewDuplicateLogic.json */; };
+		E29FF8802F2527540079A614 /* TestMobileViewDuplicateLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = E29FF87E2F2527540079A614 /* TestMobileViewDuplicateLogic.json */; };
+		E29FF8822F2527790079A614 /* TestMobileViewDuplicateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29FF8812F2527790079A614 /* TestMobileViewDuplicateLogic.swift */; };
 		E2A67F7C2E2FF618000E057F /* TableFieldTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = E2F5688B2E2A45F9005216A6 /* TableFieldTestData.json */; };
 		E2A683EE2DC8F5FC00385FE1 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = E2A683ED2DC8F5FC00385FE1 /* JoyfillModel */; };
 		E2A683F22DC8FC3A00385FE1 /* FormContainerTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A683F12DC8FC3A00385FE1 /* FormContainerTestView.swift */; };
@@ -610,6 +613,8 @@
 		E28D10A42E2E08E100E59B5F /* EncapsulatedCircularReference_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EncapsulatedCircularReference_FormulaTemplate.json; sourceTree = "<group>"; };
 		E28D10A82E2E08F700E59B5F /* ImplicitCircularReferenceObjectArrayConstruction_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ImplicitCircularReferenceObjectArrayConstruction_FormulaTemplate.json; sourceTree = "<group>"; };
 		E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FormulaTemplate_ConditionalEvaluationCircularReference.json; sourceTree = "<group>"; };
+		E29FF87E2F2527540079A614 /* TestMobileViewDuplicateLogic.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TestMobileViewDuplicateLogic.json; sourceTree = "<group>"; };
+		E29FF8812F2527790079A614 /* TestMobileViewDuplicateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMobileViewDuplicateLogic.swift; sourceTree = "<group>"; };
 		E2A683F12DC8FC3A00385FE1 /* FormContainerTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormContainerTestView.swift; sourceTree = "<group>"; };
 		E2A684362DCA40AF00385FE1 /* FormContainerTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormContainerTestView.swift; sourceTree = "<group>"; };
 		E2A6843A2DCA413B00385FE1 /* ImageReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageReplacementTest.swift; sourceTree = "<group>"; };
@@ -1219,7 +1224,9 @@
 			isa = PBXGroup;
 			children = (
 				E2F5689F2E2A4724005216A6 /* TextFieldTestData.json */,
+				E29FF87E2F2527540079A614 /* TestMobileViewDuplicateLogic.json */,
 				E2F568A02E2A4724005216A6 /* TextFieldUITestCases.swift */,
+				E29FF8812F2527790079A614 /* TestMobileViewDuplicateLogic.swift */,
 			);
 			path = TextField;
 			sourceTree = "<group>";
@@ -1570,6 +1577,7 @@
 				E274CB172E2E84F700B35C09 /* textFieldValidation.json in Resources */,
 				E274CB182E2E84F700B35C09 /* baseTableTemplateValidation.json in Resources */,
 				E274CB192E2E84F700B35C09 /* tableFieldValidation.json in Resources */,
+				E29FF8802F2527540079A614 /* TestMobileViewDuplicateLogic.json in Resources */,
 				E274CB1A2E2E84F700B35C09 /* baseMultiselectTemplateValidation.json in Resources */,
 				E274CB1B2E2E84F700B35C09 /* baseMultilineTemplateValidation.json in Resources */,
 				E274CB1C2E2E84F700B35C09 /* multiSelectFieldValidation.json in Resources */,
@@ -1755,6 +1763,7 @@
 				36A5EF482E29725B0059C2A6 /* hint_and_deficiency_demo.json in Resources */,
 				9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */,
 				36A5EF4A2E29725B0059C2A6 /* CollectionFilter.json in Resources */,
+				E29FF87F2F2527540079A614 /* TestMobileViewDuplicateLogic.json in Resources */,
 				E274CA502E2E7FB000B35C09 /* chartField.json in Resources */,
 				E274CA512E2E7FB000B35C09 /* numberField.json in Resources */,
 				E274CA522E2E7FB000B35C09 /* textField.json in Resources */,
@@ -1844,6 +1853,7 @@
 				E2F568A72E2A473D005216A6 /* DisplayTextFieldUITestCases.swift in Sources */,
 				E2F568752E2A4594005216A6 /* ImageFieldUITestCases.swift in Sources */,
 				E2F568762E2A4594005216A6 /* ImageFieldTests.swift in Sources */,
+				E29FF8822F2527790079A614 /* TestMobileViewDuplicateLogic.swift in Sources */,
 				1307CF1E2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift in Sources */,
 				E2F5687C2E2A45A8005216A6 /* SignatureFieldTests.swift in Sources */,
 				E2F5687D2E2A45A8005216A6 /* SignatureFieldUITestCases.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.json
@@ -1,0 +1,265 @@
+{
+  "fields": [
+    {
+      "rowOrder": [
+        "6972214034507075a03f4538",
+        "69722140c3599f9965167824",
+        "6972214026a5529c556c5085"
+      ],
+      "value": [
+        {
+          "_id": "6972214034507075a03f4538",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "69722140c3599f9965167824",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "6972214026a5529c556c5085",
+          "deleted": false,
+          "cells": {}
+        }
+      ],
+      "tableColumns": [
+        {
+          "deleted": false,
+          "_id": "69722140bca0ac741fb4242b",
+          "title": "Text Column",
+          "type": "text",
+          "width": 0,
+          "identifier": "6973775bb51adf823281f48f_column_69722140bca0ac741fb4242b"
+        },
+        {
+          "_id": "697221402fd59f3b4acec998",
+          "deleted": false,
+          "title": "Dropdown Column",
+          "width": 0,
+          "identifier": "6973775bb51adf823281f48f_column_697221402fd59f3b4acec998",
+          "type": "dropdown",
+          "options": [
+            {
+              "_id": "6972214049a1ecc69d4724a3",
+              "value": "Yes",
+              "deleted": false
+            },
+            {
+              "_id": "697221401302f628a75ba39e",
+              "value": "No",
+              "deleted": false
+            },
+            {
+              "_id": "6972214023d8b4669ebc0cb6",
+              "value": "N/A",
+              "deleted": false
+            }
+          ]
+        },
+        {
+          "deleted": false,
+          "_id": "697221402f8132c1326ac4b1",
+          "title": "Text Column",
+          "type": "text",
+          "width": 0,
+          "identifier": "6973775bb51adf823281f48f_column_697221402f8132c1326ac4b1"
+        }
+      ],
+      "identifier": "field_6973775bb51adf823281f48f",
+      "title": "Table",
+      "type": "table",
+      "_id": "6973775bb51adf823281f48f",
+      "tableColumnOrder": [
+        "69722140bca0ac741fb4242b",
+        "697221402fd59f3b4acec998",
+        "697221402f8132c1326ac4b1"
+      ],
+      "file": "67ad80c3a75f4648fb495481",
+      "logic": {
+        "action": "show",
+        "eval": "and",
+        "conditions": [
+          {
+            "file": "67ad80c3a75f4648fb495481",
+            "page": "67ad80e5063c0626e9c2d789",
+            "field": "6974ead090640b3bbe264785",
+            "condition": "=",
+            "value": 100
+          }
+        ]
+      },
+      "hidden": true
+    },
+    {
+      "file": "67ad80c3a75f4648fb495481",
+      "_id": "6974ead090640b3bbe264785",
+      "type": "number",
+      "title": "Number",
+      "identifier": "field_6974ead090640b3bbe264785"
+    },
+    {
+      "file": "67ad80c3a75f4648fb495481",
+      "_id": "6974ef957b5a6a28952830f0",
+      "type": "textarea",
+      "title": "Multiline Text",
+      "identifier": "field_6974ef957b5a6a28952830f0"
+    },
+    {
+      "file": "67ad80c3a75f4648fb495481",
+      "_id": "6974ef96bf7345b495222839",
+      "type": "date",
+      "title": "Date Time",
+      "identifier": "field_6974ef96bf7345b495222839"
+    },
+    {
+      "file": "67ad80c3a75f4648fb495481",
+      "_id": "6974ef976e802c16dbb6419f",
+      "type": "dropdown",
+      "title": "Dropdown",
+      "options": [
+        {
+          "_id": "69722140241a2ae6b2dcca8d",
+          "value": "Yes",
+          "deleted": false
+        },
+        {
+          "_id": "69722140328896af7d67c974",
+          "value": "No",
+          "deleted": false
+        },
+        {
+          "_id": "697221406ac405acdb4cce5a",
+          "value": "N/A",
+          "deleted": false
+        }
+      ],
+      "identifier": "field_6974ef976e802c16dbb6419f"
+    }
+  ],
+  "_id": "67ad812e4cb748d7fa5ff17a",
+  "deleted": false,
+  "createdOn": 1739424046649,
+  "source": "template_67ad80c3ac77805ed95fc898",
+  "files": [
+    {
+      "name": "Test Hidden First Page",
+      "pages": [
+        {
+          "presentation": "normal",
+          "layout": "grid",
+          "borderWidth": 0,
+          "hidden": false,
+          "width": 816,
+          "name": "Page 2 ",
+          "_id": "67ad80e5063c0626e9c2d789",
+          "cols": 8,
+          "metadata": {},
+          "fieldPositions": [
+            {
+              "_id": "6974ef954265d1fe4c11c36c",
+              "type": "textarea",
+              "displayType": "original",
+              "x": 2,
+              "y": 0,
+              "width": 4,
+              "height": 23,
+              "field": "6974ef957b5a6a28952830f0"
+            },
+            {
+              "_id": "6974ef96a6c8d70c6d260d8c",
+              "type": "date",
+              "displayType": "original",
+              "format": "MM/DD/YYYY hh:mma",
+              "x": 1,
+              "y": 23,
+              "width": 4,
+              "height": 8,
+              "field": "6974ef96bf7345b495222839"
+            },
+            {
+              "_id": "6974ef97a16ea1986f9c4cf2",
+              "type": "dropdown",
+              "displayType": "original",
+              "targetValue": "69722140241a2ae6b2dcca8d",
+              "x": 3,
+              "y": 31,
+              "width": 4,
+              "height": 8,
+              "field": "6974ef976e802c16dbb6419f"
+            }
+          ],
+          "padding": 24,
+          "margin": 0,
+          "rowHeight": 8,
+          "height": 1056
+        }
+      ],
+      "views": [
+        {
+          "pages": [
+            {
+              "hidden": false,
+              "metadata": {},
+              "padding": 12,
+              "name": "Page 2 ",
+              "margin": 0,
+              "width": 816,
+              "height": 1056,
+              "rowHeight": 1,
+              "fileName": "",
+              "borderWidth": 0,
+              "presentation": "normal",
+              "cols": 1,
+              "layout": "grid",
+              "filePath": "",
+              "backgroundImage": "",
+              "fieldPositions": [
+                {
+                  "_id": "6973775b1b7ca3cc94f959cc",
+                  "x": 0,
+                  "height": 116,
+                  "y": 64,
+                  "width": 1,
+                  "field": "6973775bb51adf823281f48f",
+                  "type": "table",
+                  "displayType": "original"
+                },
+                {
+                  "_id": "6974ead0ea8a3e7db49566b2",
+                  "type": "number",
+                  "displayType": "original",
+                  "x": 0,
+                  "y": 0,
+                  "width": 1,
+                  "height": 64,
+                  "field": "6974ead090640b3bbe264785"
+                }
+              ],
+              "_id": "67ad80e5063c0626e9c2d789"
+            }
+          ],
+          "pageOrder": [
+            "67ad80e5063c0626e9c2d789"
+          ],
+          "type": "mobile",
+          "_id": "69737752bfe554fc7738e76b"
+        }
+      ],
+      "_id": "67ad80c3a75f4648fb495481",
+      "styles": {
+        "margin": 4
+      },
+      "metadata": {},
+      "version": 1,
+      "pageOrder": [
+        "67ad80e5063c0626e9c2d789"
+      ]
+    }
+  ],
+  "metadata": {},
+  "type": "template",
+  "identifier": "doc_67ad812e4cb748d7fa5ff17a",
+  "stage": "published",
+  "name": "Test Hidden Page"
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.swift
@@ -1,0 +1,39 @@
+//
+//  MultiSelectFieldUITestCases.swift
+//  JoyfillUITests
+//
+//  Created by Vivek on 07/07/25.
+//
+
+import XCTest
+import JoyfillModel
+
+final class TestMobileViewDuplicateLogic: JoyfillUITestsBaseClass {
+    // Override to specify which JSON file to use for this test class
+    override func getJSONFileNameForTest() -> String {
+        return "TestMobileViewDuplicateLogic"
+    }
+    
+    func testMobileViewConditonalLogic() {
+        app.launchArguments.append("--page-duplicate-enabled")
+        app.launchArguments.append("true")
+        XCTAssertTrue(!app.staticTexts["Table"].exists)
+        let pageSelectionButton = app.buttons["PageNavigationIdentifier"]
+        pageSelectionButton.tap()
+        let duplicateButton = app.buttons["PageDuplicateIdentifier"]
+        duplicateButton.firstMatch.tap()
+        
+        let pageSheetSelectionButton = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        let tapOnSecondPage = pageSheetSelectionButton.element(boundBy: 1)
+        tapOnSecondPage.tap()
+        
+        let textField = app.textFields.element(boundBy: 0)
+        textField.tap()
+        textField.clearText()
+        textField.typeText("100")
+        
+        app.swipeDown()
+        
+        XCTAssertTrue(app.staticTexts["Table"].exists)
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TextField/TestMobileViewDuplicateLogic.swift
@@ -14,9 +14,67 @@ final class TestMobileViewDuplicateLogic: JoyfillUITestsBaseClass {
         return "TestMobileViewDuplicateLogic"
     }
     
-    func testMobileViewConditonalLogic() {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        
+        // Force cleanup
+        forceCleanupExistingApp()
+        
+        // Create app instance
+        self.app = XCUIApplication()
+        
+        // Add all standard launch arguments (from base class)
+        let testIdentifier = UUID().uuidString
+        app.launchArguments.append("JoyfillUITests")
+        app.launchArguments.append("--test-id")
+        app.launchArguments.append(testIdentifier)
+        app.launchArguments.append("--test-specific-id")
+        app.launchArguments.append("\(self.name)-\(testIdentifier)")
+        app.launchArguments.append("--json-file")
+        app.launchArguments.append(getJSONFileNameForTest())
+        app.launchArguments.append("--test-name")
+        app.launchArguments.append(self.name)
+        app.launchArguments.append("--test-run-id")
+        app.launchArguments.append(UUID().uuidString)
+        
+        // Add custom launch arguments for this test
         app.launchArguments.append("--page-duplicate-enabled")
         app.launchArguments.append("true")
+        
+        // Disable hardware keyboard
+        disableHardwareKeyboardForAllTests()
+        
+        // Crash prevention
+        app.launchArguments.append("--safe-mode")
+        app.launchArguments.append("--disable-crash-on-error")
+        app.launchArguments.append("--fresh-instance")
+        
+        // Alert handler
+        addUIInterruptionMonitor(withDescription: "System Alerts") { alert in
+            for btn in ["Allow", "OK", "Continue", "Don't Allow", "Remind Me Later", "While Using the App"] {
+                if alert.buttons[btn].exists {
+                    alert.buttons[btn].tap()
+                    return true
+                }
+            }
+            return false
+        }
+        
+        // Launch app
+        do {
+            app.launch()
+            XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15), "App did not launch")
+            app.activate()
+            XCTAssertTrue(waitForAppStability(timeout: 15), "App not stable")
+            verifyHardwareKeyboardDisabled()
+            ensureAppStability()
+        } catch {
+            print("❌ Launch failed: \(error)")
+            throw error
+        }
+    }
+    
+    func testMobileViewConditonalLogic() {
         XCTAssertTrue(!app.staticTexts["Table"].exists)
         let pageSelectionButton = app.buttons["PageNavigationIdentifier"]
         pageSelectionButton.tap()

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -803,16 +803,16 @@ extension DocumentEditor {
             Log("No file found in document.", type: .error)
             return
         }
-        
-        guard let originalPageIndex = firstFile.pages?.firstIndex(where: { $0.id == pageID }) else {
-            Log("Page with id \(pageID) not found in file.pages.", type: .error)
+        let originalPage: Page
+        if let viewPage = firstFile.views?.first?.pages?.first(where: { $0.id == pageID }) {
+            originalPage = viewPage
+        } else if let mainPage = firstFile.pages?.first(where: { $0.id == pageID }) {
+            originalPage = mainPage
+        } else {
+            Log("Page with id \(pageID) not found in views or pages.", type: .error)
             return
         }
-        guard let pages = firstFile.pages else {
-            Log("No pages found in file", type: .error)
-            return
-        }
-        let originalPage = pages[originalPageIndex]
+
         let newPageID = generateObjectId()
         
         var duplicatedPage = originalPage


### PR DESCRIPTION
It solves a page duplicate issue because it was taking page from file.pages even if its a mobile view Plus It solves an conditional logic issue for duplicated page
[Ticket link](https://www.notion.so/Conditional-Logic-Doesn-t-Work-On-Duplicated-Page-2e9def37c9a0805782d0fd1fc35ee387?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures page duplication works correctly for mobile views and retains conditional logic on the duplicated page.
> 
> - Updates `DocumentEditor.duplicatePage` to resolve the source page from `views.pages` first, falling back to `pages`, fixing duplication when using mobile views and ensuring field/position remapping keeps logic intact
> - Adds `TestMobileViewDuplicateLogic.swift` and `TestMobileViewDuplicateLogic.json` UI test/fixture to verify that duplicating a page in mobile view preserves conditional visibility (e.g., showing `Table` after entering `100`)
> - Includes project configuration updates to register the new test and resource files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281fb58b19231c82dac3b971255a14e8b41d5792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->