### PR TITLE
No 1786: Delete Page Round 2

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -22,10 +22,6 @@ final class ValidationTestCase: XCTestCase {
         func onUpload(event: UploadEvent) {}
         func onError(error: JoyfillError) {}
         
-        /// Reset captured changes between tests
-        func reset() {
-            capturedChanges.removeAll()
-        }
     }
     func documentEditor(document: JoyDoc) -> DocumentEditor {
         DocumentEditor(document: document, validateSchema: false)
@@ -1307,8 +1303,6 @@ final class ValidationTestCase: XCTestCase {
         let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
         let documentEditor = documentEditor(document: document)
         
-        // Verify shared field exists before deletion
-        let initialFieldCount = documentEditor.document.fields.count
         XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }), 
                      "Shared field should exist before deletion")
         

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -983,9 +983,9 @@ final class ValidationTestCase: XCTestCase {
         
         XCTAssertTrue(initialPageCount >= 2, "Document should have at least 2 pages")
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
         
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         let finalPageCount = documentEditor.document.files.first?.pages?.count ?? 0
         let finalPageOrderCount = documentEditor.document.files.first?.pageOrder?.count ?? 0
@@ -1016,9 +1016,9 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertFalse(canDelete, "Should not be able to delete the last page")
         XCTAssertTrue(warnings.contains(where: { $0.contains("last page") }), "Warning should mention last page")
         
-        let result = documentEditor.deletePage(pageID: pageID, force: true)
+        let result = documentEditor.deletePage(pageID: pageID)
         
-        XCTAssertFalse(result.success, "Deletion should fail")
+        XCTAssertFalse(result, "Deletion should fail")
         XCTAssertEqual(documentEditor.document.files.first?.pages?.count, 1, "Page should still exist")
     }
     
