### PR TITLE
NO-1880: Add page focus and blur events 

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/AllSampleJSONs.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/AllSampleJSONs.swift
@@ -154,8 +154,8 @@ struct AllSampleJSONs: View, FormChangeEvent {
     func onChange(changes: [Change], document: JoyDoc) {
 //        print("->>>>>>>>", changes)
     }
-    func onFocus(event: FieldIdentifier) { }
-    func onBlur(event: FieldIdentifier) { }
+    func onFocus(event: Event) { }
+    func onBlur(event: Event) { }
     func onCapture(event: CaptureEvent) { }
 
     func onUpload(event: UploadEvent) {

--- a/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
@@ -91,22 +91,25 @@ extension ChangeManager: FormChangeEvent {
     }
 
     func onFocus(event: Event) {
-        if let event = event.fieldEvent {
-            let fieldDict = createFieldIdentifierDict(event)
+        let timestamp = DateFormatter.timestamp.string(from: Date())
+        
+        if let fieldEvent = event.fieldEvent {
+            let fieldDict = createFieldIdentifierDict(fieldEvent)
             print(">>>>>>>>onFocus", formatDictionary(fieldDict))
-            let timestamp = DateFormatter.timestamp.string(from: Date())
-            DispatchQueue.main.async {
-                self.displayedChangelogs.append("[\(timestamp)] Focus: \(self.formatDictionary(fieldDict))")
+            
+            if let jsonData = try? JSONSerialization.data(withJSONObject: fieldDict, options: .prettyPrinted),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self.displayedChangelogs.append("[\(timestamp)] Focus: \(jsonString)")
+                }
             }
-        }
-        if let event = event.pageEvent {
-            print(">>>>>>>>onPageEvent", event.type, event.page.id ?? "unknown", event.page.name ?? "Untitled")
-            let timestamp = DateFormatter.timestamp.string(from: Date())
+        } else if let pageEvent = event.pageEvent {
+            print(">>>>>>>>onPageFocus", pageEvent.type, pageEvent.page.id ?? "unknown", pageEvent.page.name ?? "Untitled")
             
             // Create proper JSON string for the viewer
             var eventDict: [String: Any] = [:]
-            eventDict["type"] = event.type
-            eventDict["page"] = event.page.dictionary
+            eventDict["type"] = pageEvent.type
+            eventDict["page"] = pageEvent.page.dictionary
             
             if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
                let jsonString = String(data: jsonData, encoding: .utf8) {
@@ -118,22 +121,25 @@ extension ChangeManager: FormChangeEvent {
     }
 
     func onBlur(event: Event) {
-        if let event = event.fieldEvent {
-            let fieldDict = createFieldIdentifierDict(event)
+        let timestamp = DateFormatter.timestamp.string(from: Date())
+        
+        if let fieldEvent = event.fieldEvent {
+            let fieldDict = createFieldIdentifierDict(fieldEvent)
             print(">>>>>>>>onBlur", formatDictionary(fieldDict))
-            let timestamp = DateFormatter.timestamp.string(from: Date())
-            DispatchQueue.main.async {
-                self.displayedChangelogs.append("[\(timestamp)] Blur: \(self.formatDictionary(fieldDict))")
+            
+            if let jsonData = try? JSONSerialization.data(withJSONObject: fieldDict, options: .prettyPrinted),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self.displayedChangelogs.append("[\(timestamp)] Blur: \(jsonString)")
+                }
             }
-        }
-        if let event = event.pageEvent {
-            print(">>>>>>>>onPageEvent", event.type, event.page.id ?? "unknown", event.page.name ?? "Untitled")
-            let timestamp = DateFormatter.timestamp.string(from: Date())
+        } else if let pageEvent = event.pageEvent {
+            print(">>>>>>>>onPageBlur", pageEvent.type, pageEvent.page.id ?? "unknown", pageEvent.page.name ?? "Untitled")
             
             // Create proper JSON string for the viewer
             var eventDict: [String: Any] = [:]
-            eventDict["type"] = event.type
-            eventDict["page"] = event.page.dictionary
+            eventDict["type"] = pageEvent.type
+            eventDict["page"] = pageEvent.page.dictionary
             
             if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
                let jsonString = String(data: jsonData, encoding: .utf8) {

--- a/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
@@ -90,21 +90,57 @@ extension ChangeManager: FormChangeEvent {
         }
     }
 
-    func onFocus(event: FieldIdentifier) {
-        let fieldDict = createFieldIdentifierDict(event)
-        print(">>>>>>>>onFocus", formatDictionary(fieldDict))
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        DispatchQueue.main.async {
-            self.displayedChangelogs.append("[\(timestamp)] Focus: \(self.formatDictionary(fieldDict))")
+    func onFocus(event: Event) {
+        if let event = event.fieldEvent {
+            let fieldDict = createFieldIdentifierDict(event)
+            print(">>>>>>>>onFocus", formatDictionary(fieldDict))
+            let timestamp = DateFormatter.timestamp.string(from: Date())
+            DispatchQueue.main.async {
+                self.displayedChangelogs.append("[\(timestamp)] Focus: \(self.formatDictionary(fieldDict))")
+            }
+        }
+        if let event = event.pageEvent {
+            print(">>>>>>>>onPageEvent", event.type, event.page.id ?? "unknown", event.page.name ?? "Untitled")
+            let timestamp = DateFormatter.timestamp.string(from: Date())
+            
+            // Create proper JSON string for the viewer
+            var eventDict: [String: Any] = [:]
+            eventDict["type"] = event.type
+            eventDict["page"] = event.page.dictionary
+            
+            if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self.displayedChangelogs.append("[\(timestamp)] PageEvent: \(jsonString)")
+                }
+            }
         }
     }
 
-    func onBlur(event: FieldIdentifier) {
-        let fieldDict = createFieldIdentifierDict(event)
-        print(">>>>>>>>onBlur", formatDictionary(fieldDict))
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        DispatchQueue.main.async {
-            self.displayedChangelogs.append("[\(timestamp)] Blur: \(self.formatDictionary(fieldDict))")
+    func onBlur(event: Event) {
+        if let event = event.fieldEvent {
+            let fieldDict = createFieldIdentifierDict(event)
+            print(">>>>>>>>onBlur", formatDictionary(fieldDict))
+            let timestamp = DateFormatter.timestamp.string(from: Date())
+            DispatchQueue.main.async {
+                self.displayedChangelogs.append("[\(timestamp)] Blur: \(self.formatDictionary(fieldDict))")
+            }
+        }
+        if let event = event.pageEvent {
+            print(">>>>>>>>onPageEvent", event.type, event.page.id ?? "unknown", event.page.name ?? "Untitled")
+            let timestamp = DateFormatter.timestamp.string(from: Date())
+            
+            // Create proper JSON string for the viewer
+            var eventDict: [String: Any] = [:]
+            eventDict["type"] = event.type
+            eventDict["page"] = event.page.dictionary
+            
+            if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self.displayedChangelogs.append("[\(timestamp)] PageEvent: \(jsonString)")
+                }
+            }
         }
     }
 

--- a/JoyfillSwiftUIExample/JoyfillExample/CreateRowUISample.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/CreateRowUISample.swift
@@ -35,8 +35,8 @@ struct CreateRowUISample: View, FormChangeEvent {
     func onChange(changes: [Change], document: JoyfillModel.JoyDoc) {
         generateDeficiencySummary(document: document, documentEditor: documentEditor, changeEvent: changes.first!)
     }
-    func onFocus(event: FieldIdentifier) { }
-    func onBlur(event:  FieldIdentifier) { }
+    func onFocus(event: Event) { }
+    func onBlur(event:  Event) { }
     func onCapture(event: CaptureEvent) { }
     func onUpload(event: UploadEvent) { }
     func onError(error: Joyfill.JoyfillError) { }

--- a/JoyfillSwiftUIExample/JoyfillExample/DeficiencyTableDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/DeficiencyTableDemoView.swift
@@ -34,8 +34,8 @@ extension DeficiencyTableDemoView {
         deficiencyDemoDocumentEditor.change(changes: updatedChanges)
     }
     
-    func onFocus(event: FieldIdentifier) { }
-    func onBlur(event: FieldIdentifier) { }
+    func onFocus(event: Event) { }
+    func onBlur(event: Event) { }
     func onCapture(event: CaptureEvent) { }
     func onUpload(event: UploadEvent) { }
     func onError(error: Joyfill.JoyfillError) { }

--- a/JoyfillSwiftUIExample/JoyfillExample/FormContainerTestView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/FormContainerTestView.swift
@@ -47,12 +47,16 @@ class TestChangeManager: FormChangeEvent {
         }
     }
 
-    func onFocus(event: FieldIdentifier) {
-        print(">>>>>>>>onFocus", event.fieldID)
+    func onFocus(event: Event) {
+        if let event = event.fieldEvent {
+            print(">>>>>>>>onFocus", event.fieldID)
+        }
     }
 
-    func onBlur(event: FieldIdentifier) {
-        print(">>>>>>>>onBlur", event.fieldID)
+    func onBlur(event: Event) {
+        if let event = event.fieldEvent {
+            print(">>>>>>>>onBlur", event.fieldID)
+        }
     }
 
     func onUpload(event: UploadEvent) {

--- a/JoyfillSwiftUIExample/JoyfillExample/ImageReplacementTest.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ImageReplacementTest.swift
@@ -27,8 +27,8 @@ struct ImageReplacementTest: View, FormChangeEvent {
     }
 
     func onChange(changes: [Change], document: JoyfillModel.JoyDoc) {}
-    func onFocus(event: FieldIdentifier) { }
-    func onBlur(event: FieldIdentifier) { }
+    func onFocus(event: Event) { }
+    func onBlur(event: Event) { }
     func onCapture(event: CaptureEvent) { }
     func onError(error: JoyfillError) { }
     func onUpload(event: UploadEvent) {

--- a/JoyfillSwiftUIExample/JoyfillExample/JoyDoc+DummyModel.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/JoyDoc+DummyModel.swift
@@ -492,6 +492,20 @@ extension JoyDoc {
         return document
     }
     
+    func setSinglePageFile() -> JoyDoc {
+        var file = File()
+        file.id = "6629fab3c0ba3fb775b4a55c"
+        file.name = "All Fields Template"
+        file.version = 1
+        file.styles = Metadata(dictionary: [:])
+        file.pageOrder = ["6629fab320fca7c8107a6cf6"]
+        file.views = []
+        
+        var document = self
+        document.files.append(file)
+        return document
+    }
+    
     func setMobileView() -> JoyDoc {
         var view = ModelView()
         view.id = "6629fab320fca7c8107a6cf6"

--- a/JoyfillSwiftUIExample/JoyfillExample/OnChangeHandlerTest.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/OnChangeHandlerTest.swift
@@ -50,8 +50,8 @@ struct OnChangeHandlerTest: View, FormChangeEvent {
         }
     }
 
-    func onFocus(event: FieldIdentifier) { }
-    func onBlur(event:  FieldIdentifier) { }
+    func onFocus(event: Event) { }
+    func onBlur(event:  Event) { }
     func onCapture(event: CaptureEvent) { }
     func onUpload(event: UploadEvent) {
         event.uploadHandler(["https://app.joyfill.io/static/img/joyfill_logo_w.png"])

--- a/JoyfillSwiftUIExample/JoyfillExample/Simple Form Example/SimpleFormExampleView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Simple Form Example/SimpleFormExampleView.swift
@@ -25,8 +25,8 @@ struct SimpleFormExampleView: View {
 
 class ChangeHandler: FormChangeEvent {
     func onChange(changes: [Joyfill.Change], document: JoyfillModel.JoyDoc) {}
-    func onFocus(event: Joyfill.FieldIdentifier) {}
-    func onBlur(event: Joyfill.FieldIdentifier) {}
+    func onFocus(event: Joyfill.Event) {}
+    func onBlur(event: Joyfill.Event) {}
     func onUpload(event: Joyfill.UploadEvent) {}
     func onCapture(event: Joyfill.CaptureEvent) {}
     func onError(error: Joyfill.JoyfillError) {}

--- a/JoyfillSwiftUIExample/JoyfillExample/UITestFormContainerView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UITestFormContainerView.swift
@@ -100,11 +100,11 @@ class UITestFormContainerViewHandler: FormChangeEvent {
         }
     }
     
-    func onFocus(event: FieldIdentifier) {
+    func onFocus(event: Event) {
         
     }
     
-    func onBlur(event: FieldIdentifier) {
+    func onBlur(event: Event) {
         
     }
     

--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -347,8 +347,8 @@ private class MockFormChangeEvent: FormChangeEvent {
     var capturedError: JoyfillError?
 
     func onChange(changes: [Change], document: JoyDoc) {}
-    func onFocus(event: FieldIdentifier) {}
-    func onBlur(event: FieldIdentifier) {}
+    func onFocus(event: Event) {}
+    func onBlur(event: Event) {}
     func onUpload(event: UploadEvent) {}
     func onCapture(event: CaptureEvent) {}
     func onError(error: JoyfillError) { capturedError = error }

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -16,8 +16,8 @@ final class ValidationTestCase: XCTestCase {
             capturedChanges.append(contentsOf: changes)
         }
         
-        func onFocus(event: FieldIdentifier) {}
-        func onBlur(event: FieldIdentifier) {}
+        func onFocus(event: Event) {}
+        func onBlur(event: Event) {}
         func onCapture(event: CaptureEvent) {}
         func onUpload(event: UploadEvent) {}
         func onError(error: JoyfillError) {}

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -11,17 +11,30 @@ final class ValidationTestCase: XCTestCase {
     /// Mock event handler to capture onChange events for testing
     class ChangeCapture: FormChangeEvent {
         var capturedChanges: [Change] = []
+        var capturedFocusEvents: [Event] = []
+        var capturedBlurEvents: [Event] = []
         
         func onChange(changes: [Change], document: JoyDoc) {
             capturedChanges.append(contentsOf: changes)
         }
         
-        func onFocus(event: Event) {}
-        func onBlur(event: Event) {}
+        func onFocus(event: Event) {
+            capturedFocusEvents.append(event)
+        }
+        
+        func onBlur(event: Event) {
+            capturedBlurEvents.append(event)
+        }
+        
         func onCapture(event: CaptureEvent) {}
         func onUpload(event: UploadEvent) {}
         func onError(error: JoyfillError) {}
         
+        func reset() {
+            capturedChanges.removeAll()
+            capturedFocusEvents.removeAll()
+            capturedBlurEvents.removeAll()
+        }
     }
     func documentEditor(document: JoyDoc) -> DocumentEditor {
         DocumentEditor(document: document, validateSchema: false)
@@ -2311,4 +2324,321 @@ final class ValidationTestCase: XCTestCase {
             XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
             XCTAssertEqual(validationResult.fieldValidities[1].pageId, "66600801dc1d8b4f72f54917")
         }
+    
+    // MARK: - Page Focus/Blur Event Tests
+    
+    /// Test that jumping to the current page does NOT fire blur or focus events
+    func testPageFocusBlur_jumpToCurrentPage_noEvents() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: pageID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: false,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Jump to the same page
+        documentEditor.currentPageID = pageID
+        
+        // Should NOT fire any events
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 0, "No focus events should fire when jumping to current page")
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 0, "No blur events should fire when jumping to current page")
+    }
+    
+    /// Test that jumping to a different page via UI fires blur and focus events
+    func testPageFocusBlur_jumpToDifferentPage_firesEvents() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let page1ID = "6629fab320fca7c8107a6cf6"
+        let page2ID = "second_page_id_12345"
+        
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: page1ID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: false,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Jump to different page
+        documentEditor.goto(page2ID)
+        
+        // Should fire blur for page1 and focus for page2
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 1, "One blur event should fire")
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 1, "One focus event should fire")
+        
+        // Verify blur event
+        let blurEvent = eventCapture.capturedBlurEvents.first
+        XCTAssertNotNil(blurEvent?.pageEvent, "Blur event should be a page event")
+        XCTAssertEqual(blurEvent?.pageEvent?.type, "page.blur")
+        XCTAssertEqual(blurEvent?.pageEvent?.page.id, page1ID)
+        
+        // Verify focus event
+        let focusEvent = eventCapture.capturedFocusEvents.first
+        XCTAssertNotNil(focusEvent?.pageEvent, "Focus event should be a page event")
+        XCTAssertEqual(focusEvent?.pageEvent?.type, "page.focus")
+        XCTAssertEqual(focusEvent?.pageEvent?.page.id, page2ID)
+    }
+    
+    /// Test that programmatic navigation using goto() fires blur and focus events
+    func testPageFocusBlur_programmaticNavigation_firesEvents() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let page1ID = "6629fab320fca7c8107a6cf6"
+        let page2ID = "second_page_id_12345"
+        
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: page1ID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: false,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Navigate programmatically using goto
+        let result = documentEditor.goto(page2ID)
+        
+        XCTAssertEqual(result, .success, "Navigation should succeed")
+        
+        // Should fire blur for page1 and focus for page2
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 1, "One blur event should fire")
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 1, "One focus event should fire")
+        
+        // Verify blur event
+        let blurEvent = eventCapture.capturedBlurEvents.first
+        XCTAssertNotNil(blurEvent?.pageEvent, "Blur event should be a page event")
+        XCTAssertEqual(blurEvent?.pageEvent?.type, "page.blur")
+        XCTAssertEqual(blurEvent?.pageEvent?.page.id, page1ID)
+        
+        // Verify focus event
+        let focusEvent = eventCapture.capturedFocusEvents.first
+        XCTAssertNotNil(focusEvent?.pageEvent, "Focus event should be a page event")
+        XCTAssertEqual(focusEvent?.pageEvent?.type, "page.focus")
+        XCTAssertEqual(focusEvent?.pageEvent?.page.id, page2ID)
+    }
+    
+    /// Test that page duplication doesn't cause unexpected focus/blur events
+    func testPageFocusBlur_pageDuplication_noUnexpectedEvents() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+        
+        let originalPageID = "6629fab320fca7c8107a6cf6"
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: originalPageID,
+            navigation: true,
+            isPageDuplicateEnabled: true,
+            isPageDeleteEnabled: false,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Duplicate the page
+        documentEditor.duplicatePage(pageID: originalPageID)
+        
+        // Duplication should not fire focus/blur events on current page
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 0, "Page duplication should not fire focus events")
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 0, "Page duplication should not fire blur events")
+        
+        // Current page should still be the original
+        XCTAssertEqual(documentEditor.currentPageID, originalPageID, "Current page should remain unchanged after duplication")
+    }
+    
+    /// Test that deleting the currently focused page fires proper blur and focus events
+    func testPageFocusBlur_deleteCurrentPage_firesEventsForNewPage() {
+        let document = JoyDoc()
+            .setDocument()
+            .setSinglePageFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let page1ID = "6629fab320fca7c8107a6cf6"
+        let page2ID = "second_page_id_12345"
+        
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: page1ID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: true,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Delete the currently focused page
+        let result = documentEditor.deletePage(pageID: page1ID)
+        
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Should fire blur for deleted page and focus for new current page
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 1, "One blur event should fire for deleted page")
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 1, "One focus event should fire for new current page")
+        
+        // Verify blur event for deleted page
+        let blurEvent = eventCapture.capturedBlurEvents.first
+        XCTAssertNotNil(blurEvent?.pageEvent, "Blur event should be a page event")
+        XCTAssertEqual(blurEvent?.pageEvent?.type, "page.blur")
+        XCTAssertEqual(blurEvent?.pageEvent?.page.id, page1ID)
+        
+        // Verify focus event for new page
+        let focusEvent = eventCapture.capturedFocusEvents.first
+        XCTAssertNotNil(focusEvent?.pageEvent, "Focus event should be a page event")
+        XCTAssertEqual(focusEvent?.pageEvent?.type, "page.focus")
+        
+        // New current page should be page2
+        XCTAssertEqual(documentEditor.currentPageID, page2ID, "Current page should switch to remaining page")
+        XCTAssertEqual(focusEvent?.pageEvent?.page.id, page2ID, "Focus event should be for page2")
+    }
+    
+    /// Test that deleting a non-current page doesn't fire focus/blur events
+    func testPageFocusBlur_deleteNonCurrentPage_noEvents() {
+        let document = JoyDoc()
+            .setDocument()
+            .setSinglePageFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let page1ID = "6629fab320fca7c8107a6cf6"
+        let page2ID = "second_page_id_12345"
+        
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: page1ID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: true,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Delete a different page (not the current one)
+        let result = documentEditor.deletePage(pageID: page2ID)
+        
+        XCTAssertTrue(result, "Page deletion should succeed")
+        
+        // Should NOT fire any focus/blur events
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 0, "No blur events should fire when deleting non-current page")
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 0, "No focus events should fire when deleting non-current page")
+        
+        // Current page should remain unchanged
+        XCTAssertEqual(documentEditor.currentPageID, page1ID, "Current page should remain unchanged")
+    }
+    
+    /// Test multiple page navigations fire correct sequence of events
+    func testPageFocusBlur_multipleNavigations_correctSequence() {
+        let document = JoyDoc()
+            .setDocument()
+            .setSinglePageFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+        
+        let page1ID = "6629fab320fca7c8107a6cf6"
+        let page2ID = "second_page_id_12345"
+        
+        let eventCapture = ChangeCapture()
+        let documentEditor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: eventCapture,
+            pageID: page1ID,
+            navigation: true,
+            isPageDuplicateEnabled: false,
+            isPageDeleteEnabled: false,
+            validateSchema: false
+        )
+        
+        // Clear any initial events
+        eventCapture.reset()
+        
+        // Navigate page1 -> page2
+        documentEditor.currentPageID = page2ID
+        
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 1)
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 1)
+        XCTAssertEqual(eventCapture.capturedBlurEvents.first?.pageEvent?.page.id, page1ID)
+        XCTAssertEqual(eventCapture.capturedFocusEvents.first?.pageEvent?.page.id, page2ID)
+        
+        // Navigate page2 -> page1
+        documentEditor.currentPageID = page1ID
+        
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 2)
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 2)
+        XCTAssertEqual(eventCapture.capturedBlurEvents[1].pageEvent?.page.id, page2ID)
+        XCTAssertEqual(eventCapture.capturedFocusEvents[1].pageEvent?.page.id, page1ID)
+        
+        // Navigate page1 -> page2 again
+        documentEditor.currentPageID = page2ID
+        
+        XCTAssertEqual(eventCapture.capturedBlurEvents.count, 3)
+        XCTAssertEqual(eventCapture.capturedFocusEvents.count, 3)
+        XCTAssertEqual(eventCapture.capturedBlurEvents[2].pageEvent?.page.id, page1ID)
+        XCTAssertEqual(eventCapture.capturedFocusEvents[2].pageEvent?.page.id, page2ID)
+    }
 }

