### PR TITLE
Use stable column-based identity for table and collection view refresh

### DIFF
--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -163,7 +163,7 @@ struct TableDataModel {
     var filteredcellModels = [RowDataModel]()
     var filterModels = [FilterModel]()
     var sortModel = SortModel()
-    var id = UUID()
+    private(set) var id: String = ""
     var showResetSelectionAlert: Bool = false
     var singleClickRowEdit: Bool = false
     var navigationIntent = NavigationIntent.none
@@ -241,6 +241,7 @@ struct TableDataModel {
         }
         setupColumns()
         filterRowsIfNeeded()
+        self.id = fieldIdentifier.fieldID + ":" + filterModels.map { $0.colID }.sorted().joined(separator: ",")
     }
     
     mutating func buildFullSchemaChainMap() {


### PR DESCRIPTION
## Context

When the `change()` API is called (e.g. from an `onChange` callback like in DeficiencyTableDemoView), it triggers `handleFieldValueRowUpdate` → `refreshField` → rebuilds the `TableDataModel`. The `.id(model.id)` modifier on `TableQuickView` / `CollectionQuickView` in `FormView` uses this ID to control SwiftUI view identity. Previously, `TableDataModel.id` was `UUID()`, which generated a new random value on every `refreshField` call — even when no columns changed. This caused SwiftUI to destroy and recreate the view, resetting all `@State` (e.g. `isTableModalViewPresented`), which dismissed open modals and sheets unexpectedly.

## What Changed

**`Sources/JoyfillUI/ViewModels/Models.swift`**
- Replaced `var id = UUID()` with `private(set) var id: String = ""`
- Computed once at the end of `init` from `fieldIdentifier.fieldID` + sorted visible column IDs (from `filterModels`)
- Covers both table (root `tableColumns`) and collection (all schema-level columns via `filterModels`)

## Why This Approach

- **Stable identity**: The ID only changes when the set of visible columns actually changes (e.g. conditional logic shows/hides a column), not on every data refresh
- **Sorted column IDs**: Prevents false refreshes if columns arrive in a different order
- **Computed once in `init`**: No repeated `shouldShowColumn` calls on every SwiftUI view evaluation — `filterModels` is already built during init with all visibility filtering applied
- **Uses `filterModels`**: This array already contains the visible columns for both tables and all collection schema entries, so no extra filtering logic needed

## Public API

No public API changes. Internal only (`TableDataModel.id` is `private(set)`). No docs update needed.

## Testing

- Existing conditional logic column tests cover the column visibility refresh path
- Manual verification needed: open a table modal → change a dropdown cell that triggers `change()` callback → verify modal stays open
- Will add targeted test case for this scenario in follow-up if needed

## Notes for Reviewer

- The `.id(model.id)` on `TableQuickView`/`CollectionQuickView` is required for conditional logic column refresh — removing it breaks column show/hide. The fix is making the ID stable, not removing it.
- `FormView.swift` is unchanged in this PR — `.id(model.id)` was already active on main.

Made with [Cursor](https://cursor.com)