### PR TITLE
Rework validation to include row/cell output and exclude hidden items

### DIFF
--- a/.github/workflows/pr_pipeline_workflow.yml
+++ b/.github/workflows/pr_pipeline_workflow.yml
@@ -207,23 +207,50 @@ jobs:
             gem install xcpretty
           fi
 
+      - name: Boot simulator + inject JOYFILL_TEST_LICENSE into Simulator
+        env:
+          JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${JOYFILL_TEST_LICENSE}" ]]; then
+            echo "❌ JOYFILL_TEST_LICENSE secret is empty in this run."
+            exit 1
+          fi
+
+          # Pick the latest available iOS runtime identifier (e.g., com.apple.CoreSimulator.SimRuntime.iOS-18-2)
+          RUNTIME_ID=$(xcrun simctl list runtimes -j | python3 -c 'import json,sys; d=json.load(sys.stdin); r=[x["identifier"] for x in d["runtimes"] if x.get("isAvailable") and "iOS" in x.get("name","")]; print(r[-1])')
+
+          # Create a fresh simulator so destination is deterministic
+          DEVICE_ID=$(xcrun simctl create "CI-iPhone" "iPhone 15" "$RUNTIME_ID")
+          echo "DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+
+          xcrun simctl boot "$DEVICE_ID" || true
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+
+          # Inject env var into processes launched inside the simulator
+          xcrun simctl spawn "$DEVICE_ID" launchctl setenv JOYFILL_TEST_LICENSE "$JOYFILL_TEST_LICENSE"
+
+          echo "✅ Simulator ready: $DEVICE_ID"
+
       - name: Run Unit Tests
         env:
           JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
         run: |
           set -o pipefail
           cd JoyfillSwiftUIExample
+
           xcodebuild test \
             -project JoyfillExample.xcodeproj \
             -scheme JoyfillTests \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination "id=$DEVICE_ID" \
+            -resultBundlePath TestResults.xcresult \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            EXCLUDED_ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
           | xcpretty --color --report html --output unit-test-report.html
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/pr_pipeline_workflow.yml
+++ b/.github/workflows/pr_pipeline_workflow.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Run Unit Tests
         env:
-          SIMCTL_CHILD_JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
+          JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
         run: |
           set -o pipefail
           cd JoyfillSwiftUIExample

--- a/.github/workflows/pr_pipeline_workflow.yml
+++ b/.github/workflows/pr_pipeline_workflow.yml
@@ -208,7 +208,7 @@ jobs:
           fi
 
       - name: Run Unit Tests
-      env:
+        env:
           SIMCTL_CHILD_JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
         run: |
           set -o pipefail

--- a/.github/workflows/pr_pipeline_workflow.yml
+++ b/.github/workflows/pr_pipeline_workflow.yml
@@ -208,6 +208,8 @@ jobs:
           fi
 
       - name: Run Unit Tests
+      env:
+          SIMCTL_CHILD_JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
         run: |
           set -o pipefail
           cd JoyfillSwiftUIExample

--- a/.github/workflows/pr_pipeline_workflow.yml
+++ b/.github/workflows/pr_pipeline_workflow.yml
@@ -53,6 +53,7 @@ on:
 env:
   # Use pre-merge as default for all PR events
   PIPELINE_TYPE: ${{ github.event.inputs.pipeline_type || 'pre-merge' }}
+  JOYFILL_TEST_LICENSE: ${{ secrets.JOYFILL_TEST_LICENSE }}
 
 jobs:
   # 🔍 Job 1: SwiftLint (Code Quality)

--- a/JoyfillSwiftUIExample/JoyfillExample/JoyDoc+DummyModel.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/JoyDoc+DummyModel.swift
@@ -3034,13 +3034,13 @@ extension JoyDoc {
             ],
             "child_schema_1": [
                 "title": "Child Schema",
-                "required": true,
+                "required": isSchemaRequired,
                 "tableColumns": [
                     [
                         "_id": "nested_col_1",
                         "type": "text",
                         "title": "Nested Column",
-                        "required": true
+                        "required": isSchemaRequired
                     ]
                 ]
             ]

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -369,7 +369,12 @@ struct FormDestinationView: View {
             )
         ) {
             if let validation = self.lastValidation {
-                ValidationResultsView(validation: validation)
+                ValidationResultsView(
+                    validation: validation,
+                    documentEditor: documentEditor
+                ) {
+                    self.lastValidation = nil
+                }
             }
         }
         // Kick off background creation once the view appears

--- a/JoyfillSwiftUIExample/JoyfillExample/ValidationResultsView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ValidationResultsView.swift
@@ -259,9 +259,9 @@ struct ValidationResultsView: View {
               let fieldPositionId = fv.fieldPositionId else { return }
         dismiss()
         onGoToField?()
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
             _ = editor.goto("\(pageId)/\(fieldPositionId)")
-//        }
+        }
     }
 
     private func navigateToRow(row: RowValidity, fieldValidity: FieldValidity) {
@@ -271,9 +271,9 @@ struct ValidationResultsView: View {
               let rowId = row.rowId else { return }
         dismiss()
         onGoToField?()
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             _ = editor.goto("\(pageId)/\(fieldPositionId)/\(rowId)", gotoConfig: GotoConfig(open: true))
-//        }
+        }
     }
 
 }

--- a/JoyfillSwiftUIExample/JoyfillExample/ValidationResultsView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ValidationResultsView.swift
@@ -1,85 +1,300 @@
 import SwiftUI
 import JoyfillModel
+import Joyfill
 
 struct ValidationResultsView: View {
     let validation: Validation
+    let documentEditor: DocumentEditor?
+    let onGoToField: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    init(validation: Validation, documentEditor: DocumentEditor? = nil, onGoToField: (() -> Void)? = nil) {
+        self.validation = validation
+        self.documentEditor = documentEditor
+        self.onGoToField = onGoToField
+    }
+
+    private var pageGroups: [(pageId: String, pageName: String, fields: [FieldValidity])] {
+        let pages = documentEditor?.pagesForCurrentView ?? []
+        var grouped: [String: [FieldValidity]] = [:]
+        var pageOrder: [String] = []
+
+        for fv in validation.fieldValidities {
+            let pid = fv.pageId ?? "unknown"
+            if grouped[pid] == nil {
+                pageOrder.append(pid)
+            }
+            grouped[pid, default: []].append(fv)
+        }
+
+        return pageOrder.compactMap { pid in
+            let pageName = pages.first(where: { $0.id == pid })?.name
+            let displayName = pageName ?? "Page"
+            return (pageId: pid, pageName: displayName, fields: grouped[pid] ?? [])
+        }
+    }
+
+    private var invalidCount: Int {
+        validation.fieldValidities.filter { $0.status == .invalid }.count
+    }
+
+    private var totalCount: Int {
+        validation.fieldValidities.count
+    }
 
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    header
-                    Divider()
-                    ForEach(Array(validation.fieldValidities.enumerated()), id: \.offset) { _, fv in
-                        FieldValidityView(fieldValidity: fv)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .background(Color.gray.opacity(0.06))
-                            .cornerRadius(12)
+                VStack(alignment: .leading, spacing: 20) {
+                    summaryCard
+                    ForEach(Array(pageGroups.enumerated()), id: \.offset) { index, group in
+                        pageSection(index: index + 1, group: group)
                     }
                 }
                 .padding(16)
             }
+            .background(Color(.systemGroupedBackground))
             .navigationTitle("Validation Results")
             .navigationBarTitleDisplayMode(.inline)
         }
     }
 
