### PR TITLE
NO-2007: Per-page deletable and copyable controls

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		9EAAC7E02EAB3EF4000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
 		9EAAC7E12EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */; };
 		9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
+		E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */; };
 		E22516882E8BA4C60089E2D2 /* UserJsonTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */; };
 		E225D1C52F3AE626000674CF /* HiddenViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E225D1C42F3AE626000674CF /* HiddenViewsTests.swift */; };
 		E225D1C92F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E225D1C82F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift */; };
@@ -564,6 +565,7 @@
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
 		9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyModeUITestCases.swift; sourceTree = "<group>"; };
+		E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableValidationTests.swift; sourceTree = "<group>"; };
 		E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJsonTextFieldView.swift; sourceTree = "<group>"; };
 		E225D1C42F3AE626000674CF /* HiddenViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenViewsTests.swift; sourceTree = "<group>"; };
 		E225D1C82F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentEditor+ChangeHandlerMetadataTests.swift"; sourceTree = "<group>"; };
@@ -574,9 +576,9 @@
 		E27061CB2E797E68006BAD18 /* DocumentEditor+ChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentEditor+ChangeHandlerTests.swift"; sourceTree = "<group>"; };
 		E27061CD2E797F3B006BAD18 /* ChangerHandlerUnit.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChangerHandlerUnit.json; sourceTree = "<group>"; };
 		E274CA2F2E2E60A000B35C09 /* OnChangeHandlerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeHandlerUITests.swift; sourceTree = "<group>"; };
-		E274CA372E2E60A100B35C09 /* FocusCallbackUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCallbackUITests.swift; sourceTree = "<group>"; };
 		E274CA352E2E7FB000B35C09 /* blockField.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = blockField.json; sourceTree = "<group>"; };
 		E274CA362E2E7FB000B35C09 /* chartField.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chartField.json; sourceTree = "<group>"; };
+		E274CA372E2E60A100B35C09 /* FocusCallbackUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCallbackUITests.swift; sourceTree = "<group>"; };
 		E274CA372E2E7FB000B35C09 /* collectionField.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = collectionField.json; sourceTree = "<group>"; };
 		E274CA382E2E7FB000B35C09 /* dateField.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dateField.json; sourceTree = "<group>"; };
 		E274CA392E2E7FB000B35C09 /* dropdownField.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dropdownField.json; sourceTree = "<group>"; };
@@ -834,6 +836,7 @@
 			children = (
 				363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */,
 				E29FF86A2F2161DD0079A614 /* NavigationJSONTests.swift */,
+				E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */,
 				E2C8BD262E4628A900B93B9E /* MobileTitleDisplayTests.swift */,
 				E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */,
 				E27061C62E797E12006BAD18 /* OnChangeHandler */,
@@ -987,14 +990,6 @@
 			path = ChangeUITests;
 			sourceTree = "<group>";
 		};
