### PR TITLE
Fix: Update local model with document when performing bulk edit and row form

### DIFF
--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -1669,9 +1669,11 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                                                                       isRootRow: isRootRow,
                                                                       fieldvalue: tableDataModel.valueToValueElements ?? [])
         DispatchQueue.main.sync {
-            self.tableDataModel.valueToValueElements = result?.0
-            for (key, value) in result?.1 ?? [:] {
-                self.rowToValueElementMap[key] = value
+            if let result = result {
+                self.tableDataModel.valueToValueElements = result.0
+                for (key, value) in result.1 {
+                    self.rowToValueElementMap[key] = value
+                }
             }
         }
     }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -405,10 +405,10 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         isBulkLoading = true
         
         // Perform heavy processing on background thread
-        let updatedCellModels: [RowDataModel] = await withCheckedContinuation { cont in
+        let (newValueToValueElements, updatedCellModels): ([ValueElement]?, [RowDataModel]) = await withCheckedContinuation { cont in
             dispatchQueue.async { [weak self] in
                 guard let self else {
-                    cont.resume(returning: [])
+                    cont.resume(returning: (nil, []))
                     return
                 }
                 var columnIDChanges = [String: ValueUnion]()
@@ -421,11 +421,6 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                 self.makeChangeDict(&newChanges, columnIDChanges, tableDataModel.tableColumns)
                 
                 let result = tableDataModel.documentEditor?.bulkEdit(changes: newChanges, selectedRows: tableDataModel.selectedRows, fieldIdentifier: tableDataModel.fieldIdentifier, fieldData: tableDataModel.valueToValueElements ?? [])
-                DispatchQueue.main.async {
-                    if let result = result {
-                        self.tableDataModel.valueToValueElements = result
-                    }
-                }
                 
                 var updatedModels = tableDataModel.cellModels
                 for rowId in tableDataModel.selectedRows {
@@ -467,10 +462,13 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                     }
                 }
                 
-                cont.resume(returning: updatedModels)
+                cont.resume(returning: (result, updatedModels))
             }
         }
         
+        if let newValueToValueElements = newValueToValueElements {
+            tableDataModel.valueToValueElements = newValueToValueElements
+        }
         tableDataModel.cellModels = updatedCellModels
         tableDataModel.filterRowsIfNeeded()
         isBulkLoading = false

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -420,7 +420,12 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                 var newChanges: [String: [String: ValueUnion]] = [:]
                 self.makeChangeDict(&newChanges, columnIDChanges, tableDataModel.tableColumns)
                 