-    private var header: some View {
-        HStack {
+    // MARK: - Summary
+
+    private var summaryCard: some View {
+        VStack(spacing: 12) {
             Image(systemName: validation.status == .valid ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
                 .foregroundColor(validation.status == .valid ? .green : .orange)
-            Text(validation.status == .valid ? "All fields valid" : "Some fields need attention")
+
+            Text(validation.status == .valid ? "All fields valid" : "\(invalidCount) of \(totalCount) fields need attention")
                 .font(.headline)
+                .multilineTextAlignment(.center)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
     }
-}
 
-private struct FieldValidityView: View {
-    let fieldValidity: FieldValidity
+    // MARK: - Page Section
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private func pageSection(index: Int, group: (pageId: String, pageName: String, fields: [FieldValidity])) -> some View {
+        let pageInvalidCount = group.fields.filter { $0.status == .invalid }.count
+
+        return VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text(fieldTitle)
-                    .font(.subheadline).bold()
+                Image(systemName: "doc.text")
+                    .foregroundColor(.accentColor)
+                Text("\(group.pageName) \(index)")
+                    .font(.subheadline.weight(.semibold))
                 Spacer()
-                
-                StatusTag(status: fieldValidity.status)
+                if pageInvalidCount > 0 {
+                    Text("\(pageInvalidCount) invalid")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(6)
+                } else {
+                    Text("All valid")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.green.opacity(0.1))
+                        .cornerRadius(6)
+                }
             }
-            
-            Text("Field ID: \(fieldID)")
-                .font(.subheadline)
-            
-            
-            Text("Page ID: \(pageID)")
-                .font(.subheadline)
+            .padding(.horizontal, 4)
+
+            ForEach(Array(group.fields.enumerated()), id: \.offset) { _, fv in
+                fieldCard(fv)
+            }
         }
     }
 
-    private var fieldTitle: String {
-        fieldValidity.field.title ?? (fieldValidity.field.id ?? "Untitled Field")
+    // MARK: - Field Card
+
+    private func fieldCard(_ fv: FieldValidity) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(fv.field.title ?? (fv.field.id ?? "Untitled Field"))
+                        .font(.subheadline.weight(.medium))
+
+                }
+                Spacer()
+                StatusTag(status: fv.status)
+            }
+
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Field ID: \(fv.fieldId ?? fv.field.id ?? "")")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text("Page ID: \(fv.pageId ?? "")")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+
+                if fv.status == .invalid, documentEditor != nil {
+                    goToFieldButton(fv)
+                }
+            }
+
+            if let rows = fv.rowValidities, !rows.isEmpty {
+                invalidRowsList(rows: rows, fieldValidity: fv)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(fv.status == .invalid ? Color.red.opacity(0.25) : Color.clear, lineWidth: 1)
+        )
     }
-    private var fieldID: String {
-        fieldValidity.field.id ?? ""
+
+    // MARK: - Invalid Rows List
+
+    private func invalidRowsList(rows: [RowValidity], fieldValidity: FieldValidity) -> some View {
+        let invalidRows = rows.filter { $0.status == .invalid }
+        let totalRows = rows.count
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Divider()
+
+            HStack(spacing: 4) {
+                Image(systemName: "tablecells")
+                    .font(.caption2)
+                    .foregroundColor(invalidRows.isEmpty ? .secondary : .red)
+                Text(invalidRows.isEmpty
+                     ? "\(totalRows) rows — all valid"
+                     : "\(invalidRows.count) of \(totalRows) rows invalid")
+                    .font(.caption)
+                    .foregroundColor(invalidRows.isEmpty ? .secondary : .red)
+            }
+
+            ForEach(Array(invalidRows.enumerated()), id: \.offset) { index, row in
+                invalidRowCard(row: row, index: index, fieldValidity: fieldValidity)
+            }
+        }
     }
-    private var pageID: String {
-        fieldValidity.pageId ?? ""
+
+    private func invalidRowCard(row: RowValidity, index: Int, fieldValidity: FieldValidity) -> some View {
+        let invalidCells = row.cellValidities.filter { $0.status == .invalid }
+
+        return HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Row \(row.rowId ?? "?")")
+                    .font(.caption.weight(.medium))
+                if !invalidCells.isEmpty {
+                    Text("\(invalidCells.count) cell(s) invalid")
+                        .font(.caption2)
+                        .foregroundColor(.red)
+                }
+                if let schemaId = row.schemaId {
+                    Text("Schema: \(schemaId)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            if documentEditor != nil {
+                goToRowButton(row: row, fieldValidity: fieldValidity)
+            }
+        }
+        .padding(8)
+        .background(Color.red.opacity(0.04))
+        .cornerRadius(8)
     }
+
+    // MARK: - Navigation Buttons
+
+    private func goToFieldButton(_ fv: FieldValidity) -> some View {
+        Button {
+            navigateToField(fv)
+        } label: {
+            HStack(spacing: 4) {
+                Text("Go to")
+                Image(systemName: "arrow.right.circle.fill")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.accentColor)
+            .cornerRadius(8)
+        }
+    }
+
+    private func goToRowButton(row: RowValidity, fieldValidity: FieldValidity) -> some View {
+        Button {
+            navigateToRow(row: row, fieldValidity: fieldValidity)
+        } label: {
+            HStack(spacing: 3) {
+                Text("Go to row")
+                Image(systemName: "arrow.right.circle")
+            }
+            .font(.caption2.weight(.semibold))
+            .foregroundColor(.accentColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.accentColor.opacity(0.12))
+            .cornerRadius(6)
+        }
+    }
+
+    private func navigateToField(_ fv: FieldValidity) {
+        guard let editor = documentEditor,
+              let pageId = fv.pageId,
+              let fieldPositionId = fv.fieldPositionId else { return }
+        dismiss()
+        onGoToField?()
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            _ = editor.goto("\(pageId)/\(fieldPositionId)")
+//        }
+    }
+
+    private func navigateToRow(row: RowValidity, fieldValidity: FieldValidity) {
+        guard let editor = documentEditor,
+              let pageId = fieldValidity.pageId,
+              let fieldPositionId = fieldValidity.fieldPositionId,
+              let rowId = row.rowId else { return }
+        dismiss()
+        onGoToField?()
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            _ = editor.goto("\(pageId)/\(fieldPositionId)/\(rowId)", gotoConfig: GotoConfig(open: true))
+//        }
+    }
+
 }