--- a/Sources/JoyfillUI/View/Types.swift
+++ b/Sources/JoyfillUI/View/Types.swift
@@ -33,7 +33,7 @@ public struct Event {
     public var fieldEvent: FieldIdentifier?
     public var pageEvent: PageEvent?
     
-    init(fieldEvent: FieldIdentifier? = nil, pageEvent: PageEvent? = nil) {
+    public init(fieldEvent: FieldIdentifier? = nil, pageEvent: PageEvent? = nil) {
         self.fieldEvent = fieldEvent
         self.pageEvent = pageEvent
     }

--- a/Sources/JoyfillUI/View/Types.swift
+++ b/Sources/JoyfillUI/View/Types.swift
@@ -29,6 +29,16 @@ public struct FieldIdentifier: Equatable {
     }
 }
 
+public struct Event {
+    public var fieldEvent: FieldIdentifier?
+    public var pageEvent: PageEvent?
+    
+    init(fieldEvent: FieldIdentifier? = nil, pageEvent: PageEvent? = nil) {
+        self.fieldEvent = fieldEvent
+        self.pageEvent = pageEvent
+    }
+}
+
 public struct UploadEvent {
     public var fieldEvent: FieldIdentifier
     public var target: String?
@@ -77,6 +87,16 @@ public struct CaptureEvent {
         self.parentPath = parentPath
         self.rowIds = rowIds
         self.columnId = columnId
+    }
+}
+
+public struct PageEvent {
+    public let type: String  // "page.focus" or "page.blur"
+    public let page: Page
+    
+    public init(type: String, page: Page) {
+        self.type = type
+        self.page = page
     }
 }
 
@@ -262,7 +282,7 @@ public protocol FormChangeEvent {
     ///     - Triggers the field blur event for the focused field.
     ///     - If there are pending changes in the field that have not triggered the `onChange` event yet then the `e.blur()` function will trigger both the change and blur events in the following order: 1) `onChange` 2) `onBlur`.
     ///     - If the focused field utilizes a modal for field modification, ie. signature, image, tables, etc. the `e.blur()` will close the modal.
-    func onFocus(event: FieldIdentifier)
+    func onFocus(event: Event)
 
     /// Used to listen to field focus events.
     ///
@@ -270,7 +290,7 @@ public protocol FormChangeEvent {
     ///
     ///  params: object :
     ///  - Specifies information about the blurred field.
-    func onBlur(event: FieldIdentifier)
+    func onBlur(event: Event)
 
     /// Used to listen to file upload events.
     ///

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -1205,11 +1205,11 @@ extension DocumentEditor {
     }
 
     func onFocus(event: FieldIdentifier) {
-        events?.onFocus(event: event)
+        events?.onFocus(event: Event(fieldEvent: event))
     }
 
     func onBlur(event: FieldIdentifier) {
-        events?.onBlur(event: event)
+        events?.onBlur(event: Event(fieldEvent: event))
     }
 
     func onUpload(event: UploadEvent) {
@@ -1218,6 +1218,14 @@ extension DocumentEditor {
     
     func onCapture(event: CaptureEvent) {
         events?.onCapture(event: event)
+    }
+    
+    func onFocus(event: PageEvent) {
+        events?.onFocus(event: Event(pageEvent: event))
+    }
+    
+    func onBlur(event: PageEvent) {
+        events?.onBlur(event: Event(pageEvent: event))
     }
 }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -1053,9 +1053,11 @@ extension DocumentEditor {
             }
         }
         
-        // Fire blur event for page to delete
-        if let previousPage = firstPageFor(currentPageID: pageID) {
-            onPageBlur(page: previousPage)
+        // Fire blur event for page to delete only if current page == pageID
+        if currentPageID == pageID {
+            if let previousPage = firstPageFor(currentPageID: pageID) {
+                onPageBlur(page: previousPage)
+            }
         }
                 
         // 3. Handle navigation before deletion


### PR DESCRIPTION
Breaking Changes:
- FormChangeEvent protocol methods(onFocus and onBlur) now accept Event instead of FieldIdentifier
- Implementations must check event.fieldEvent or event.pageEvent to determine type

This change also include fixing of all errors in example project related to FormChangeEvent protocol change