@@ -1043,8 +1043,8 @@ final class ValidationTestCase: XCTestCase {
         
         let initialFieldCount = documentEditor.document.fields.count
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         let finalFieldCount = documentEditor.document.fields.count
         
@@ -1075,8 +1075,8 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertTrue(initialPageOrder.count >= 3, "Should have at least 3 pages")
         XCTAssertTrue(initialPageOrder.contains(pageToDeleteID), "PageOrder should contain page to delete")
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         let finalPageOrder = documentEditor.document.files.first?.pageOrder ?? []
         XCTAssertEqual(finalPageOrder.count, initialPageOrder.count - 1, "PageOrder count should decrease by 1")
@@ -1100,8 +1100,8 @@ final class ValidationTestCase: XCTestCase {
         documentEditor.currentPageID = pageToDeleteID
         XCTAssertEqual(documentEditor.currentPageID, pageToDeleteID)
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         // Current page should have changed
         XCTAssertNotEqual(documentEditor.currentPageID, pageToDeleteID, "Current page should have changed")
@@ -1133,8 +1133,8 @@ final class ValidationTestCase: XCTestCase {
         let initialViewPageCount = documentEditor.document.files.first?.views?.first?.pages?.count ?? 0
         XCTAssertTrue(initialViewPageCount >= 2, "View should have at least 2 pages")
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         // Check main pages
         let mainPageExists = documentEditor.document.files.first?.pages?.contains(where: { $0.id == pageToDeleteID }) ?? false
@@ -1164,8 +1164,8 @@ final class ValidationTestCase: XCTestCase {
         let pageToDeleteID = "6629fab320fca7c8107a6cf6"
         let documentEditor = documentEditor(document: document)
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         // Verify no pages have logic referencing the deleted page
         let remainingPages = documentEditor.document.files.first?.pages ?? []
@@ -1190,8 +1190,8 @@ final class ValidationTestCase: XCTestCase {
         let pageToDeleteID = "6629fab320fca7c8107a6cf6"
         let documentEditor = documentEditor(document: document)
         
-        let result = documentEditor.deletePage(pageID: pageToDeleteID, force: true)
-        XCTAssertTrue(result.success, "Page deletion should succeed")
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
         
         // Verify no fields have logic referencing the deleted page
         for field in documentEditor.document.fields {
@@ -1220,6 +1220,456 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertTrue(canDelete, "Page should be deletable")
         // Warnings array may or may not be empty depending on the document structure
         XCTAssertNotNil(warnings, "Warnings array should exist")
+    }
+    
+    // MARK: - Orphaned Fields Tests
+    
+    /// Test that fields shared across pages are NOT deleted when one page is deleted
+    func testPageDeletion_sharedFieldsAcrossPagesPreserved() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        // Add a shared field that will appear on both pages
+        let sharedFieldID = "shared_field_abc123"
+        var sharedField = JoyDocField(field: [:])
+        sharedField.id = sharedFieldID
+        sharedField.identifier = "sharedField"
+        sharedField.type = "text"
+        sharedField.title = "Shared Field"
+        document.fields.append(sharedField)
+        
+        // Modify pages to add the shared field to both
+        guard var file = document.files.first, var pages = file.pages, pages.count >= 2 else {
+            XCTFail("Document should have at least 2 pages")
+            return
+        }
+        
+        // Add shared field position to page 1
+        var page1 = pages[0]
+        let sharedFieldPos1 = FieldPosition(dictionary: [
+            "field": sharedFieldID,
+            "_id": "shared_pos_1",
+            "x": 0,
+            "y": 0,
+            "width": 4,
+            "height": 8
+        ])
+        var page1FieldPositions = page1.fieldPositions ?? []
+        page1FieldPositions.append(sharedFieldPos1)
+        page1.fieldPositions = page1FieldPositions
+        pages[0] = page1
+        
+        // Add shared field position to page 2 (the one we'll delete)
+        var page2 = pages[1]
+        let sharedFieldPos2 = FieldPosition(dictionary: [
+            "field": sharedFieldID,
+            "_id": "shared_pos_2",
+            "x": 0,
+            "y": 8,
+            "width": 4,
+            "height": 8
+        ])
+        var page2FieldPositions = page2.fieldPositions ?? []
+        page2FieldPositions.append(sharedFieldPos2)
+        page2.fieldPositions = page2FieldPositions
+        pages[1] = page2
+        
+        file.pages = pages
+        document.files[0] = file
+        
+        let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
+        let documentEditor = documentEditor(document: document)
+        
+        // Verify shared field exists before deletion
+        let initialFieldCount = documentEditor.document.fields.count
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }), 
+                     "Shared field should exist before deletion")
+        
+        // Delete page 2
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Verify shared field still exists (because it's on page 1)
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }),
+                     "Shared field should NOT be deleted because it's still on page 1")
+        
+        // Verify page 2's exclusive field was deleted
+        let page2ExclusiveFieldID = "second_page_field_1"
+        XCTAssertFalse(documentEditor.document.fields.contains(where: { $0.id == page2ExclusiveFieldID }),
+                      "Page 2 exclusive field should be deleted")
+    }
+    
+    /// Test that fields shared across desktop and mobile views are preserved
+    func testPageDeletion_sharedFieldsAcrossViewsPreserved() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .addSecondPage()
+            .addSecondPageInMobileView()
+            .setHeadingText()
+            .setTextField()
+        
+        // Add a field that appears in mobile view but also on the desktop page we're deleting
+        let sharedFieldID = "mobile_desktop_field_xyz"
+        var sharedField = JoyDocField(field: [:])
+        sharedField.id = sharedFieldID
+        sharedField.identifier = "mobileDesktopField"
+        sharedField.type = "text"
+        sharedField.title = "Mobile Desktop Field"
+        document.fields.append(sharedField)
+        
+        guard var file = document.files.first else {
+            XCTFail("Document should have a file")
+            return
+        }
+        
+        // Add to desktop page 2 (which we'll delete)
+        if var pages = file.pages, pages.count >= 2 {
+            var page2 = pages[1]
+            let desktopFieldPos = FieldPosition(dictionary: [
+                "field": sharedFieldID,
+                "_id": "desktop_pos",
+                "x": 0,
+                "y": 0,
+                "width": 4,
+                "height": 8
+            ])
+            var fieldPositions = page2.fieldPositions ?? []
+            fieldPositions.append(desktopFieldPos)
+            page2.fieldPositions = fieldPositions
+            pages[1] = page2
+            file.pages = pages
+        }
+        
+        // Add to mobile view page 1
+        if var views = file.views, !views.isEmpty {
+            var view = views[0]
+            if var mobilePages = view.pages, !mobilePages.isEmpty {
+                var mobilePage1 = mobilePages[0]
+                let mobileFieldPos = FieldPosition(dictionary: [
+                    "field": sharedFieldID,
+                    "_id": "mobile_pos",
+                    "x": 0,
+                    "y": 0,
+                    "width": 1,
+                    "height": 64
+                ])
+                var mobileFieldPositions = mobilePage1.fieldPositions ?? []
+                mobileFieldPositions.append(mobileFieldPos)
+                mobilePage1.fieldPositions = mobileFieldPositions
+                mobilePages[0] = mobilePage1
+                view.pages = mobilePages
+                views[0] = view
+            }
+            file.views = views
+        }
+        
+        document.files[0] = file
+        
+        let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
+        let documentEditor = documentEditor(document: document)
+        
+        // Verify field exists before deletion
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }),
+                     "Shared field should exist before deletion")
+        
+        // Delete desktop page 2
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Verify field still exists (because it's in mobile view page 1)
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }),
+                     "Shared field should NOT be deleted because it's still in mobile view page 1")
+    }
+    
+    /// Test that only truly orphaned fields are deleted
+    func testPageDeletion_onlyOrphanedFieldsDeleted() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .addThirdPage()
+            .setHeadingText()
+            .setTextField()
+        
+        // Create three fields:
+        // - Field A: Only on page 2 (will be deleted) - ORPHANED
+        // - Field B: On page 2 AND page 3 - NOT ORPHANED
+        // - Field C: Only on page 3 - NOT ORPHANED
+        
+        let orphanedFieldID = "orphaned_field_123"
+        let sharedFieldID = "shared_field_456"
+        let page3FieldID = "page3_field_789"
+        
+        // Add all three fields to document
+        var orphanedField = JoyDocField(field: [:])
+        orphanedField.id = orphanedFieldID
+        orphanedField.identifier = "orphanedField"
+        orphanedField.type = "text"
+        document.fields.append(orphanedField)
+        
+        var sharedField = JoyDocField(field: [:])
+        sharedField.id = sharedFieldID
+        sharedField.identifier = "sharedField"
+        sharedField.type = "text"
+        document.fields.append(sharedField)
+        
+        var page3Field = JoyDocField(field: [:])
+        page3Field.id = page3FieldID
+        page3Field.identifier = "page3Field"
+        page3Field.type = "text"
+        document.fields.append(page3Field)
+        
+        guard var file = document.files.first, var pages = file.pages, pages.count >= 3 else {
+            XCTFail("Document should have at least 3 pages")
+            return
+        }
+        
+        // Add orphaned field only to page 2
+        var page2 = pages[1]
+        var page2Positions = page2.fieldPositions ?? []
+        page2Positions.append(FieldPosition(dictionary: [
+            "field": orphanedFieldID,
+            "_id": "orphaned_pos",
+            "x": 0, "y": 0, "width": 4, "height": 8
+        ]))
+        
+        // Add shared field to page 2
+        page2Positions.append(FieldPosition(dictionary: [
+            "field": sharedFieldID,
+            "_id": "shared_pos_page2",
+            "x": 0, "y": 8, "width": 4, "height": 8
+        ]))
+        page2.fieldPositions = page2Positions
+        pages[1] = page2
+        
+        // Add shared field to page 3
+        var page3 = pages[2]
+        var page3Positions = page3.fieldPositions ?? []
+        page3Positions.append(FieldPosition(dictionary: [
+            "field": sharedFieldID,
+            "_id": "shared_pos_page3",
+            "x": 0, "y": 0, "width": 4, "height": 8
+        ]))
+        
+        // Add page3-exclusive field to page 3
+        page3Positions.append(FieldPosition(dictionary: [
+            "field": page3FieldID,
+            "_id": "page3_pos",
+            "x": 0, "y": 8, "width": 4, "height": 8
+        ]))
+        page3.fieldPositions = page3Positions
+        pages[2] = page3
+        
+        file.pages = pages
+        document.files[0] = file
+        
+        let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
+        let documentEditor = documentEditor(document: document)
+        
+        let initialFieldCount = documentEditor.document.fields.count
+        
+        // Delete page 2
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Verify orphaned field was deleted
+        XCTAssertFalse(documentEditor.document.fields.contains(where: { $0.id == orphanedFieldID }),
+                      "Orphaned field should be deleted")
+        
+        // Verify shared field still exists
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }),
+                     "Shared field should NOT be deleted (still on page 3)")
+        
+        // Verify page 3 exclusive field still exists
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == page3FieldID }),
+                     "Page 3 field should NOT be deleted")
+        
+        // Verify correct number of fields deleted
+        let finalFieldCount = documentEditor.document.fields.count
+        let deletedCount = initialFieldCount - finalFieldCount
+        XCTAssertGreaterThan(deletedCount, 0, "At least one field should be deleted")
+    }
+    
+    /// Test complex scenario with multiple views and shared fields
+    func testPageDeletion_complexMultiViewScenario() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .addSecondPage()
+            .addSecondPageInMobileView()
+            .addThirdPage()
+            .setHeadingText()
+            .setTextField()
+        
+        // Create complex field sharing:
+        // Field A: Desktop Page 1, Desktop Page 2, Mobile Page 1
+        // Field B: Desktop Page 2 only (ORPHANED when page 2 deleted)
+        // Field C: Desktop Page 2, Desktop Page 3
+        // Field D: Mobile Page 1, Mobile Page 2
+        
+        let fieldA_ID = "field_a_everywhere"
+        let fieldB_ID = "field_b_page2_only"
+        let fieldC_ID = "field_c_desktop_pages"
+        let fieldD_ID = "field_d_mobile_pages"
+        
+        // Add all fields
+        for (id, identifier) in [(fieldA_ID, "fieldA"), (fieldB_ID, "fieldB"), 
+                                   (fieldC_ID, "fieldC"), (fieldD_ID, "fieldD")] {
+            var field = JoyDocField(field: [:])
+            field.id = id
+            field.identifier = identifier
+            field.type = "text"
+            document.fields.append(field)
+        }
+        
+        guard var file = document.files.first else {
+            XCTFail("Document should have a file")
+            return
+        }
+        
+        // Setup desktop pages
+        if var pages = file.pages, pages.count >= 3 {
+            // Desktop Page 1: Field A
+            var page1 = pages[0]
+            var page1Pos = page1.fieldPositions ?? []
+            page1Pos.append(FieldPosition(dictionary: ["field": fieldA_ID, "_id": "a_d1", "x": 0, "y": 0, "width": 4, "height": 8]))
+            page1.fieldPositions = page1Pos
+            pages[0] = page1
+            
+            // Desktop Page 2 (to be deleted): Field A, B, C
+            var page2 = pages[1]
+            var page2Pos = page2.fieldPositions ?? []
+            page2Pos.append(FieldPosition(dictionary: ["field": fieldA_ID, "_id": "a_d2", "x": 0, "y": 0, "width": 4, "height": 8]))
+            page2Pos.append(FieldPosition(dictionary: ["field": fieldB_ID, "_id": "b_d2", "x": 0, "y": 8, "width": 4, "height": 8]))
+            page2Pos.append(FieldPosition(dictionary: ["field": fieldC_ID, "_id": "c_d2", "x": 0, "y": 16, "width": 4, "height": 8]))
+            page2.fieldPositions = page2Pos
+            pages[1] = page2
+            
+            // Desktop Page 3: Field C
+            var page3 = pages[2]
+            var page3Pos = page3.fieldPositions ?? []
+            page3Pos.append(FieldPosition(dictionary: ["field": fieldC_ID, "_id": "c_d3", "x": 0, "y": 0, "width": 4, "height": 8]))
+            page3.fieldPositions = page3Pos
+            pages[2] = page3
+            
+            file.pages = pages
+        }
+        
+        // Setup mobile pages
+        if var views = file.views, !views.isEmpty {
+            var view = views[0]
+            if var mobilePages = view.pages, mobilePages.count >= 2 {
+                // Mobile Page 1: Field A, D
+                var mobilePage1 = mobilePages[0]
+                var mp1Pos = mobilePage1.fieldPositions ?? []
+                mp1Pos.append(FieldPosition(dictionary: ["field": fieldA_ID, "_id": "a_m1", "x": 0, "y": 0, "width": 1, "height": 64]))
+                mp1Pos.append(FieldPosition(dictionary: ["field": fieldD_ID, "_id": "d_m1", "x": 0, "y": 64, "width": 1, "height": 64]))
+                mobilePage1.fieldPositions = mp1Pos
+                mobilePages[0] = mobilePage1
+                
+                // Mobile Page 2: Field D
+                var mobilePage2 = mobilePages[1]
+                var mp2Pos = mobilePage2.fieldPositions ?? []
+                mp2Pos.append(FieldPosition(dictionary: ["field": fieldD_ID, "_id": "d_m2", "x": 0, "y": 0, "width": 1, "height": 64]))
+                mobilePage2.fieldPositions = mp2Pos
+                mobilePages[1] = mobilePage2
+                
+                view.pages = mobilePages
+                views[0] = view
+            }
+            file.views = views
+        }
+        
+        document.files[0] = file
+        
+        let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
+        let documentEditor = documentEditor(document: document)
+        
+        // Delete desktop page 2
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Verify Field A still exists (on desktop page 1 and mobile page 1)
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == fieldA_ID }),
+                     "Field A should NOT be deleted (on desktop page 1 and mobile page 1)")
+        
+        // Verify Field B was deleted (only on deleted page 2)
+        XCTAssertFalse(documentEditor.document.fields.contains(where: { $0.id == fieldB_ID }),
+                      "Field B should be deleted (orphaned)")
+        
+        // Verify Field C still exists (on desktop page 3)
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == fieldC_ID }),
+                     "Field C should NOT be deleted (still on desktop page 3)")
+        
+        // Verify Field D still exists (on mobile pages 1 and 2)
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == fieldD_ID }),
+                     "Field D should NOT be deleted (on mobile pages)")
+    }
+    
+    /// Test that deleting last occurrence of a field removes it
+    func testPageDeletion_lastOccurrenceRemoved() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        // Add a field that only exists on page 2
+        let exclusiveFieldID = "exclusive_field_xyz"
+        var exclusiveField = JoyDocField(field: [:])
+        exclusiveField.id = exclusiveFieldID
+        exclusiveField.identifier = "exclusiveField"
+        exclusiveField.type = "text"
+        document.fields.append(exclusiveField)
+        
+        guard var file = document.files.first, var pages = file.pages, pages.count >= 2 else {
+            XCTFail("Document should have at least 2 pages")
+            return
+        }
+        
+        // Add exclusive field only to page 2
+        var page2 = pages[1]
+        var page2Positions = page2.fieldPositions ?? []
+        page2Positions.append(FieldPosition(dictionary: [
+            "field": exclusiveFieldID,
+            "_id": "exclusive_pos",
+            "x": 0, "y": 0, "width": 4, "height": 8
+        ]))
+        page2.fieldPositions = page2Positions
+        pages[1] = page2
+        
+        file.pages = pages
+        document.files[0] = file
+        
+        let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
+        let documentEditor = documentEditor(document: document)
+        
+        // Verify field exists before deletion
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == exclusiveFieldID }),
+                     "Exclusive field should exist before deletion")
+        
+        // Delete page 2
+        let result = documentEditor.deletePage(pageID: pageToDeleteID)
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Verify field was deleted (last occurrence removed)
+        XCTAssertFalse(documentEditor.document.fields.contains(where: { $0.id == exclusiveFieldID }),
+                      "Exclusive field should be deleted (no references remain)")
     }
 }
 

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -437,8 +437,8 @@ struct PageDuplicateListView: View {
                     "⚠️ Warning\n\n\(deleteWarningMessage)\n\nThis action cannot be undone."),
                 primaryButton: .destructive(Text("Delete")) {
                     if let pageID = pageToDelete {
-                        let result = documentEditor.deletePage(pageID: pageID, force: true)
-                        if result.success {
+                        let result = documentEditor.deletePage(pageID: pageID)
+                        if result {
                             // Close the sheet if we deleted the current page
                             if currentPageID == pageID {
                                 presentationMode.wrappedValue.dismiss()

--- a/Sources/JoyfillUI/View/Types.swift
+++ b/Sources/JoyfillUI/View/Types.swift
@@ -220,10 +220,12 @@ public struct Change {
         dictionary["createdOn"] = createdOn
     }
     // instance for the page.delete
-    public init(v: Int, sdk: String, id: String, identifier: String, target: String, fileId: String, viewType: String, pageId: String, createdOn: Double) {
+    public init(v: Int, sdk: String, id: String, identifier: String, target: String, fileId: String, viewType: String? = nil, pageId: String, createdOn: Double) {
         dictionary["v"] = v
         dictionary["sdk"] = sdk
-        dictionary["view"] = viewType
+        if viewType != nil {
+            dictionary["view"] = viewType
+        }
         dictionary["target"] = target
         dictionary["_id"] = id
         dictionary["identifier"] = identifier

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -1670,6 +1670,22 @@ extension DocumentEditor {
         }
         
         // Generate page.delete event for the main page
+        if !viewId.isEmpty {
+            // Delete mobile view page
+            changes.append(Change(
+                v: 1,
+                sdk: "swift",
+                id: documentID,
+                identifier: documentIdentifier,
+                target: "page.delete",
+                fileId: fileId,
+                viewType: "mobile",
+                pageId: pageID,
+                createdOn: Date().timeIntervalSince1970
+            ))
+        }
+        
+        // Delete main page on change
         changes.append(Change(
             v: 1,
             sdk: "swift",
@@ -1677,7 +1693,6 @@ extension DocumentEditor {
             identifier: documentIdentifier,
             target: "page.delete",
             fileId: fileId,
-            viewType: viewId.isEmpty ? "web" : "mobile",
             pageId: pageID,
             createdOn: Date().timeIntervalSince1970
         ))

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -1020,13 +1020,7 @@ extension DocumentEditor {
         }
         
         let fieldsToDelete = page.fieldPositions?.compactMap { $0.field } ?? []
-        
-        // Collect field data BEFORE deletion (while fields still exist)
-        let fieldsData = fieldsToDelete.compactMap { fieldID -> (id: String, identifier: String?, positionId: String?)? in
-            guard let field = field(fieldID: fieldID) else { return nil }
-            return (fieldID, field.identifier, fieldPosition(fieldID: fieldID)?.id)
-        }
-        
+                
         // 3. Handle navigation before deletion
         let shouldNavigate = currentPageID == pageID
         let nextPageID = shouldNavigate ? determineNextPage(after: pageID) : currentPageID
@@ -1088,6 +1082,12 @@ extension DocumentEditor {
             !remainingFieldIDs.contains(id)
         }
 
+        // Collect field data BEFORE deletion (while fields still exist)
+        let fieldsData = fieldsToRemove.compactMap { fieldID -> (id: String, identifier: String?, positionId: String?)? in
+            guard let field = field(fieldID: fieldID) else { return nil }
+            return (fieldID, field.identifier, fieldPosition(fieldID: fieldID)?.id)
+        }
+        
         // 10. Remove fields completely
         if !fieldsToRemove.isEmpty {
             // Remove from document.fields

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -1088,19 +1088,9 @@ extension DocumentEditor {
             return (fieldID, field.identifier, fieldPosition(fieldID: fieldID)?.id)
         }
         
-        // 10. Remove fields completely
-        if !fieldsToRemove.isEmpty {
-            // Remove from document.fields
-            document.fields.removeAll { field in
-                guard let fieldID = field.id else { return false }
-                let shouldRemove = fieldsToRemove.contains(fieldID)
-                return shouldRemove
-            }
-
-            // Remove from fieldMap (important: prevents didSet from restoring them)
-            for fieldID in fieldsToRemove {
-                fieldMap.removeValue(forKey: fieldID)
-            }
+        // 10. Remove fields from fieldMap (didSet will automatically update document.fields)
+        for fieldID in fieldsToRemove {
+            fieldMap.removeValue(forKey: fieldID)
         }
         
         // 11. Reinitialize conditional logic handler

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -997,32 +997,26 @@ extension DocumentEditor {
     ///   - pageID: The ID of the page to delete
     ///   - force: If true, bypasses warnings and deletes anyway
     /// - Returns: Tuple with success flag and message
-    public func deletePage(pageID: String, force: Bool = false) -> (success: Bool, message: String) {
+    public func deletePage(pageID: String) -> Bool {
         // 1. Validate
         let (canDelete, warnings) = canDeletePage(pageID: pageID)
         
         guard canDelete else {
             let message = warnings.first ?? "Cannot delete page"
             Log(message, type: .error)
-            return (false, message)
-        }
-        
-        if !warnings.isEmpty && !force {
-            let message = warnings.joined(separator: "\n")
-            Log("Page deletion requires confirmation: \(message)", type: .warning)
-            return (false, message)
+            return false
         }
         
         guard var firstFile = document.files.first else {
             Log("No file found in document", type: .error)
-            return (false, "No file found in document")
+            return false
         }
         
         // 2. Find page and collect field IDs and data BEFORE deletion
         guard let pageIndex = firstFile.pages?.firstIndex(where: { $0.id == pageID }),
               let page = firstFile.pages?[pageIndex] else {
             Log("Page with id \(pageID) not found", type: .error)
-            return (false, "Page not found")
+            return false
         }
         
         let fieldsToDelete = page.fieldPositions?.compactMap { $0.field } ?? []
@@ -1120,6 +1114,6 @@ extension DocumentEditor {
         // 13. Fire change events with pre-collected field data
         onChangeDeletePage(pageID: pageID, fieldsData: fieldsData, fileId: firstFile.id ?? "", viewId: "")
 
-        return (true, "Page deleted successfully")
+        return true
     }
 }


### PR DESCRIPTION
• Prevent deleting fields that are still referenced elsewhere (shared fields) when a page is removed.
• Remove the unnecessary parameter from the deletePage API.
• Add unit tests to cover shared-field behavior and the updated delete flow.
[Ticket link](https://www.notion.so/joyfill/Delete-Page-Round-2-2cadef37c9a08027835eee4492761fd9?v=136def37c9a080c98eac000c50ab34c2&source=copy_link)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces safer page deletion and streamlines the API.
> 
> - Replace `deletePage(pageID:force:) -> (success: Bool, message: String)` with `deletePage(pageID:) -> Bool`; update UI (`FormView`) and tests accordingly
> - Only delete truly orphaned fields: detect remaining references across main pages and mobile views before removing fields and cleaning `fieldMap`
> - Change events: emit `field.delete` only for orphaned fields; generate `page.delete` for mobile view (when applicable) and for the main page; make `Change` page.delete initializer accept optional `view`
> - Add extensive tests covering shared-field preservation across pages/views, orphaned-field removal, changelog correctness, navigation/pageOrder updates, and last-page protection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 726fc913e74e9e292447eb24f05e02077654c755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->