### PR TITLE
Fix page duplication for mobile views

### DIFF
--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -820,13 +820,11 @@ extension DocumentEditor {
             Log("No file found in document.", type: .error)
             return
         }
-        let mobilePage: Page
+        let originalPage: Page
         if let viewPage = firstFile.views?.first?.pages?.first(where: { $0.id == pageID }) {
-            mobilePage = viewPage
-        }
-        let webPage: Page
-        if let mainPage = firstFile.pages?.first(where: { $0.id == pageID }) {
-            webPage = mainPage
+            originalPage = viewPage
+        } else if let mainPage = firstFile.pages?.first(where: { $0.id == pageID }) {
+            originalPage = mainPage
         } else {
             Log("Page with id \(pageID) not found in views or pages.", type: .error)
             return
@@ -834,14 +832,14 @@ extension DocumentEditor {
 
         let newPageID = generateObjectId()
         
-        var duplicatedPage = webPage
+        var duplicatedPage = originalPage
         duplicatedPage.id = newPageID
         
         var fieldMapping: [String: String] = [:]
         var newFields: [JoyDocField] = []
         var newFieldPositions: [FieldPosition] = []
         
-        addFieldAndFieldPositionForWeb(webPage, &fieldMapping, &newFields, &newFieldPositions, newPageID)
+        addFieldAndFieldPositionForWeb(originalPage, &fieldMapping, &newFields, &newFieldPositions, newPageID)
         
         document.fields = newFields
         duplicatedPage.fieldPositions = newFieldPositions
@@ -866,7 +864,7 @@ extension DocumentEditor {
             var altView = altViews[0]
             if let originalAlternatePageIndex = altView.pages?.firstIndex(where: { $0.id == pageID }) {
                 var originalAltPage = altView.pages![originalAlternatePageIndex]
-                originalAltPage.id = newPageID
+                originalAltPage.id = duplicatedPage.id
                 
                 var alternateFieldMapping: [String: String] = [:]
                 var alternateNewFields: [JoyDocField] = []
@@ -937,10 +935,7 @@ extension DocumentEditor {
         document.files = files
         updateFieldMap()
         updateFieldPositionMap()
-        if !isMobileViewActive {
-            updatePageFieldModels(duplicatedPage, newPageID, firstFile.id ?? "")
-        }
-        
+        updatePageFieldModels(duplicatedPage, newPageID, firstFile.id ?? "")
         if let views = document.files.first?.views, !views.isEmpty {
             if let page = views.first?.pages?.first(where: { $0.id == newPageID }) {
                 updatePageFieldModels(page, newPageID, firstFile.id ?? "")

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -821,9 +821,7 @@ extension DocumentEditor {
             return
         }
         let originalPage: Page
-        if let viewPage = firstFile.views?.first?.pages?.first(where: { $0.id == pageID }) {
-            originalPage = viewPage
-        } else if let mainPage = firstFile.pages?.first(where: { $0.id == pageID }) {
+        if let mainPage = firstFile.pages?.first(where: { $0.id == pageID }) {
             originalPage = mainPage
         } else {
             Log("Page with id \(pageID) not found in views or pages.", type: .error)
@@ -872,9 +870,6 @@ extension DocumentEditor {
                 
                 for var fieldPos in originalAltPage.fieldPositions ?? [] {
                     guard let origFieldID = fieldPos.field else { continue }
-                    if let newField = fieldMapping[origFieldID] {
-                        fieldPos.field = newField
-                    }else {
                         if let origField = field(fieldID: origFieldID) {
                             var duplicateField = origField
                             let newFieldID = generateObjectId()
@@ -884,7 +879,6 @@ extension DocumentEditor {
                             alternateNewFields.append(duplicateField)
                             fieldPos.field = newFieldID
                         }
-                    }
                     alternateNewFieldPositions.append(fieldPos)
                 }
                 // apply conditional logic here
@@ -935,7 +929,9 @@ extension DocumentEditor {
         document.files = files
         updateFieldMap()
         updateFieldPositionMap()
-        updatePageFieldModels(duplicatedPage, newPageID, firstFile.id ?? "")
+        if !isMobileViewActive {
+            updatePageFieldModels(duplicatedPage, newPageID, firstFile.id ?? "")
+        }
         if let views = document.files.first?.views, !views.isEmpty {
             if let page = views.first?.pages?.first(where: { $0.id == newPageID }) {
                 updatePageFieldModels(page, newPageID, firstFile.id ?? "")


### PR DESCRIPTION
Handle page duplication when the mobile view is active and the web and mobile pages have different field positions.