+
+// MARK: - Status Tag
 
 private struct StatusTag: View {
     let status: ValidationStatus
 
     var body: some View {
-        Text(status.rawValue.capitalized)
-            .font(.caption)
-            .foregroundColor(status == .valid ? .green : .red)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
-            .background((status == .valid ? Color.green : Color.red).opacity(0.12))
-            .cornerRadius(6)
+        HStack(spacing: 4) {
+            Circle()
+                .fill(status == .valid ? Color.green : Color.red)
+                .frame(width: 6, height: 6)
+            Text(status == .valid ? "Valid" : "Invalid")
+                .font(.caption.weight(.medium))
+                .foregroundColor(status == .valid ? .green : .red)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background((status == .valid ? Color.green : Color.red).opacity(0.1))
+        .cornerRadius(6)
     }
 }
-
-

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -3547,4 +3547,40 @@ final class ValidationTestCase: XCTestCase {
         let rootRow = rows.first(where: { $0.rowId == "row_1" })
         XCTAssertEqual(rootRow?.status, .invalid)
     }
+
+    // MARK: - Unknown Field Type Excluded
+
+    func testUnknownFieldType_ExcludedFromValidation() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+
+        var field = JoyDocField()
+        field.type = "someFutureType"
+        field.id = "unknown_field_1"
+        field.identifier = "field_unknown_1"
+        field.title = "Unknown Field"
+        field.required = true
+        field.value = .string("")
+        field.file = "6629fab3c0ba3fb775b4a55c"
+        document.fields.append(field)
+
+        var fieldPosition = FieldPosition()
+        fieldPosition.field = "unknown_field_1"
+        fieldPosition.displayType = "original"
+        fieldPosition.width = 12
+        fieldPosition.height = 8
+        fieldPosition.x = 0
+        fieldPosition.y = 60
+        fieldPosition.id = "unknown_field_1_pos"
+        document.files[0].views?[0].pages?[0].fieldPositions?.append(fieldPosition)
+
+        let editor = documentEditor(document: document)
+        let result = editor.validate()
+
+        XCTAssertFalse(result.fieldValidities.contains(where: { $0.fieldId == "unknown_field_1" }))
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -841,7 +841,7 @@ final class ValidationTestCase: XCTestCase {
 
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
-        //Result should be invalid coz a row with id "67612793a6cd1f9d39c8433d" has nil cells
+        //Result should be invalid because a row with id "67612793a6cd1f9d39c8433d" has nil cells
         XCTAssertEqual(validationResult.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -3076,9 +3076,9 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
 
         let fieldValidity = validationResult.fieldValidities.first
-        XCTAssertNotNil(fieldValidity?.rows)
+        XCTAssertNotNil(fieldValidity?.rowValidities)
         // 5 rows total: 3 with data + 1 deleted (skipped) + 1 nil cells = 4 non-deleted
-        XCTAssertEqual(fieldValidity?.rows?.count, 4)
+        XCTAssertEqual(fieldValidity?.rowValidities?.count, 4)
     }
 
     func testTableField_DeletedRowsExcludedFromOutput() {
@@ -3094,7 +3094,7 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
-        let rows = validationResult.fieldValidities.first?.rows ?? []
+        let rows = validationResult.fieldValidities.first?.rowValidities ?? []
         let deletedRowId = "67612793a6cd1f9d39c8433c"
         XCTAssertFalse(rows.contains(where: { $0.row.id == deletedRowId }))
     }
@@ -3112,7 +3112,7 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
-        let firstRow = validationResult.fieldValidities.first?.rows?.first
+        let firstRow = validationResult.fieldValidities.first?.rowValidities?.first
         XCTAssertNotNil(firstRow)
         // 3 columns visible (none hidden), but column3 is not required
         XCTAssertEqual(firstRow?.cellValidities.count, 3)
@@ -3133,7 +3133,7 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
 
         // Row 5 (id: 67612793a6cd1f9d39c8433d) has nil cells, should be invalid
-        let nilCellsRow = validationResult.fieldValidities.first?.rows?.first(where: { $0.row.id == "67612793a6cd1f9d39c8433d" })
+        let nilCellsRow = validationResult.fieldValidities.first?.rowValidities?.first(where: { $0.row.id == "67612793a6cd1f9d39c8433d" })
         XCTAssertNotNil(nilCellsRow)
         XCTAssertEqual(nilCellsRow?.status, .invalid)
 
@@ -3155,7 +3155,7 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
 
         // Row 1 (id: 676127938056dcd158942bad) has all cells populated
-        let validRow = validationResult.fieldValidities.first?.rows?.first(where: { $0.row.id == "676127938056dcd158942bad" })
+        let validRow = validationResult.fieldValidities.first?.rowValidities?.first(where: { $0.row.id == "676127938056dcd158942bad" })
         XCTAssertNotNil(validRow)
         XCTAssertEqual(validRow?.status, .valid)
         XCTAssertTrue(validRow?.cellValidities.allSatisfy { $0.status == .valid } ?? false)
@@ -3174,7 +3174,7 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
-        let rows = validationResult.fieldValidities.first?.rows ?? []
+        let rows = validationResult.fieldValidities.first?.rowValidities ?? []
         XCTAssertFalse(rows.isEmpty)
         // Row 2 has empty cells, should be invalid
         let row2 = rows.first(where: { $0.row.id == "67612793f70928da78973744" })
@@ -3211,7 +3211,7 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
-        let rows = validationResult.fieldValidities.first?.rows ?? []
+        let rows = validationResult.fieldValidities.first?.rowValidities ?? []
         for row in rows {
             XCTAssertEqual(row.status, .valid)
             XCTAssertTrue(row.cellValidities.allSatisfy { $0.status == .valid })
@@ -3232,7 +3232,7 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
 
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
-        let rows = validationResult.fieldValidities.first?.rows
+        let rows = validationResult.fieldValidities.first?.rowValidities
         XCTAssertNotNil(rows)
         XCTAssertEqual(rows?.count, 0)
     }
@@ -3260,7 +3260,7 @@ final class ValidationTestCase: XCTestCase {
 
         XCTAssertEqual(validationResult.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
-        XCTAssertEqual(validationResult.fieldValidities.first?.rows?.count, 0)
+        XCTAssertEqual(validationResult.fieldValidities.first?.rowValidities?.count, 0)
     }
 
     // MARK: - Collection Row/Cell Output Tests
@@ -3279,8 +3279,8 @@ final class ValidationTestCase: XCTestCase {
         let result = editor.validate()
 
         let fieldValidity = result.fieldValidities.first
-        XCTAssertNotNil(fieldValidity?.rows)
-        XCTAssertFalse(fieldValidity?.rows?.isEmpty ?? true)
+        XCTAssertNotNil(fieldValidity?.rowValidities)
+        XCTAssertFalse(fieldValidity?.rowValidities?.isEmpty ?? true)
     }
 
     func testCollectionField_RootRowHasCorrectSchemaId() {
@@ -3296,7 +3296,7 @@ final class ValidationTestCase: XCTestCase {
         let editor = documentEditor(document: document)
         let result = editor.validate()
 
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         let rootRow = rows.first(where: { $0.row.id == "row_1" })
         XCTAssertNotNil(rootRow)
         XCTAssertEqual(rootRow?.schemaId, "main_schema")
@@ -3315,7 +3315,7 @@ final class ValidationTestCase: XCTestCase {
         let editor = documentEditor(document: document)
         let result = editor.validate()
 
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         let nestedRow = rows.first(where: { $0.row.id == "nested_row_1" })
         XCTAssertNotNil(nestedRow)
         XCTAssertEqual(nestedRow?.schemaId, "child_schema_1")
@@ -3334,7 +3334,7 @@ final class ValidationTestCase: XCTestCase {
         let editor = documentEditor(document: document)
         let result = editor.validate()
 
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         // Should have root row + nested row in flat array
         XCTAssertEqual(rows.count, 2)
 
@@ -3356,7 +3356,7 @@ final class ValidationTestCase: XCTestCase {
         let editor = documentEditor(document: document)
         let result = editor.validate()
 
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         let rootRow = rows.first(where: { $0.schemaId == "main_schema" })
         XCTAssertEqual(rootRow?.cellValidities.count, 1)
         XCTAssertEqual(rootRow?.cellValidities.first?.column.id, "col_text_1")
@@ -3379,7 +3379,7 @@ final class ValidationTestCase: XCTestCase {
         let editor = documentEditor(document: document)
         let result = editor.validate()
 
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         let rootRow = rows.first(where: { $0.schemaId == "main_schema" })
         XCTAssertEqual(rootRow?.status, .invalid)
         XCTAssertEqual(rootRow?.cellValidities.first?.status, .invalid)
@@ -3401,7 +3401,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(result.status, .invalid)
         XCTAssertEqual(result.fieldValidities.first?.status, .invalid)
         // Only root row in output (no nested rows)
-        let rows = result.fieldValidities.first?.rows ?? []
+        let rows = result.fieldValidities.first?.rowValidities ?? []
         XCTAssertFalse(rows.contains(where: { $0.schemaId == "child_schema_1" }))
     }
 

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -2,7 +2,7 @@ import XCTest
 import Foundation
 import SwiftUI
 import JoyfillModel
-import Joyfill
+@testable import Joyfill
 
 final class ValidationTestCase: XCTestCase {
     
@@ -44,9 +44,8 @@ final class ValidationTestCase: XCTestCase {
     func collectionDocumentEditor(document: JoyDoc) -> DocumentEditor {
         let license = (ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if license.isEmpty {
-            XCTSkip("Missing JOYFILL_TEST_LICENSE")
-        }
+        XCTAssertFalse(license.isEmpty, "Missing license: set JOYFILL_TEST_LICENSE env var or check licenseKey")
+        XCTAssertTrue(LicenseValidator.isCollectionEnabled(licenseToken: license), "License verification failed — the token does not match the public key in LicenseValidator")
         return DocumentEditor(document: document, validateSchema: false, license: license)
     }
     //

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -930,9 +930,10 @@ final class ValidationTestCase: XCTestCase {
 
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
-
-        XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
+        //if table/collection is not required , but some internal things are req and not filled , whole table is invalid
+        
+        XCTAssertEqual(validationResult.status, .invalid)
+        XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
     }
@@ -2578,9 +2579,9 @@ final class ValidationTestCase: XCTestCase {
 
             let editor = documentEditor(document: document)
             let result = editor.validate()
-
-            XCTAssertEqual(result.status, .valid)
-            XCTAssertEqual(result.fieldValidities.first?.status, .valid)
+            //if table/collection is not required , but some internal things are req and not filled , whole table is invalid
+            XCTAssertEqual(result.status, .invalid)
+            XCTAssertEqual(result.fieldValidities.first?.status, .invalid)
             XCTAssertEqual(result.fieldValidities.first?.field.id, "67ddc52d35de157f6d7ebb63")
             XCTAssertEqual(result.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         }

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -7,6 +7,7 @@ import Joyfill
 final class ValidationTestCase: XCTestCase {
     
     // MARK: - Test Helpers
+    let licenseKey: String = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3N1ZXIiOiJKb3lmaWxsIExMQyIsImlzc3VlZCI6IlNlcnZpY2UgVHJhZGUiLCJjb2xsZWN0aW9uRmllbGQiOnRydWV9.EA_6ZEq9viV6omtSquXzHkGMMIOtqyR2utE6sq2swATFn7-GCR032WZyxkJhc7dSl9rBG0sSNdQhfLYafKpJ07LD2jK7izKXcl0lZ4OkYWUjBlJzZqQVS9VIfkJxZg_CshuyTI5Srzw0-V8AuuaC_Lu2oAEiRxwMqCWXuZl6uHloe2sO5XmMUcZnkoOlwmNwsKwgjmL2N_9-FuuMha15jcqsEcgoA4y2caGIGsXdJlvEaQKT81nn4fN79eYGHVv_EucFutZLLLDbtZLheIYaV9gIGUrFyX210AGZ56sp6tGuadHu9yqQGM_a6kK_d5A97tnMlOzg06-CvWXzEaibMduxX1fecg8_iu6mUgA_1HN8E5FjtBtDUa6qpcIVMlGFss2rWiu1NdDBnZPhu6ZDPy9-h3edVFrGF-qCAaEk_Kvg2H4qnRhdZOzvS1JA1ZgxTKTH9UeQff5QJ8k4h83rG5_aPHuAEwj1KD9nK_h9Qlk3ClIUO_vaRxYl-SyyOffCUBBbnwCdyV4oKE4giJAxBbsup_pKYGZFKgpeBx_s3hOFvrHjShd-pFqgBJJUGf8Niz2yge4y7U0efuG9XAYKeIqAm5KF9x7_oDMmXYswF554QOb49V8SCaOmjTs3hU2zf0TzWv4WTOLW78Ahd4q3-pJVG8535r1oOH8Z7YiI6-4"
     
     /// Mock event handler to capture onChange events for testing
     class ChangeCapture: FormChangeEvent {
@@ -38,6 +39,11 @@ final class ValidationTestCase: XCTestCase {
     }
     func documentEditor(document: JoyDoc) -> DocumentEditor {
         DocumentEditor(document: document, validateSchema: false)
+    }
+
+    func collectionDocumentEditor(document: JoyDoc) -> DocumentEditor {
+        let license = ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey
+        return DocumentEditor(document: document, validateSchema: false, license: license)
     }
     //
     // Test Case for check at same time web and mobile view fields
@@ -2481,7 +2487,7 @@ final class ValidationTestCase: XCTestCase {
                 .setCollectionFieldRequired()
                 .setCollectionFieldPosition()
 
-            let documentEditor = documentEditor(document: document)
+            let documentEditor = collectionDocumentEditor(document: document)
             let validationResult = documentEditor.validate()
 
             XCTAssertEqual(validationResult.status, .invalid)
@@ -2505,8 +2511,8 @@ final class ValidationTestCase: XCTestCase {
                 )
                 .setCollectionFieldPosition()
 
-            let editor = documentEditor(document: document)
-            let result = editor.validate()
+            let documentEditor = collectionDocumentEditor(document: document)
+            let result = documentEditor.validate()
 
             XCTAssertEqual(result.status, .valid)
             XCTAssertEqual(result.fieldValidities.first?.status, .valid)
@@ -2529,7 +2535,7 @@ final class ValidationTestCase: XCTestCase {
                 )
                 .setCollectionFieldPosition()
 
-            let editor = documentEditor(document: document)
+            let editor = collectionDocumentEditor(document: document)
             let result = editor.validate()
 
             XCTAssertEqual(result.status, .invalid)
@@ -2553,7 +2559,7 @@ final class ValidationTestCase: XCTestCase {
                 )
                 .setCollectionFieldPosition()
 
-            let editor = documentEditor(document: document)
+            let editor = collectionDocumentEditor(document: document)
             let result = editor.validate()
 
             XCTAssertEqual(result.status, .invalid)
@@ -2577,7 +2583,7 @@ final class ValidationTestCase: XCTestCase {
                 )
                 .setCollectionFieldPosition()
 
-            let editor = documentEditor(document: document)
+            let editor = collectionDocumentEditor(document: document)
             let result = editor.validate()
             //if table/collection is not required , but some internal things are req and not filled , whole table is invalid
             XCTAssertEqual(result.status, .invalid)
@@ -2596,7 +2602,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: false, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .valid)
@@ -2615,7 +2621,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: false, omitRequiredValues: true)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .invalid)
@@ -2634,7 +2640,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: true)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .invalid)
@@ -2653,7 +2659,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .valid)
@@ -2672,7 +2678,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: true)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .invalid)
@@ -3263,7 +3269,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let fieldValidity = result.fieldValidities.first
@@ -3281,7 +3287,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3300,7 +3306,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3319,7 +3325,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3341,7 +3347,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3364,7 +3370,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: true)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3383,7 +3389,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: false, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .invalid)
@@ -3403,7 +3409,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: false, includeNestedRows: false, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .valid)
@@ -3422,7 +3428,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: false, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3445,7 +3451,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: false, includeNestedRows: false, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3480,7 +3486,7 @@ final class ValidationTestCase: XCTestCase {
             document.fields[fieldIndex].value = .valueElementArray(elements)
         }
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3508,7 +3514,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: false)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         let rows = result.fieldValidities.first?.rowValidities ?? []
@@ -3532,7 +3538,7 @@ final class ValidationTestCase: XCTestCase {
             .setCollectionFieldRequired(isFieldRequired: true, isSchemaRequired: true, includeNestedRows: true, omitRequiredValues: true)
             .setCollectionFieldPosition()
 
-        let editor = documentEditor(document: document)
+        let editor = collectionDocumentEditor(document: document)
         let result = editor.validate()
 
         XCTAssertEqual(result.status, .invalid)
@@ -3582,5 +3588,80 @@ final class ValidationTestCase: XCTestCase {
         let result = editor.validate()
 
         XCTAssertFalse(result.fieldValidities.contains(where: { $0.fieldId == "unknown_field_1" }))
+    }
+
+    // MARK: - Collection License Validation Tests
+
+    func testCollectionField_NoLicense_ShouldBeExcludedFromValidation() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionFieldRequired(
+                isFieldRequired: true,
+                isSchemaRequired: true,
+                includeNestedRows: true,
+                omitRequiredValues: true
+            )
+            .setCollectionFieldPosition()
+
+        let editor = documentEditor(document: document)
+        let result = editor.validate()
+
+        XCTAssertFalse(
+            result.fieldValidities.contains(where: { $0.field.fieldType == .collection }),
+            "Collection field should not appear in validation results when no license is provided"
+        )
+    }
+
+    func testCollectionField_NoLicense_OtherFieldsStillValidated() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionFieldRequired(
+                isFieldRequired: true,
+                isSchemaRequired: true,
+                includeNestedRows: true,
+                omitRequiredValues: true
+            )
+            .setCollectionFieldPosition()
+
+        let editor = documentEditor(document: document)
+        let result = editor.validate()
+
+        XCTAssertFalse(
+            result.fieldValidities.contains(where: { $0.field.fieldType == .collection }),
+            "Collection field should be excluded when no license is provided"
+        )
+
+    }
+
+    func testCollectionField_ValidLicense_ShouldBeIncludedInValidation() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionFieldRequired(
+                isFieldRequired: true,
+                isSchemaRequired: true,
+                includeNestedRows: true,
+                omitRequiredValues: true
+            )
+            .setCollectionFieldPosition()
+
+        let editor = collectionDocumentEditor(document: document)
+        let result = editor.validate()
+
+        XCTAssertTrue(
+            result.fieldValidities.contains(where: { $0.field.fieldType == .collection }),
+            "Collection field should be included in validation when a valid license is provided"
+        )
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -7,7 +7,7 @@ import Joyfill
 final class ValidationTestCase: XCTestCase {
     
     // MARK: - Test Helpers
-    let licenseKey: String = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3N1ZXIiOiJKb3lmaWxsIExMQyIsImlzc3VlZCI6IlNlcnZpY2UgVHJhZGUiLCJjb2xsZWN0aW9uRmllbGQiOnRydWV9.EA_6ZEq9viV6omtSquXzHkGMMIOtqyR2utE6sq2swATFn7-GCR032WZyxkJhc7dSl9rBG0sSNdQhfLYafKpJ07LD2jK7izKXcl0lZ4OkYWUjBlJzZqQVS9VIfkJxZg_CshuyTI5Srzw0-V8AuuaC_Lu2oAEiRxwMqCWXuZl6uHloe2sO5XmMUcZnkoOlwmNwsKwgjmL2N_9-FuuMha15jcqsEcgoA4y2caGIGsXdJlvEaQKT81nn4fN79eYGHVv_EucFutZLLLDbtZLheIYaV9gIGUrFyX210AGZ56sp6tGuadHu9yqQGM_a6kK_d5A97tnMlOzg06-CvWXzEaibMduxX1fecg8_iu6mUgA_1HN8E5FjtBtDUa6qpcIVMlGFss2rWiu1NdDBnZPhu6ZDPy9-h3edVFrGF-qCAaEk_Kvg2H4qnRhdZOzvS1JA1ZgxTKTH9UeQff5QJ8k4h83rG5_aPHuAEwj1KD9nK_h9Qlk3ClIUO_vaRxYl-SyyOffCUBBbnwCdyV4oKE4giJAxBbsup_pKYGZFKgpeBx_s3hOFvrHjShd-pFqgBJJUGf8Niz2yge4y7U0efuG9XAYKeIqAm5KF9x7_oDMmXYswF554QOb49V8SCaOmjTs3hU2zf0TzWv4WTOLW78Ahd4q3-pJVG8535r1oOH8Z7YiI6-4"
+    let licenseKey: String = ""
     
     /// Mock event handler to capture onChange events for testing
     class ChangeCapture: FormChangeEvent {
@@ -42,7 +42,11 @@ final class ValidationTestCase: XCTestCase {
     }
 
     func collectionDocumentEditor(document: JoyDoc) -> DocumentEditor {
-        let license = ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey
+        let license = (ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if license.isEmpty {
+            XCTSkip("Missing JOYFILL_TEST_LICENSE")
+        }
         return DocumentEditor(document: document, validateSchema: false, license: license)
     }
     //

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -878,8 +878,8 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
-        XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
+        XCTAssertEqual(validationResult.status, .invalid)
+        XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
     }
@@ -3231,9 +3231,36 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
 
+        XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         let rows = validationResult.fieldValidities.first?.rows
         XCTAssertNotNil(rows)
         XCTAssertEqual(rows?.count, 0)
+    }
+
+    func testTableField_AllRowsDeleted_IsInvalid() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTableField(hideColumn: false, isTableRequired: true, isColumnRequired: true, areCellsEmpty: false, isZeroRows: false, isColumnsZero: false, isRowOrderNil: false)
+            .setTableFieldPosition(hideColumn: false)
+
+        if let fieldIndex = document.fields.firstIndex(where: { $0.id == "67612793c4e6a5e6a05e64a3" }),
+           var elements = document.fields[fieldIndex].valueToValueElements {
+            for i in elements.indices {
+                elements[i].deleted = true
+            }
+            document.fields[fieldIndex].value = .valueElementArray(elements)
+        }
+
+        let documentEditor = documentEditor(document: document)
+        let validationResult = documentEditor.validate()
+
+        XCTAssertEqual(validationResult.status, .invalid)
+        XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
+        XCTAssertEqual(validationResult.fieldValidities.first?.rows?.count, 0)
     }
 
     // MARK: - Collection Row/Cell Output Tests

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -682,14 +682,12 @@ final class ValidationTestCase: XCTestCase {
             .setMultilineTextField(hidden: true, value: .string(""), required: true)
                 let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
-
+        //Test case changed as we not returning the hidden fields/any elements
         XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.count, 2)
+        XCTAssertEqual(validationResult.fieldValidities.count, 1)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa29c05db08120464a2875")
-        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
     }
 
     func testRequiredHiddenNumberFieldWithValue() {
@@ -710,12 +708,11 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
 
         XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.count, 2)
+        XCTAssertEqual(validationResult.fieldValidities.count, 1)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa29c05db08120464a2875")
-        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
+        
     }
 
     // Show Hidden Field Test Cases