-                tableDataModel.documentEditor?.bulkEdit(changes: newChanges, selectedRows: tableDataModel.selectedRows, fieldIdentifier: tableDataModel.fieldIdentifier, fieldData: tableDataModel.valueToValueElements ?? [])
+                let result = tableDataModel.documentEditor?.bulkEdit(changes: newChanges, selectedRows: tableDataModel.selectedRows, fieldIdentifier: tableDataModel.fieldIdentifier, fieldData: tableDataModel.valueToValueElements ?? [])
+                DispatchQueue.main.async {
+                    if let result = result {
+                        self.tableDataModel.valueToValueElements = result
+                    }
+                }
                 
                 var updatedModels = tableDataModel.cellModels
                 for rowId in tableDataModel.selectedRows {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -822,7 +822,7 @@ extension DocumentEditor {
     ///   - changes: A dictionary of String keys and values representing the changes to be made.
     ///   - selectedRows: An array of String identifiers for the rows to be edited.
     ///   - fieldIdentifier: A `FieldIdentifier` object that uniquely identifies the table field.
-    public func bulkEdit(changes: [String: [String: ValueUnion]], selectedRows: [String], fieldIdentifier: FieldIdentifier, fieldData: [ValueElement]) {
+    public func bulkEdit(changes: [String: [String: ValueUnion]], selectedRows: [String], fieldIdentifier: FieldIdentifier, fieldData: [ValueElement]) -> [ValueElement] {
         var elements = fieldData
         let columns = field(fieldID: fieldIdentifier.fieldID)?.tableColumns ?? []
         var isDateColumn: Bool = false
@@ -867,6 +867,7 @@ extension DocumentEditor {
         fieldMap[fieldIdentifier.fieldID]?.value = ValueUnion.valueElementArray(elements)
         
         sendRowUpdateEvent(for: fieldIdentifier, with: rows)
+        return elements
     }
     
     public func bulkEditForNested(changes: [String: [String : ValueUnion]],

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -822,6 +822,7 @@ extension DocumentEditor {
     ///   - changes: A dictionary of String keys and values representing the changes to be made.
     ///   - selectedRows: An array of String identifiers for the rows to be edited.
     ///   - fieldIdentifier: A `FieldIdentifier` object that uniquely identifies the table field.
+    @discardableResult
     public func bulkEdit(changes: [String: [String: ValueUnion]], selectedRows: [String], fieldIdentifier: FieldIdentifier, fieldData: [ValueElement]) -> [ValueElement] {
         var elements = fieldData
         let columns = field(fieldID: fieldIdentifier.fieldID)?.tableColumns ?? []


### PR DESCRIPTION
# Fix: Update local model with document when performing bulk edit and editing the row form

## 1. Context

Table and Collection fields keep a local copy of row data (`valueToValueElements`) for the UI. When the user performs a **bulk edit** (or applies changes from the row form), we call `DocumentEditor.bulkEdit` / `bulkEditForNested`, which updates the **document** (field map). Previously we did not write the updated value back into the table/collection’s local model, so the row form and any logic depending on `valueToValueElements` could see stale data after save.

This PR ensures the local model is updated from the document after bulk edit so UI and downstream logic stay in sync.

## 2. What changed

| File | Change |
|------|--------|
| **DocumentEditor+ChangeHandler.swift** | `bulkEdit(changes:selectedRows:fieldIdentifier:fieldData:)` now returns `[ValueElement]` (updated elements) instead of `Void`. Callers can sync their local model from this return value. |
| **TableViewModel.swift** | After `documentEditor?.bulkEdit(...)`, assigns the returned array to `tableDataModel.valueToValueElements` on the main queue. Uses `if let result = result` so we never overwrite with `nil` when `documentEditor` is nil. |
| **CollectionViewModel.swift** | In `updateJSON`, when applying the result of `bulkEditForNested`, wraps assignment in `if let result = result` and then sets `valueToValueElements = result.0` and updates `rowToValueElementMap` from `result.1`. Avoids clearing local state when `documentEditor` is nil. |

## 3. Decisions

- **Return value from `bulkEdit`**  
  Returning the updated `[ValueElement]` from `bulkEdit` keeps the document as the single source of truth (including any transforms, e.g. dates) and lets the table sync its local copy in one place.

- **Main-queue update in Table**  
  Table’s bulk edit runs on a background queue. We use `DispatchQueue.main.async` to assign `valueToValueElements` so UI-related state is updated on the main thread.

- **Nil guards**  
  `documentEditor?.bulkEdit(...)` and `documentEditor?.bulkEditForNested(...)` are optional chaining, so the result can be `nil`. We only assign when `result != nil` so we never replace valid local data with `nil`.

- **Collection**  
  Collection already synced via `updateJSON` → `bulkEditForNested` and assigned `result?.0` / `result?.1`. Only the explicit `if let result = result` was added for consistency and to avoid clearing state when `documentEditor` is nil.

## 4. Screenshot / video

_Optional: Add a short screen recording or screenshot showing:_  
_1) Open table/collection row form, edit cells, save._  
_2) Re-open same row or rely on `valueToValueElements` — values should match what was saved (no stale data)._

## 5. Public API and docs

- **Public API change:** Yes. `DocumentEditor.bulkEdit(...)` signature changes from returning `Void` to returning `[ValueElement]`. Any caller that invokes `bulkEdit` directly will get a return value; existing callers that ignore it remain valid.
- **Docs:** SDK/changelog or API docs should note that `bulkEdit` now returns the updated row elements so integrators can sync local state if they hold their own copy.

## 6. Tests

- No new automated tests in this PR. Manual verification: bulk edit in table and collection row forms, then confirm reopened row form and any UI using `valueToValueElements` show the saved data.
- Additional unit tests (e.g. that `bulkEdit` return value matches updated document) can be added in a follow-up.

## 7. Notes for reviewers (and AI agents)

- Focus review on: (1) correctness of `bulkEdit` return value and (2) that Table/Collection only update local model when `result` is non-nil.
- Single-cell edit and other table/collection operations were already syncing local model; no changes there.
- Collection’s `updateJSON` already called `bulkEditForNested` and assigned the result; this PR only adds the nil guard around that assignment.