-		E274CA392E2E60A100B35C09 /* FocusCallbackUITests */ = {
-			isa = PBXGroup;
-			children = (
-				E274CA372E2E60A100B35C09 /* FocusCallbackUITests.swift */,
-			);
-			path = FocusCallbackUITests;
-			sourceTree = "<group>";
-		};
 		E274CA342E2E7EDB00B35C09 /* Schema-Validation */ = {
 			isa = PBXGroup;
 			children = (
@@ -1008,6 +1003,14 @@
 				E274CB062E2E84F700B35C09 /* optionalPropertiesRemovedTemplate */,
 			);
 			path = "Schema-Validation";
+			sourceTree = "<group>";
+		};
+		E274CA392E2E60A100B35C09 /* FocusCallbackUITests */ = {
+			isa = PBXGroup;
+			children = (
+				E274CA372E2E60A100B35C09 /* FocusCallbackUITests.swift */,
+			);
+			path = FocusCallbackUITests;
 			sourceTree = "<group>";
 		};
 		E274CA422E2E7FB000B35C09 /* allFieldsDesktopAndMobileTemplates */ = {
@@ -1959,6 +1962,7 @@
 				E225D1C52F3AE626000674CF /* HiddenViewsTests.swift in Sources */,
 				E2B8E3EF2E43806700AC6018 /* FormulaTemplate_BlockFieldTests.swift in Sources */,
 				36BCD3732E0BFA0600F5DA4B /* FormulaTemplate_TableField.swift in Sources */,
+				E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */,
 				369D45772E0E586300677280 /* FormulaTemplate_CollectionField.swift in Sources */,
 				369025652E06E8EC00DCFF5B /* SimpleTableTest.swift in Sources */,
 				E2B8E3C22E436F2D00AC6018 /* FormulaTemplate_TextareaFieldTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample/AllSampleJSONs.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/AllSampleJSONs.swift
@@ -135,7 +135,7 @@ struct AllSampleJSONs: View, FormChangeEvent {
             do {
                 let document = sampleJSONDocument(fileName: fileName)
                 // Construct the editor off the main thread to avoid UI hitching
-                let editor = DocumentEditor(document: document, events: self, validateSchema: false, license: licenseKey)
+                let editor = DocumentEditor(document: document, events: self, isPageDuplicateEnabled: true, isPageDeleteEnabled: true, validateSchema: false, license: licenseKey, singleClickRowEdit: true)
                 DispatchQueue.main.async {
                     self.documentEditor = editor
                     self.isLoading = false

--- a/JoyfillSwiftUIExample/JoyfillExample/FormContainerView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/FormContainerView.swift
@@ -15,7 +15,7 @@ struct FormContainerView: View {
 
     init(document: JoyDoc, pageID: String, changeManager: ChangeManager, enableChangelogs: Bool = true, customLicense: String? = nil) {
         let license = customLicense ?? licenseKey
-        self.documentEditor = DocumentEditor(document: document, mode: .fill, events: changeManager, pageID: pageID, navigation: true, isPageDuplicateEnabled: true, license: license)
+        self.documentEditor = DocumentEditor(document: document, mode: .fill, events: changeManager, pageID: pageID, navigation: true, isPageDuplicateEnabled: true, isPageDeleteEnabled: true, license: license, singleClickRowEdit: true)
         self.changeManager = changeManager
         self.enableChangelogs = enableChangelogs
     }

--- a/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
@@ -66,7 +66,8 @@ struct JoyfillExampleApp: App {
                 isPageDuplicateEnabled: isPageDuplicateEnabled,
                 isPageDeleteEnabled: isPageDeleteEnabled,
                 validateSchema: false,
-                license: licenseKey
+                license: licenseKey,
+                singleClickRowEdit: true
             )
         } catch {
             print("⚠️  Error creating document editor: \(error)")
@@ -79,7 +80,8 @@ struct JoyfillExampleApp: App {
                 isPageDuplicateEnabled: isPageDuplicateEnabled,
                 isPageDeleteEnabled: isPageDeleteEnabled,
                 validateSchema: false,
-                license: licenseKey
+                license: licenseKey,
+                singleClickRowEdit: true
             )
         }
         

--- a/JoyfillSwiftUIExample/JoyfillExample/Simple Form Example/SimpleFormExampleView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Simple Form Example/SimpleFormExampleView.swift
@@ -15,7 +15,7 @@ struct SimpleFormExampleView: View {
     let document = loadDoc(named: "first-form")
     
     init() {
-        self.documentEditor = DocumentEditor(document: document, mode: .fill, events: changeHandler, pageID: "your_Page_Id", navigation: true, isPageDuplicateEnabled: true, validateSchema: true)
+        self.documentEditor = DocumentEditor(document: document, mode: .fill, events: changeHandler, pageID: "your_Page_Id", navigation: true, isPageDuplicateEnabled: true, isPageDeleteEnabled: true, validateSchema: true, singleClickRowEdit: true)
     }
 
     var body: some View {

--- a/JoyfillSwiftUIExample/JoyfillExample/SimpleNavigationTestView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/SimpleNavigationTestView.swift
@@ -75,6 +75,8 @@ struct SimpleNavigationTestView: View {
         let editor = DocumentEditor(
             document: sampleDoc,
             mode: .fill,
+            isPageDuplicateEnabled: true,
+            isPageDeleteEnabled: true,
             validateSchema: false,
             license: licenseKey,
             singleClickRowEdit: true

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -234,9 +234,9 @@ struct FormDestinationView: View {
     @State private var documentEditor: DocumentEditor? = nil
     let enableChangelogs: Bool
     @State var validateSchema: Bool = false
-    @State var isPageDuplicated: Bool = false
-    @State var isPageDelete: Bool = false
-    @State var singleClickRowEdit: Bool = false
+    @State var isPageDuplicated: Bool = true
+    @State var isPageDelete: Bool = true
+    @State var singleClickRowEdit: Bool = true
     @State var document = JoyDoc()
     @State var license: String
 
@@ -265,6 +265,14 @@ struct FormDestinationView: View {
 
     // Build the DocumentEditor off the main thread and assign it on the main thread
     private func buildDocumentEditorInBackground() {
+        // Capture @State values on the main actor before entering the detached task,
+        // so the correct initial values are used regardless of concurrency timing.
+        let isDuplicate = isPageDuplicated
+        let isDelete = isPageDelete
+        let isSingleClick = singleClickRowEdit
+        let currentSchema = validateSchema
+        let currentLicense = license
+
         // Heavy work (JSON parse + DocumentEditor construction) off the main thread
         Task.detached { [jsonString, changeManager] in
             let jsonData = jsonString.data(using: .utf8) ?? Data()
@@ -275,11 +283,11 @@ struct FormDestinationView: View {
                 events: changeManager,
                 pageID: "",
                 navigation: true,
-                isPageDuplicateEnabled: isPageDuplicated,
-                isPageDeleteEnabled: isPageDelete,
-                validateSchema: validateSchema,
-                license: license,
-                singleClickRowEdit: singleClickRowEdit
+                isPageDuplicateEnabled: isDuplicate,
+                isPageDeleteEnabled: isDelete,
+                validateSchema: currentSchema,
+                license: currentLicense,
+                singleClickRowEdit: isSingleClick
             )
 
             // Publish to UI on the main actor

--- a/JoyfillSwiftUIExample/JoyfillExample/UserJsonTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserJsonTextFieldView.swift
@@ -181,8 +181,11 @@ struct UserJsonTextFieldView: View {
                             events: cm,
                             pageID: "",
                             navigation: true,
+                            isPageDuplicateEnabled: true,
+                            isPageDeleteEnabled: true,
                             validateSchema: false,
-                            license: license
+                            license: license,
+                            singleClickRowEdit: true
                         )
                         await MainActor.run {
                             self.preparedEditor = editor

--- a/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
@@ -1,0 +1,317 @@
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+/// Tests for the per-page `deletable` and `copyable` controls introduced in NO-2007.
+///
+/// Feature spec:
+/// - `Page.deletable = false`  → hide delete button; `canDeletePage` returns `(false, [])`
+/// - `Page.copyable = [.none]` → hide duplicate button
+/// - `Page.copyable = [.withValues, .withoutValues]` → show dialog on duplicate
+/// - Copied pages always reset to `deletable=true, copyable=[.withValues,.withoutValues]`
+/// - Last-page protection still applies even when `deletable=true`
+final class PageDeletableCopyableValidationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeEditor(document: JoyDoc) -> DocumentEditor {
+        DocumentEditor(document: document, validateSchema: false)
+    }
+
+    /// Applies a closure to the page with the given id and returns the modified document.
+    private func applyToPage(
+        _ pageID: String,
+        in document: JoyDoc,
+        modify: (inout Page) -> Void
+    ) -> JoyDoc {
+        var doc = document
+        guard var file = doc.files.first,
+              var pages = file.pages,
+              let idx = pages.firstIndex(where: { $0.id == pageID }) else { return doc }
+        modify(&pages[idx])
+        file.pages = pages
+        doc.files[0] = file
+        return doc
+    }
+
+    // MARK: - canDeletePage: deletable=false
+
+    /// A non-deletable page among multiple pages must not be deletable.
+    func testCanDeletePage_DeletableFalse_ReturnsFalse() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()   // page id: "6629fab320fca7c8107a6cf6"
+            .addSecondPage()              // page id: "second_page_id_12345"
+            .setHeadingText()
+            .setTextField()
+
+        document = applyToPage("second_page_id_12345", in: document) { $0.deletable = false }
+
+        let editor = makeEditor(document: document)
+        let result = editor.canDeletePage(pageID: "second_page_id_12345")
+        XCTAssertFalse(result.canDelete, "Non-deletable page should not be deletable even when multiple pages exist.")
+    }
+
+    /// A non-deletable page must return empty warnings (no user-facing message per spec).
+    func testCanDeletePage_DeletableFalse_ReturnsEmptyWarnings() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+
+        document = applyToPage("second_page_id_12345", in: document) { $0.deletable = false }
+
+        let editor = makeEditor(document: document)
+        let result = editor.canDeletePage(pageID: "second_page_id_12345")
+        XCTAssertTrue(result.warnings.isEmpty, "Non-deletable page should return empty warnings (spec: hide button silently).")
+    }
+
+    /// `deletePage` must return false and leave the document unchanged for a non-deletable page.
+    func testDeletePage_DeletableFalse_ReturnsFalseAndPageUnchanged() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+
+        document = applyToPage("second_page_id_12345", in: document) { $0.deletable = false }
+
+        let editor = makeEditor(document: document)
+        let initialCount = editor.document.files.first?.pages?.count ?? 0
+
+        let result = editor.deletePage(pageID: "second_page_id_12345")
+
+        XCTAssertFalse(result, "deletePage should return false for a non-deletable page.")
+        let finalCount = editor.document.files.first?.pages?.count ?? 0
+        XCTAssertEqual(finalCount, initialCount, "Page count must not change when deletion is blocked by deletable=false.")
+        XCTAssertNotNil(
+            editor.document.files.first?.pages?.first(where: { $0.id == "second_page_id_12345" }),
+            "Non-deletable page must still exist after failed deletion."
+        )
+    }
+
+    // MARK: - canDeletePage: deletable=true still works
+
+    /// A page with `deletable=true` among multiple pages must be deletable.
+    func testCanDeletePage_DeletableTrue_MultiplePages_ReturnsTrue() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+
+        document = applyToPage("second_page_id_12345", in: document) { $0.deletable = true }
+
+        let editor = makeEditor(document: document)
+        let result = editor.canDeletePage(pageID: "second_page_id_12345")
+        XCTAssertTrue(result.canDelete, "Page with deletable=true should be deletable when other pages exist.")
+        XCTAssertTrue(result.warnings.isEmpty, "No warnings expected for a straightforward deletion.")
+    }
+
+    // MARK: - canDeletePage: last page protection takes priority
+
+    /// Last-page protection fires before the `deletable` check — a single page is still blocked.
+    func testCanDeletePage_LastPage_BlockedEvenWhenDeletableIsTrue() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+
+        document = applyToPage("6629fab320fca7c8107a6cf6", in: document) { $0.deletable = true }
+
+        let editor = makeEditor(document: document)
+        let result = editor.canDeletePage(pageID: "6629fab320fca7c8107a6cf6")
+        XCTAssertFalse(result.canDelete, "Last page must not be deletable even if deletable=true.")
+        XCTAssertFalse(result.warnings.isEmpty, "Last page protection should return a warning message.")
+    }
+
+    // MARK: - duplicatePage: resets deletable=true
+
+    /// After duplication the copy should always have `deletable=true`,
+    /// regardless of what the original page had.
+    func testDuplicatePage_ResetsDeletableToTrue_WhenOriginalIsFalse() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        document = applyToPage(pageID, in: document) { $0.deletable = false }
+
+        let editor = makeEditor(document: document)
+        editor.duplicatePage(pageID: pageID)
+
+        let firstFile = editor.document.files.first
+        let pageOrder = firstFile?.pageOrder
+        guard let duplicatedPageID = pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        XCTAssertTrue(duplicatedPage.deletable, "Duplicated page must have deletable=true regardless of original.")
+    }
+
+    // MARK: - duplicatePage: resets copyable=[.withValues,.withoutValues]
+
+    /// After duplication the copy should always have full copyable access.
+    func testDuplicatePage_ResetsCopyableToFullAccess_WhenOriginalIsNone() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        document = applyToPage(pageID, in: document) { $0.copyable = [.none] }
+
+        let editor = makeEditor(document: document)
+        editor.duplicatePage(pageID: pageID)
+
+        let firstFile = editor.document.files.first
+        let pageOrder = firstFile?.pageOrder
+        guard let duplicatedPageID = pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        XCTAssertEqual(duplicatedPage.copyable, [.withValues, .withoutValues],
+                       "Duplicated page must always have copyable=[.withValues,.withoutValues].")
+    }
+
+    /// Original has only one copy mode — duplicate should still be fully copyable.
+    func testDuplicatePage_ResetsCopyableToFullAccess_WhenOriginalIsWithValuesOnly() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        document = applyToPage(pageID, in: document) { $0.copyable = [.withValues] }
+
+        let editor = makeEditor(document: document)
+        editor.duplicatePage(pageID: pageID)
+
+        let firstFile = editor.document.files.first
+        let pageOrder = firstFile?.pageOrder
+        guard let duplicatedPageID = pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        XCTAssertEqual(duplicatedPage.copyable, [.withValues, .withoutValues],
+                       "Duplicated page must always have full copyable even when original had only withValues.")
+    }
+
+    // MARK: - duplicatePage: original page properties unchanged
+
+    /// Duplication must not mutate the original page's `deletable` or `copyable`.
+    func testDuplicatePage_OriginalPagePropertiesUnchanged() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setHeadingText()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        document = applyToPage(pageID, in: document) {
+            $0.deletable = false
+            $0.copyable = [.none]
+        }
+
+        let editor = makeEditor(document: document)
+        editor.duplicatePage(pageID: pageID)
+
+        let originalPage = editor.document.files.first?.pages?.first(where: { $0.id == pageID })
+        XCTAssertNotNil(originalPage, "Original page must still exist after duplication.")
+        XCTAssertFalse(originalPage?.deletable ?? true, "Original page deletable must not be changed by duplication.")
+        XCTAssertEqual(originalPage?.copyable, [.none], "Original page copyable must not be changed by duplication.")
+    }
+
+    // MARK: - copyWithValues behaviour
+
+    /// Duplicate with `copyWithValues=false` should clear values only on the new page's fields.
+    func testDuplicatePage_WithoutValues_ClearsOnlyDuplicatedPageFieldValues() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let editor = makeEditor(document: document)
+
+        XCTAssertFalse(editor.document.fields.isEmpty, "Test requires at least one field.")
+
+        editor.duplicatePage(pageID: pageID, copyWithValues: false)
+
+        // Find the duplicated page
+        let firstFile = editor.document.files.first
+        let pageOrder = firstFile?.pageOrder
+        guard let duplicatedPageID = pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        // Collect the field IDs that belong to the duplicated page
+        let duplicatedFieldIDs = Set(duplicatedPage.fieldPositions?.compactMap { $0.field } ?? [])
+        XCTAssertFalse(duplicatedFieldIDs.isEmpty, "Duplicated page should have field positions.")
+
+        // Only those fields should have nil values
+        let duplicatedFields = editor.document.fields.filter { duplicatedFieldIDs.contains($0.id ?? "") }
+        for field in duplicatedFields {
+            XCTAssertNil(field.value, "copyWithValues=false should nil out the value of duplicated page field '\(field.id ?? "")'.")
+        }
+    }
+
+    /// Duplicate with `copyWithValues=true` (default) should preserve values on the new page's fields.
+    func testDuplicatePage_WithValues_PreservesDuplicatedPageFieldValues() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let editor = makeEditor(document: document)
+
+        XCTAssertFalse(editor.document.fields.isEmpty, "Test requires at least one field.")
+
+        editor.duplicatePage(pageID: pageID, copyWithValues: true)
+
+        // Find the duplicated page
+        let firstFile = editor.document.files.first
+        let pageOrder = firstFile?.pageOrder
+        guard let duplicatedPageID = pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        let duplicatedFieldIDs = Set(duplicatedPage.fieldPositions?.compactMap { $0.field } ?? [])
+        let duplicatedFields = editor.document.fields.filter { duplicatedFieldIDs.contains($0.id ?? "") }
+
+        let hasValue = duplicatedFields.contains(where: { $0.value != nil })
+        XCTAssertTrue(hasValue, "copyWithValues=true should preserve at least one field value on the duplicated page.")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
@@ -348,6 +348,98 @@ final class PageDeletableCopyableValidationTests: XCTestCase {
                        "copyWithValues=false must not clear the original page's field values.")
     }
 
+    // MARK: - duplicatePage: shared field between alt-view and web page duplicated only once
+    func testDuplicatePage_SharedField_BetweenAltViewAndWebPage_IsNotDuplicatedTwice() {
+        let pageID       = "shared_test_page_001"
+        let sharedFieldID = "shared_test_field_001"
+
+        // Build one field that lives on both the web page and the alternate-view page.
+        var sharedField = JoyDocField()
+        sharedField.id    = sharedFieldID
+        sharedField.type  = "text"
+        sharedField.value = .string("Original value")
+
+        let sharedFieldPos = FieldPosition(dictionary: [
+            "field":       sharedFieldID,
+            "displayType": "original",
+            "width":       4,
+            "height":      8,
+            "x":           0,
+            "y":           0,
+            "_id":         "shared_pos_id_001",
+            "type":        "text"
+        ])
+
+        // Web page — references the shared field.
+        var webPage = Page()
+        webPage.id             = pageID
+        webPage.name           = "Page 1"
+        webPage.fieldPositions = [sharedFieldPos]
+
+        // Alternate-view page — same pageID, same field position.
+        var altPage = Page()
+        altPage.id             = pageID
+        altPage.name           = "Page 1"
+        altPage.fieldPositions = [sharedFieldPos]
+
+        var altView = ModelView()
+        altView.id        = "alt_view_id_001"
+        altView.type      = "web"
+        altView.pages     = [altPage]
+        altView.pageOrder = [pageID]
+
+        var file = File()
+        file.id        = "file_id_001"
+        file.pages     = [webPage]
+        file.views     = [altView]
+        file.pageOrder = [pageID]
+
+        var document = JoyDoc()
+        document.fields = [sharedField]
+        document.files  = [file]
+
+        let editor           = makeEditor(document: document)
+        let fieldCountBefore = editor.document.fields.count // 1
+
+        editor.duplicatePage(pageID: pageID)
+
+        // ── 1. Exactly one new field added, not two ───────────────────────────
+        let fieldCountAfter = editor.document.fields.count
+        XCTAssertEqual(
+            fieldCountAfter, fieldCountBefore + 1,
+            "A field shared between the alt-view and web page must be duplicated only once, not twice."
+        )
+
+        // ── 2. Duplicated page exists ─────────────────────────────────────────
+        guard let newPageID = editor.document.files.first?.pageOrder?.first(where: { $0 != pageID }),
+              let newPage   = editor.document.files.first?.pages?.first(where: { $0.id == newPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+
+        // ── 3. New page has exactly one field position ────────────────────────
+        let newFieldIDs = newPage.fieldPositions?.compactMap { $0.field } ?? []
+        XCTAssertEqual(newFieldIDs.count, 1,
+                       "Duplicated web page should have exactly 1 field position.")
+
+        // ── 4. That position uses a new ID (not the original) ─────────────────
+        let newFieldID = newFieldIDs.first
+        XCTAssertNotEqual(newFieldID, sharedFieldID,
+                          "Duplicated page field position must use a newly generated ID.")
+
+        // ── 5. The new ID resolves to a real field in document.fields ─────────
+        XCTAssertNotNil(
+            editor.document.fields.first(where: { $0.id == newFieldID }),
+            "The new field position must reference a field that actually exists in document.fields."
+        )
+
+        // ── 6. Alt-view new page also points to the SAME new field ID ─────────
+        let altNewPage    = editor.document.files.first?.views?.first?.pages?.first(where: { $0.id == newPageID })
+        let altNewFieldID = altNewPage?.fieldPositions?.first?.field
+        XCTAssertEqual(altNewFieldID, newFieldID,
+                       "Alt-view duplicated page must point to the same new field ID as the web page, not a separate copy.")
+    }
+
     // MARK: - canDeletePage: deletable key absent defaults to true
 
     /// A page that has no `deletable` key set (i.e., the default) must be treated

--- a/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
@@ -314,4 +314,57 @@ final class PageDeletableCopyableValidationTests: XCTestCase {
         let hasValue = duplicatedFields.contains(where: { $0.value != nil })
         XCTAssertTrue(hasValue, "copyWithValues=true should preserve at least one field value on the duplicated page.")
     }
+
+    // MARK: - copyWithValues=false: original page fields untouched
+
+    /// `copyWithValues=false` must only clear the NEW page's fields — the original page's
+    /// field values must remain intact.
+    func testDuplicatePage_WithoutValues_OriginalPageFieldsUnchanged() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .setTextField()
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let editor = makeEditor(document: document)
+
+        // Collect the original page's field IDs before duplication.
+        let originalPage = editor.document.files.first?.pages?.first(where: { $0.id == pageID })
+        let originalFieldIDs = Set(originalPage?.fieldPositions?.compactMap { $0.field } ?? [])
+        XCTAssertFalse(originalFieldIDs.isEmpty, "Test requires original page to have field positions.")
+
+        // Snapshot which original fields have values before the duplicate.
+        let fieldsBefore = editor.document.fields.filter { originalFieldIDs.contains($0.id ?? "") }
+        let valuesBefore = fieldsBefore.compactMap { $0.value }
+        XCTAssertFalse(valuesBefore.isEmpty, "Test requires at least one original field with a value.")
+
+        editor.duplicatePage(pageID: pageID, copyWithValues: false)
+
+        // Original page fields must still have their values.
+        let fieldsAfter = editor.document.fields.filter { originalFieldIDs.contains($0.id ?? "") }
+        let valuesAfter = fieldsAfter.compactMap { $0.value }
+        XCTAssertEqual(valuesAfter.count, valuesBefore.count,
+                       "copyWithValues=false must not clear the original page's field values.")
+    }
+
+    // MARK: - canDeletePage: deletable key absent defaults to true
+
+    /// A page that has no `deletable` key set (i.e., the default) must be treated
+    /// as deletable — `canDeletePage` should return `(true, [])`.
+    func testCanDeletePage_DeletableKeyAbsent_DefaultsToTrue() {
+        // addSecondPage() creates a page with no deletable key set — raw default.
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+            .addSecondPage()
+            .setHeadingText()
+            .setTextField()
+
+        let editor = makeEditor(document: document)
+        let result = editor.canDeletePage(pageID: "second_page_id_12345")
+        XCTAssertTrue(result.canDelete, "Page with no deletable key should be deletable by default.")
+        XCTAssertTrue(result.warnings.isEmpty, "No warnings expected for a default-deletable page.")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -1033,8 +1033,12 @@ final class ValidationTestCase: XCTestCase {
                     XCTAssertNotEqual(dupFieldPos.field, origFieldPos.field, "Duplicated field id should differ from original field id.")
                 }
             }
-            
+
             XCTAssertEqual(documentEditor.document.fields.count, fieldCount, "Fields count can not match.")
+
+            // Verify duplicated page has reset deletable and copyable per spec
+            XCTAssertTrue(duplicatedPage?.deletable ?? false, "Duplicated page should always have deletable=true regardless of original.")
+            XCTAssertEqual(duplicatedPage?.copyable, [.withValues, .withoutValues], "Duplicated page should always have copyable=[.withValues,.withoutValues].")
         }
     
     // Test formula duplication when duplicating a page
@@ -1198,6 +1202,11 @@ final class ValidationTestCase: XCTestCase {
         
         // Get duplicated fields
         let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID })
+
+        // Verify duplicated page has reset deletable and copyable per spec
+        XCTAssertTrue(duplicatedPage?.deletable ?? false, "Duplicated page should always have deletable=true regardless of original.")
+        XCTAssertEqual(duplicatedPage?.copyable, [.withValues, .withoutValues], "Duplicated page should always have copyable=[.withValues,.withoutValues].")
+
         let duplicatedFieldIDs = duplicatedPage?.fieldPositions?.compactMap { $0.field } ?? []
         XCTAssertEqual(duplicatedFieldIDs.count, 6, "Duplicated page should have 6 fields")
         
@@ -1345,6 +1354,9 @@ final class ValidationTestCase: XCTestCase {
         let duplicatedPage = firstFile?.pages?.first(where: { $0.id != "empty_page_1" })
         XCTAssertNotNil(duplicatedPage, "Duplicated page should exist.")
         XCTAssertEqual(duplicatedPage?.fieldPositions?.count ?? 0, 0, "Duplicated page should have no field positions.")
+        // Verify duplicated page has reset deletable and copyable per spec
+        XCTAssertTrue(duplicatedPage?.deletable ?? false, "Duplicated page should always have deletable=true.")
+        XCTAssertEqual(duplicatedPage?.copyable, [.withValues, .withoutValues], "Duplicated page should always have copyable=[.withValues,.withoutValues].")
     }
 
     /// Desktop has 1 page with 2 fields; mobile view has the same page with 2 fields + 1 extra (3 total).

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1609,7 +1609,7 @@ public struct Point: Codable,Hashable, Equatable {
 
 // MARK: - CopyMode
 /// Represents the allowed duplication modes for a page.
-public enum CopyMode: String, CaseIterable {
+public enum CopyMode: String {
     case none = "none"
     case withValues = "with-values"
     case withoutValues = "without-values"

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1607,6 +1607,14 @@ public struct Point: Codable,Hashable, Equatable {
     }
 }
 
+// MARK: - CopyMode
+/// Represents the allowed duplication modes for a page.
+public enum CopyMode: String, CaseIterable {
+    case none = "none"
+    case withValues = "with-values"
+    case withoutValues = "without-values"
+}
+
 // MARK: - Page
 /// Represents a page in a document.
 public struct Page {
@@ -1716,6 +1724,27 @@ public struct Page {
     public var formulas: [AppliedFormula]? {
         get { (dictionary["formulas"] as? [[String: Any]])?.compactMap(AppliedFormula.init) }
         set { dictionary["formulas"] = newValue?.compactMap { $0.dictionary } }
+    }
+
+    /// Whether this page can be deleted. Defaults to true when not set or when set to null.
+    public var deletable: Bool {
+        get {
+            guard let value = dictionary["deletable"] else { return true }
+            if let boolValue = value as? Bool { return boolValue }
+            return true
+        }
+        set { dictionary["deletable"] = newValue }
+    }
+
+    /// The copy modes allowed for this page.
+    /// Defaults to [.withValues] when not set, null, or contains no valid values.
+    public var copyable: [CopyMode] {
+        get {
+            guard let arr = dictionary["copyable"] as? [String] else { return [.withValues] }
+            let valid = arr.compactMap { CopyMode(rawValue: $0) }
+            return valid.isEmpty ? [.withValues] : valid
+        }
+        set { dictionary["copyable"] = newValue.map { $0.rawValue } }
     }
 }
 

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -506,7 +506,7 @@ struct PageDuplicateListView: View {
             showCopyModeDialog = true
         } else if hasWithoutValues {
             documentEditor.duplicatePage(pageID: pageID, copyWithValues: false)
-        } else {
+        } else if hasWithValues {
             documentEditor.duplicatePage(pageID: pageID, copyWithValues: true)
         }
     }

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -384,6 +384,9 @@ struct PageDuplicateListView: View {
     @State private var pageToDelete: String?
     @State private var deleteWarningMessage: String = ""
 
+    @State private var showCopyModeDialog = false
+    @State private var pageToCopyID: String?
+
     private var pageIDs: [String] {
         if !documentEditor.currentPageOrder.isEmpty {
             return documentEditor.currentPageOrder
@@ -439,7 +442,7 @@ struct PageDuplicateListView: View {
                                         presentationMode.wrappedValue.dismiss()
                                     },
                                     onDuplicate: {
-                                        documentEditor.duplicatePage(pageID: pageID)
+                                        handleDuplicatePage(pageID: pageID)
                                     },
                                     onDelete: {
                                         let (canDelete, warnings) = documentEditor.canDeletePage(pageID: pageID)
@@ -475,8 +478,39 @@ struct PageDuplicateListView: View {
                 secondaryButton: .cancel()
             )
         }
+        .alert("Duplicate Page", isPresented: $showCopyModeDialog) {
+            Button("With Values") {
+                if let id = pageToCopyID {
+                    documentEditor.duplicatePage(pageID: id, copyWithValues: true)
+                }
+            }
+            Button("Without Values") {
+                if let id = pageToCopyID {
+                    documentEditor.duplicatePage(pageID: id, copyWithValues: false)
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("How would you like to duplicate this page?")
+        }
     }
-    
+
+    private func handleDuplicatePage(pageID: String) {
+        guard let page = documentEditor.firstPageFor(currentPageID: pageID) else { return }
+        let copyable = page.copyable
+        let hasWithValues = copyable.contains(.withValues)
+        let hasWithoutValues = copyable.contains(.withoutValues)
+
+        if hasWithValues && hasWithoutValues {
+            pageToCopyID = pageID
+            showCopyModeDialog = true
+        } else if hasWithoutValues {
+            documentEditor.duplicatePage(pageID: pageID, copyWithValues: false)
+        } else {
+            documentEditor.duplicatePage(pageID: pageID, copyWithValues: true)
+        }
+    }
+
     private func handleDeletePage(pageID: String, canDelete: Bool, warnings: [String]) {
         guard canDelete else {
             return
@@ -499,7 +533,21 @@ struct PageRowView: View {
     let onDelete: () -> Void
     
     @State private var isPressed = false
-    
+
+    /// Whether this page can be duplicated based on its copyable property.
+    /// Returns false only when copyable contains .none and no other valid modes.
+    private var canDuplicate: Bool {
+        let copyable = page.copyable
+        return copyable.contains(.withValues) || copyable.contains(.withoutValues)
+    }
+
+    /// Whether this page is allowed to be deleted per its deletable property.
+    /// Note: the page may still be disabled if it is the last remaining page.
+    private var isDeletable: Bool {
+        page.deletable
+    }
+
+    /// Whether the delete action can actually proceed (also checks last-page constraint).
     private var canDelete: Bool {
         documentEditor.canDeletePage(pageID: pageID).canDelete
     }
@@ -523,8 +571,8 @@ struct PageRowView: View {
                 
                 // Action Buttons
                 HStack(spacing: 8) {
-                    // Duplicate Button
-                    if documentEditor.isPageDuplicateEnabled {
+                    // Duplicate Button — hidden when page is not copyable
+                    if documentEditor.isPageDuplicateEnabled && canDuplicate {
                         Button(action: {
                             onDuplicate()
                         }) {
@@ -541,9 +589,9 @@ struct PageRowView: View {
                         .buttonStyle(ScaleButtonStyle())
                         .accessibilityIdentifier("PageDuplicateIdentifier")
                     }
-                    
-                    // Delete Button
-                    if documentEditor.isPageDeleteEnabled {
+
+                    // Delete Button — hidden when page.deletable == false
+                    if documentEditor.isPageDeleteEnabled && isDeletable {
                         Button(action: {
                             onDelete()
                         }) {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -849,7 +849,7 @@ extension DocumentEditor {
             guard let origFieldID = fieldPos.field else { continue }
             if let origField = field(fieldID: origFieldID) {
                 if fieldMapping[origFieldID] != nil {
-                    fieldPos.field = origFieldID
+                    fieldPos.field = fieldMapping[origFieldID]
                     newFieldPositions.append(fieldPos)
                     continue
                 }
@@ -1035,7 +1035,6 @@ extension DocumentEditor {
                 
                 originalAltPage.fieldPositions = alternateNewFieldPositions
                 newFields.append(contentsOf: alternateNewFields)
-                document.fields = newFields
                 if altView.pages == nil {
                     altView.pages = [originalAltPage]
                 } else {
@@ -1067,7 +1066,7 @@ extension DocumentEditor {
             }
         }
 
-        document.fields = newFields
+        document.fields.append(contentsOf: newFields)
         duplicatedPage.fieldPositions = newFieldPositions
         
         if firstFile.pages == nil {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -977,7 +977,7 @@ extension DocumentEditor {
         return formulaMapping
     }
     
-    public func duplicatePage(pageID: String) {
+    public func duplicatePage(pageID: String, copyWithValues: Bool = true) {
         guard var firstFile = document.files.first else {
             Log("No file found in document.", type: .error)
             return
@@ -994,6 +994,9 @@ extension DocumentEditor {
         
         var duplicatedPage = originalPage
         duplicatedPage.id = newPageID
+        // Copied pages are always fully editable per spec
+        duplicatedPage.deletable = true
+        duplicatedPage.copyable = [.withValues, .withoutValues]
         
         var fieldMapping: [String: String] = [:]
         var newFields: [JoyDocField] = []
@@ -1057,7 +1060,13 @@ extension DocumentEditor {
         addFieldAndFieldPositionForWeb(originalPage, &fieldMapping, &newFields, &newFieldPositions, newPageID)
         
         let _ = duplicateFormulasForPage(&newFields, fieldMapping: fieldMapping)
-        
+
+        if !copyWithValues {
+            for i in newFields.indices {
+                newFields[i].value = nil
+            }
+        }
+
         document.fields = newFields
         duplicatedPage.fieldPositions = newFieldPositions
         
@@ -1133,10 +1142,15 @@ extension DocumentEditor {
         }
         
         // Check 2: Page must exist
-        guard firstFile.pages?.contains(where: { $0.id == pageID }) == true else {
+        guard let page = firstFile.pages?.first(where: { $0.id == pageID }) else {
             return (false, ["Page with ID \(pageID) not found"])
         }
-        
+
+        // Check 3: Page-level deletable property
+        if !page.deletable {
+            return (false, [])
+        }
+
         return (true, warnings)
     }
     /// Determines the next page to navigate to after deleting a page


### PR DESCRIPTION
## Context

Introduces per-page `deletable` and `copyable` controls for fill mode. These allow API consumers to lock individual pages from being deleted or duplicated, and to control whether a duplicate carries field values over.

---

## What Changed

### Model — `JoyfillModel/JoyDoc.swift`
- Added `CopyMode` enum: `.none`, `.withValues` (`"with-values"`), `.withoutValues` (`"without-values"`)
- Added `Page.deletable: Bool` — defaults to `true` when absent/null
- Added `Page.copyable: [CopyMode]` — defaults to `[.withValues]` when absent/null/empty

### ViewModel — `JoyfillUI/ViewModels/DocumentEditor.swift`
- `duplicatePage(pageID:copyWithValues:)` — new `copyWithValues` parameter (default `true`); when `false`, clears field values on the new page only
- Duplicated pages always reset to `deletable = true`, `copyable = [.withValues, .withoutValues]` regardless of original
- `canDeletePage` — added Check 3: returns `(false, [])` silently if `page.deletable == false`

### UI — `JoyfillUI/View/FormView.swift`
- Duplicate button hidden when `page.copyable == [.none]`
- Delete button hidden when `page.deletable == false`
- When `copyable` contains both `.withValues` and `.withoutValues`, tapping duplicate shows a choice dialog ("With Values" / "Without Values")
- When only one mode is set, duplicate fires directly without a dialog

### Example Project
- `FormDestinationView` (`UserAccessTokenTextFieldView`): `isPageDuplicateEnabled`, `isPageDeleteEnabled`, `singleClickRowEdit` default to `true`; captured correctly before `Task.detached` to avoid concurrency timing issues
- `FormContainerView`, `SimpleFormExampleView`, `AllSampleJSONs`, `UserJsonTextFieldView`, `JoyfillExampleApp`: same flags enabled

---

## Key Decisions

- **`deletable=false` returns empty warnings** — the button is hidden proactively; no warning dialog is shown to the user. A warning would imply the user did something wrong, but the button should simply not be visible.
- **Copied pages reset to fully editable** — spec requirement: the SDK controls `deletable`/`copyable` on source pages; copies should always be freely manageable by the user.
- **`copyWithValues` scoped to new page only** — clearing values only affects the duplicated page's fields, not the entire document field array.
- **State capture before `Task.detached`** — `@State` vars captured as local `let` constants before entering the detached task ensures the initial `DocumentEditor` gets the correct flag values without a toggle-off/on workaround.

---

## Public API Changes

Yes — this is a public API change:

| Addition | Type |
|---|---|
| `CopyMode` enum | `JoyfillModel` |
| `Page.deletable` | `JoyfillModel` |
| `Page.copyable` | `JoyfillModel` |
| `DocumentEditor.duplicatePage(pageID:copyWithValues:)` | `JoyfillUI` |

**Docs need updating** to describe `deletable`, `copyable`, and `CopyMode` on the `Page` object, and the new `copyWithValues` parameter on `duplicatePage`.

---

## Screenshot / Demo

> _No automated screenshot — reviewer can test via the example app: load any multi-page document, set `page.deletable = false` or `page.copyable = ["none"]` in the JSON, and confirm the delete/duplicate buttons hide accordingly. Set `copyable = ["with-values", "without-values"]` to trigger the copy mode dialog._

---

## Test Coverage

- `PageDeletableCopyableValidationTests.swift` (new, 11 cases) covers:
  - `canDeletePage` returns `false` + empty warnings when `deletable=false`
  - `deletePage` is blocked and page count unchanged when `deletable=false`
  - `deletable=true` with multiple pages is allowed
  - Last-page protection takes priority over `deletable=true`
  - Duplicated page resets `deletable=true` and `copyable=[.withValues,.withoutValues]`
  - Original page properties are not mutated by duplication
  - `copyWithValues=false` clears only the new page's field values
  - `copyWithValues=true` preserves field values on the new page
- `ValidationTestCase.swift` — existing duplication tests extended with `deletable`/`copyable` reset assertions

---

## Notes for Reviewer

- The `copyable` default is `[.withValues]` (not `[.withValues, .withoutValues]`) to preserve backward-compatible behaviour — existing pages without the key will duplicate with values, silently, matching prior behaviour.
- `deletable` last-page protection check runs before the `deletable` property check (order: last-page → page-exists → deletable).
- Specialized demo views (`MetadataChangeAPIDemoView`, `SchemaValidationExampleView`, `DeficiencyTableDemoView`, `FormBuilderView`, `FormContainerTestView`) were intentionally left unchanged — they test specific features unrelated to page management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)