@@ -790,12 +787,10 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
         
         XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.count, 2)
+        XCTAssertEqual(validationResult.fieldValidities.count, 1)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
-        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
     }
 
     func testRequiredHideNumberFieldWithValues() {
@@ -816,12 +811,12 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
         
         XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.count, 2)
+        XCTAssertEqual(validationResult.fieldValidities.count, 1)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
-        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
+//        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
+//        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
         
     }
     
@@ -837,7 +832,7 @@ final class ValidationTestCase: XCTestCase {
 
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
-        //Invalid coz "67612793a6cd1f9d39c8433d" this row has nil cells
+        //Result should be invalid coz a row with id "67612793a6cd1f9d39c8433d" has nil cells
         XCTAssertEqual(validationResult.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
@@ -1744,7 +1739,7 @@ final class ValidationTestCase: XCTestCase {
         let pageToDeleteID = "second_page_id_12345" // ✅ Fixed: Using correct page ID
         let documentEditor = documentEditor(document: document)
         
-        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }), 
+        XCTAssertTrue(documentEditor.document.fields.contains(where: { $0.id == sharedFieldID }),
                      "Shared field should exist before deletion")
         
         // Delete page 2
@@ -1983,7 +1978,7 @@ final class ValidationTestCase: XCTestCase {
         let fieldD_ID = "field_d_mobile_pages"
         
         // Add all fields
-        for (id, identifier) in [(fieldA_ID, "fieldA"), (fieldB_ID, "fieldB"), 
+        for (id, identifier) in [(fieldA_ID, "fieldA"), (fieldB_ID, "fieldB"),
                                    (fieldC_ID, "fieldC"), (fieldD_ID, "fieldD")] {
             var field = JoyDocField(field: [:])
             field.id = id
@@ -2709,12 +2704,7 @@ final class ValidationTestCase: XCTestCase {
         let validationResult = documentEditor.validate()
         
         XCTAssertEqual(validationResult.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities.count, 2)
-        XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
-        XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa29c05db08120464a2875")
-        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
-        XCTAssertEqual(validationResult.fieldValidities[1].pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(validationResult.fieldValidities.count, 0)
     }
         
         func testTwoPageFieldIds() {
@@ -2734,13 +2724,10 @@ final class ValidationTestCase: XCTestCase {
             let validationResult = documentEditor.validate()
             
             XCTAssertEqual(validationResult.status, .valid)
-            XCTAssertEqual(validationResult.fieldValidities.count, 2)
+            XCTAssertEqual(validationResult.fieldValidities.count, 1)
             XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
             XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
             XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-            XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa29c05db08120464a2875")
-            XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
-            XCTAssertEqual(validationResult.fieldValidities[1].pageId, "66600801dc1d8b4f72f54917")
         }
     
     // MARK: - Page Focus/Blur Event Tests

--- a/Sources/JoyfillModel/Validator.swift
+++ b/Sources/JoyfillModel/Validator.swift
@@ -24,40 +24,40 @@ public struct Validation {
 
 public struct CellValidity {
     public let status: ValidationStatus
-    public let column: FieldTableColumn
+    public let columnId: String?
     public let value: ValueUnion?
 
-    public init(status: ValidationStatus, column: FieldTableColumn, value: ValueUnion? = nil) {
+    public init(status: ValidationStatus, columnId: String? = nil, value: ValueUnion? = nil) {
         self.status = status
-        self.column = column
+        self.columnId = columnId
         self.value = value
     }
 }
 
 public struct RowValidity {
     public let status: ValidationStatus
-    public let row: ValueElement
+    public let rowId: String?
     public let cellValidities: [CellValidity]
-    public let schema: Schema?
     public let schemaId: String?
 
-    public init(status: ValidationStatus, cellValidities: [CellValidity], row: ValueElement, schema: Schema? = nil, schemaId: String? = nil) {
+    public init(status: ValidationStatus, cellValidities: [CellValidity], rowId: String? = nil, schemaId: String? = nil) {
         self.status = status
+        self.rowId = rowId
         self.cellValidities = cellValidities
-        self.row = row
-        self.schema = schema
         self.schemaId = schemaId
     }
 }
 
 public struct FieldValidity {
     public let status: ValidationStatus
+    public let fieldId: String?
     public let pageId: String?
     public let fieldPositionId: String?
     public let field: JoyDocField
     public let rowValidities: [RowValidity]?
     
-    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldPositionId: String? = nil, rowValidities: [RowValidity]? = nil) {
+    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldId: String? = nil, fieldPositionId: String? = nil, rowValidities: [RowValidity]? = nil) {
+        self.fieldId = fieldId
         self.field = field
         self.status = status
         self.pageId = pageId

--- a/Sources/JoyfillModel/Validator.swift
+++ b/Sources/JoyfillModel/Validator.swift
@@ -55,13 +55,13 @@ public struct FieldValidity {
     public let pageId: String?
     public let fieldPositionId: String?
     public let field: JoyDocField
-    public let rows: [RowValidity]?
-
-    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldPositionId: String? = nil, rows: [RowValidity]? = nil) {
+    public let rowValidities: [RowValidity]?
+    
+    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldPositionId: String? = nil, rowValidities: [RowValidity]? = nil) {
         self.field = field
         self.status = status
         self.pageId = pageId
         self.fieldPositionId = fieldPositionId
-        self.rows = rows
+        self.rowValidities = rowValidities
     }
 }

--- a/Sources/JoyfillModel/Validator.swift
+++ b/Sources/JoyfillModel/Validator.swift
@@ -24,42 +24,30 @@ public struct Validation {
 
 public struct CellValidity {
     public let status: ValidationStatus
-    public let row: ValueElement
     public let column: FieldTableColumn
-    public let reasons: [String]?
-    
-    public init(status: ValidationStatus, row: ValueElement, column: FieldTableColumn, reasons: [String]? = nil) {
+    public let value: ValueUnion?
+
+    public init(status: ValidationStatus, column: FieldTableColumn, value: ValueUnion? = nil) {
         self.status = status
-        self.row = row
         self.column = column
-        self.reasons = reasons
+        self.value = value
     }
 }
 
 public struct RowValidity {
     public let status: ValidationStatus
+    public let row: ValueElement
     public let cellValidities: [CellValidity]
-    
-    public init(status: ValidationStatus, cellValidities: [CellValidity]) {
+    public let schema: Schema?
+    public let schemaId: String?
+
+    public init(status: ValidationStatus, cellValidities: [CellValidity], row: ValueElement, schema: Schema? = nil, schemaId: String? = nil) {
         self.status = status
         self.cellValidities = cellValidities
+        self.row = row
+        self.schema = schema
+        self.schemaId = schemaId
     }
-}
-
-public struct ColumnValidity {
-    public let status: ValidationStatus
-    public let cellValidities: [CellValidity]
-    
-    public init(status: ValidationStatus, cellValidities: [CellValidity]) {
-        self.status = status
-        self.cellValidities = cellValidities
-    }
-}
-
-struct TableValidity {
-    let status: ValidationStatus
-    let rowValidities: [RowValidity]
-    let columnValidities: [ColumnValidity]
 }
 
 public struct FieldValidity {
@@ -67,19 +55,13 @@ public struct FieldValidity {
     public let pageId: String?
     public let fieldPositionId: String?
     public let field: JoyDocField
-//    public let children: [FieldValidity]? // For fields with nested structures
-//    public let rowValidities: [RowValidity]? // Only available if field is a table
-//    public let columnValidities: [ColumnValidity]? // Only available if field is a table
-//    public let reasons: [String]? // Available only if status is invalid
-    
-    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldPositionId: String? = nil) {
+    public let rows: [RowValidity]?
+
+    public init(field: JoyDocField, status: ValidationStatus, pageId: String?, fieldPositionId: String? = nil, rows: [RowValidity]? = nil) {
         self.field = field
         self.status = status
-//        self.children = children
-//        self.rowValidities = rowValidities
-//        self.columnValidities = columnValidities
-//        self.reasons = reasons
         self.pageId = pageId
         self.fieldPositionId = fieldPositionId
+        self.rows = rows
     }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionQuickView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionQuickView.swift
@@ -28,7 +28,7 @@ struct CollectionQuickView : View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            FieldHeaderView(tableDataModel.fieldHeaderModel, isFilled: !viewModel.tableDataModel.rowOrder.isEmpty)
+            FieldHeaderView(tableDataModel.fieldHeaderModel, isFilled: viewModel.tableDataModel.nondeletedRowsCount > 0)
 
             if viewModel.isLoading {
                 loadingView

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -74,7 +74,7 @@ public class DocumentEditor: ObservableObject {
     }
     @Published var currentPageOrder: [String] = []
     let navigationPublisher = PassthroughSubject<NavigationTarget, Never>()
-    private var isCollectionFieldEnabled: Bool = false
+    private(set) var isCollectionFieldEnabled: Bool = false
 
     public var mode: Mode = .fill
     public var isPageDuplicateEnabled: Bool = true

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -74,7 +74,7 @@ public class DocumentEditor: ObservableObject {
     }
     @Published var currentPageOrder: [String] = []
     let navigationPublisher = PassthroughSubject<NavigationTarget, Never>()
-    private(set) var isCollectionFieldEnabled: Bool = false
+    public private(set) var isCollectionFieldEnabled: Bool = false
 
     public var mode: Mode = .fill
     public var isPageDuplicateEnabled: Bool = true

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -98,7 +98,7 @@ class ValidationHandler {
         }
 
         if nonDeletedRows.isEmpty {
-            return FieldValidity(field: field, status: .invalid, pageId: pageId, fieldPositionId: fieldPositionId, rows: [])
+            return FieldValidity(field: field, status: .invalid, pageId: pageId, fieldPositionId: fieldPositionId, rowValidities: [])
         }
 
         var rowValidities = [RowValidity]()
@@ -130,7 +130,7 @@ class ValidationHandler {
         }
 
         let fieldStatus: ValidationStatus = isTableValid ? .valid : .invalid
-        return FieldValidity(field: field, status: fieldStatus, pageId: pageId, fieldPositionId: fieldPositionId, rows: rowValidities)
+        return FieldValidity(field: field, status: fieldStatus, pageId: pageId, fieldPositionId: fieldPositionId, rowValidities: rowValidities)
     }
 
     // MARK: - Collection Validation
@@ -151,7 +151,7 @@ class ValidationHandler {
         let nonDeletedRows = rows.filter { !($0.deleted ?? false) }
 
         if nonDeletedRows.isEmpty {
-            return FieldValidity(field: field, status: .invalid, pageId: pageId, fieldPositionId: fieldPositionId, rows: [])
+            return FieldValidity(field: field, status: .invalid, pageId: pageId, fieldPositionId: fieldPositionId, rowValidities: [])
         }
 
         var allRowValidities = [RowValidity]()
@@ -184,7 +184,7 @@ class ValidationHandler {
         }
 
         let status: ValidationStatus = isCollectionValid ? .valid : .invalid
-        return FieldValidity(field: field, status: status, pageId: pageId, fieldPositionId: fieldPositionId, rows: allRowValidities)
+        return FieldValidity(field: field, status: status, pageId: pageId, fieldPositionId: fieldPositionId, rowValidities: allRowValidities)
     }
 
     private func validateCollectionRow(

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -39,11 +39,9 @@ class ValidationHandler {
                 let fieldPositionId = fieldPosition.id
 
                 if !isPageVisible {
-                    fieldValidities.append(FieldValidity(field: field, status: .valid, pageId: pageID, fieldId: field.id, fieldPositionId: fieldPositionId))
                     continue
                 }
                 if !documentEditor.shouldShow(fieldID: field.id) {
-                    fieldValidities.append(FieldValidity(field: field, status: .valid, pageId: pageID, fieldId: field.id, fieldPositionId: fieldPositionId))
                     continue
                 }
 

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -85,6 +85,7 @@ class ValidationHandler {
         }
 
         let rows = field.valueToValueElements ?? []
+        let nonDeletedRows = rows.filter { !($0.deleted ?? false) }
         let columnOrder = field.tableColumnOrder ?? []
         let allColumns = field.tableColumns ?? []
 
@@ -96,11 +97,14 @@ class ValidationHandler {
             return documentEditor.shouldShowColumn(columnID: columnID, fieldID: fieldID)
         }
 
+        if nonDeletedRows.isEmpty {
+            return FieldValidity(field: field, status: .invalid, pageId: pageId, fieldPositionId: fieldPositionId, rows: [])
+        }
+
         var rowValidities = [RowValidity]()
         var isTableValid = true
 
-        for row in rows {
-            if row.deleted == true { continue }
+        for row in nonDeletedRows {
             let cells = row.cells ?? [:]
 
             var cellValidities = [CellValidity]()

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -36,6 +36,11 @@ class ValidationHandler {
                       let field = documentEditor.fieldMap[id] else {
                     continue
                 }
+
+                guard field.fieldType != .unknown else {
+                    continue
+                }
+
                 let fieldPositionId = fieldPosition.id
 
                 if !isPageVisible {

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -92,8 +92,6 @@ class ValidationHandler {
         let sortedColumns = sortColumns(allColumns, by: columnOrder)
         let visibleColumns = sortedColumns.filter { column in
             guard let columnID = column.id else { return false }
-            let isStaticHidden = fieldPosition.tableColumns?.first(where: { $0.id == columnID })?.hidden ?? false
-            if isStaticHidden { return false }
             return documentEditor.shouldShowColumn(columnID: columnID, fieldID: fieldID)
         }
 
@@ -205,7 +203,6 @@ class ValidationHandler {
 
             let isColumnVisible = documentEditor.shouldShowColumn(columnID: columnID, fieldID: fieldID, schemaKey: schemaId)
             if !isColumnVisible {
-                cellValidities.append(CellValidity(status: .valid, column: column, value: cells[columnID]))
                 continue
             }
 

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -62,6 +62,9 @@ class ValidationHandler {
                     if validity.status == .invalid { isValid = false }
                     fieldValidities.append(validity)
                 } else if field.fieldType == .collection {
+                    if !documentEditor.isCollectionFieldEnabled {
+                        continue
+                    }
                     let validity = validateCollectionField(field: field, fieldID: fieldID, pageId: pageID, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
                     if validity.status == .invalid { isValid = false }
                     fieldValidities.append(validity)


### PR DESCRIPTION
## Context

This PR implements the **Validation (Required Fields & Columns)** spec. Validation ensures that required data is collected by checking visible field positions for the target view (desktop/mobile). The validator walks the form hierarchy: **pages → fields → rows → cells**, respecting conditional logic and view-specific field positions.

## What Changed

### `Sources/JoyfillModel/Validator.swift`
- **`CellValidity`**: `value` is now optional (was required but never properly used by the handler)
- **`RowValidity`**: Added `schemaId: String?` — identifies which collection schema a row belongs to (nil for tables)
- **`FieldValidity`**: No init change. `rows: [RowValidity]?` was already present but was never populated — now it is

### `Sources/JoyfillUI/ViewModels/ValidationHandler.swift`
- **Full rewrite** of `validate()`, `validateTableField`, and collection validation
- Rows and cells are now **wired into the output** (previously computed and discarded)
- Hidden pages, fields, columns, and collection schemas are **excluded** from the output entirely per conditional logic resolution
- Table columns sorted by `tableColumnOrder`
- Table column visibility uses `shouldShowColumn()` (conditional logic) in addition to static `hidden`
- Collection validation flattened: all nested schema rows are in a single `rows` array, each tagged with `schemaId`
- Required schema with zero non-deleted rows correctly marks the collection as invalid

### `JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift`
- 17 new tests covering: row/cell output for tables and collections, schemaId on rows, flat collection rows, deleted row exclusion, hidden column handling, required schema enforcement
- Updated 3 existing hidden-field tests for adjusted expectations

### `JoyfillSwiftUIExample/JoyfillExample/JoyDoc+DummyModel.swift`
- Fixed `setCollectionFieldRequired()` helper: `isSchemaRequired` parameter was being ignored (child schema had `required: true` hardcoded)

## Design Decisions

1. **Flat collection rows instead of nested tree**: All collection rows (root + child + grandchild schemas) are in a single `rows` array with `schemaId` to identify which schema each row belongs to. This was chosen over a recursive `RowValidity.children` approach for simplicity and cross-SDK alignment.

2. **Hidden items excluded from output**: Hidden pages, fields, columns, and collection schemas are excluded entirely from the validation output. They are not returned in `fieldValidities`, `cellValidities`, or `rowValidities`. This means consumers only receive validities for visible items, and hidden items never block submission.

3. **Backward-compatible model structs**: Existing init signatures are preserved. `CellValidity.value` changed from required to optional (source-compatible). `RowValidity.schemaId` added as optional at the end. No breaking changes for existing consumers.

## Public API Change

`Validation`, `FieldValidity`, `RowValidity`, and `CellValidity` are public structs in `JoyfillModel`. The changes are **additive and source-compatible**:
- `FieldValidity.rows` is now populated (was always nil before)
- `RowValidity.schemaId` is new (optional)
- `CellValidity.value` changed from required to optional

**Docs should be updated** to document the row/cell output structure and the `schemaId` property for collection fields.

## Test Coverage

All spec requirements are covered with tests:
- Form/field/row/cell status resolution
- Hidden page and field handling (excluded from output)
- Table: rows returned, cells per row, deleted rows excluded, hidden columns, non-required columns
- Collection: flat rows with schemaId, required schema enforcement, nested row validation

## Notes for Reviewers

- The `ColumnValidity` type that existed in the old handler has been removed — it was computed but never returned and is not part of the spec
- The `shouldShowColumn()` call in table validation is new — previously only static `hidden` was checked, missing conditional-logic-driven column hiding
- Collection validation is now recursive via `validateCollectionChildren` which returns both row validities and a flag for required-but-empty schemas