### PR TITLE
NO-2017: Add filter and sort support for date/time columns in Table & Collection views

### DIFF
--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -2180,6 +2180,7 @@ public struct SortModel {
 }
 
 public struct FilterModel: Equatable {
+    public static let emptyDateSentinel = "null"
     public var filterText: String = ""
     public var colIndex: Int
     public var colID: String

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
@@ -43,6 +43,12 @@ struct CollectionSearchBar: View {
                             self.model.filterText = cellDataModel.multiSelectValues?.first ?? ""
                         case .barcode:
                             self.model.filterText = cellDataModel.title ?? ""
+                        case .date:
+                            if let dateEpoch = cellDataModel.date {
+                                self.model.filterText = String(dateEpoch)
+                            } else {
+                                self.model.filterText = ""
+                            }
                         default:
                             break
                         }
@@ -76,6 +82,11 @@ struct CollectionSearchBar: View {
                             .cornerRadius(8)
                             .padding(.leading, 8)
                             .padding(.trailing, 8)
+                    case .date:
+                        TableDateView(cellModel: Binding.constant(cellModel), initialFilterText: model.filterText)
+                            .accessibilityIdentifier("SearchBarDateIdentifier")
+                            .frame(height: 40)
+                            .padding(.horizontal, 4)
                     default:
                         HStack(spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill")

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
@@ -47,7 +47,7 @@ struct CollectionSearchBar: View {
                             if let dateEpoch = cellDataModel.date {
                                 self.model.filterText = String(dateEpoch)
                             } else {
-                                self.model.filterText = ""
+                                self.model.filterText = "null"
                             }
                         default:
                             break
@@ -87,6 +87,11 @@ struct CollectionSearchBar: View {
                             .accessibilityIdentifier("SearchBarDateIdentifier")
                             .frame(height: 40)
                             .padding(.horizontal, 4)
+                            .onAppear {
+                                if self.model.filterText.isEmpty {
+                                    self.model.filterText = "null"
+                                }
+                            }
                     default:
                         HStack(spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill")

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionSearchBar.swift
@@ -47,7 +47,7 @@ struct CollectionSearchBar: View {
                             if let dateEpoch = cellDataModel.date {
                                 self.model.filterText = String(dateEpoch)
                             } else {
-                                self.model.filterText = "null"
+                                self.model.filterText = FilterModel.emptyDateSentinel
                             }
                         default:
                             break
@@ -89,7 +89,7 @@ struct CollectionSearchBar: View {
                             .padding(.horizontal, 4)
                             .onAppear {
                                 if self.model.filterText.isEmpty {
-                                    self.model.filterText = "null"
+                                    self.model.filterText = FilterModel.emptyDateSentinel
                                 }
                             }
                     default:

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -334,9 +334,9 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                 case .date:
                     switch tableDataModel.sortModel.order {
                     case .ascending:
-                        return (cell1.date ?? 0) < (cell2.date ?? 0)
+                        return (cell1.date ?? -.infinity) < (cell2.date ?? -.infinity)
                     case .descending:
-                        return (cell1.date ?? 0) > (cell2.date ?? 0)
+                        return (cell1.date ?? -.infinity) > (cell2.date ?? -.infinity)
                     case .none:
                         return true
                     }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -331,6 +331,15 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                     case .none:
                         return true
                     }
+                case .date:
+                    switch tableDataModel.sortModel.order {
+                    case .ascending:
+                        return (cell1.date ?? 0) < (cell2.date ?? 0)
+                    case .descending:
+                        return (cell1.date ?? 0) > (cell2.date ?? 0)
+                    case .none:
+                        return true
+                    }
                 default:
                     return false
                 }
@@ -1595,6 +1604,8 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                     cellValues[columnId] = ValueUnion.string(change)
                 case .signature:
                     cellValues[columnId] = ValueUnion.string(change)
+                case .date:
+                    cellValues[columnId] = ValueUnion.string(change)
                 default:
                     break
                 }
@@ -1815,7 +1826,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         let tableColumns = tableDataModel.filterTableColumns(key: schemaKey)
         return tableColumns.filter { column in
             switch column.type {
-            case .text, .dropdown, .multiSelect, .number, .barcode:
+            case .text, .dropdown, .multiSelect, .number, .barcode, .date:
                 return true
             default:
                 return false

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -1605,7 +1605,11 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                 case .signature:
                     cellValues[columnId] = ValueUnion.string(change)
                 case .date:
-                    cellValues[columnId] = ValueUnion.string(change)
+                    if let doubleChange = Double(change) {
+                        cellValues[columnId] = ValueUnion.double(doubleChange)
+                    } else {
+                        cellValues[columnId] = ValueUnion.null
+                    }
                 default:
                     break
                 }

--- a/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
@@ -125,6 +125,7 @@ struct SearchBar: View {
                 .accessibilityIdentifier("HideFilterSearchBar")
             }
         }
+        .id(model.colID)
         .frame(height: 40)
         .background(Color(.systemGray6))
         .cornerRadius(8)

--- a/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
@@ -49,7 +49,7 @@ struct SearchBar: View {
                             if let dateEpoch = cellDataModel.date {
                                 self.model.filterText = String(dateEpoch)
                             } else {
-                                self.model.filterText = "null"
+                                self.model.filterText = FilterModel.emptyDateSentinel
                             }
                         default:
                             break
@@ -89,7 +89,7 @@ struct SearchBar: View {
                             .frame(height: 25)
                             .onAppear {
                                 if self.model.filterText.isEmpty {
-                                    self.model.filterText = "null"
+                                    self.model.filterText = FilterModel.emptyDateSentinel
                                 }
                             }
                     default:

--- a/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
@@ -18,7 +18,7 @@ struct SearchBar: View {
     var body: some View {
         HStack {
             if !viewModel.tableDataModel.rowOrder.isEmpty, selectedColumnIndex != Int.min {
-                let column = viewModel.tableDataModel.getDummyCell(col: selectedColumnIndex)
+                let column = viewModel.tableDataModel.getDummyCell(col: selectedColumnIndex, empty: true)
                 if let column = column {
                     let cellModel = TableCellModel(rowID: "",
                                                    timezoneId: "",
@@ -49,7 +49,7 @@ struct SearchBar: View {
                             if let dateEpoch = cellDataModel.date {
                                 self.model.filterText = String(dateEpoch)
                             } else {
-                                self.model.filterText = ""
+                                self.model.filterText = "null"
                             }
                         default:
                             break
@@ -87,6 +87,11 @@ struct SearchBar: View {
                         TableDateView(cellModel: Binding.constant(cellModel), initialFilterText: model.filterText)
                             .accessibilityIdentifier("SearchBarDateIdentifier")
                             .frame(height: 25)
+                            .onAppear {
+                                if self.model.filterText.isEmpty {
+                                    self.model.filterText = "null"
+                                }
+                            }
                     default:
                         Text("")
                     }

--- a/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/SearchBar.swift
@@ -45,6 +45,12 @@ struct SearchBar: View {
                             self.model.filterText = cellDataModel.multiSelectValues?.first ?? ""
                         case .barcode:
                             self.model.filterText = cellDataModel.title ?? ""
+                        case .date:
+                            if let dateEpoch = cellDataModel.date {
+                                self.model.filterText = String(dateEpoch)
+                            } else {
+                                self.model.filterText = ""
+                            }
                         default:
                             break
                         }
@@ -77,6 +83,10 @@ struct SearchBar: View {
                             .frame(height: 25)
                             .cornerRadius(6)
                             .padding(.leading, 8)
+                    case .date:
+                        TableDateView(cellModel: Binding.constant(cellModel), initialFilterText: model.filterText)
+                            .accessibilityIdentifier("SearchBarDateIdentifier")
+                            .frame(height: 25)
                     default:
                         Text("")
                     }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableDateView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableDateView.swift
@@ -16,20 +16,26 @@ struct TableDateView: View {
     @State var dateString: String = ""
     @State var eraseDate: Bool = false
     
-    public init(cellModel: Binding<TableCellModel>, isUsedForBulkEdit: Bool = false) {
+    public init(cellModel: Binding<TableCellModel>, isUsedForBulkEdit: Bool = false, initialFilterText: String = "") {
         _cellModel = cellModel
         self.isUsedForBulkEdit = isUsedForBulkEdit
-        if !isUsedForBulkEdit {
-            if let dateValue = cellModel.wrappedValue.data.date {
-                if let dateString = ValueUnion.double(dateValue).dateTime(format: cellModel.wrappedValue.data.format ?? .empty, tzId: cellModel.wrappedValue.timezoneId) {
-                    _dateString = State(initialValue: dateString)
-                    if let date = Utility.stringToDate(dateString, format: cellModel.wrappedValue.data.format ?? .empty, tzId: cellModel.wrappedValue.timezoneId) {
-                        _selectedDate = State(initialValue: date)
-                    }
+        datePickerComponent = Utility.getDateType(format: cellModel.wrappedValue.data.format ?? .empty)
+        func setupDate(dateValue: Double) {
+            if let dateString = ValueUnion.double(dateValue).dateTime(format: cellModel.wrappedValue.data.format ?? .empty, tzId: cellModel.wrappedValue.timezoneId) {
+                _dateString = State(initialValue: dateString)
+                if let date = Utility.stringToDate(dateString, format: cellModel.wrappedValue.data.format ?? .empty, tzId: cellModel.wrappedValue.timezoneId) {
+                    _selectedDate = State(initialValue: date)
                 }
             }
         }
-        datePickerComponent = Utility.getDateType(format: cellModel.wrappedValue.data.format ?? .empty)
+        if !initialFilterText.isEmpty, let dateValue = Double(initialFilterText) {
+            setupDate(dateValue: dateValue)
+        }
+        if !isUsedForBulkEdit {
+            if let dateValue = cellModel.wrappedValue.data.date {
+                setupDate(dateValue: dateValue)
+            }
+        }
     }
     
     var body: some View {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableDateView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableDateView.swift
@@ -30,8 +30,7 @@ struct TableDateView: View {
         }
         if !initialFilterText.isEmpty, let dateValue = Double(initialFilterText) {
             setupDate(dateValue: dateValue)
-        }
-        if !isUsedForBulkEdit {
+        } else if !isUsedForBulkEdit {
             if let dateValue = cellModel.wrappedValue.data.date {
                 setupDate(dateValue: dateValue)
             }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -176,9 +176,9 @@ struct TableModalView : View {
                 case .date:
                     switch viewModel.tableDataModel.sortModel.order {
                     case .ascending:
-                        return (column1.date ?? 0) < (column2.date ?? 0)
+                        return (column1.date ?? -.infinity) < (column2.date ?? -.infinity)
                     case .descending:
-                        return (column1.date ?? 0) > (column2.date ?? 0)
+                        return (column1.date ?? -.infinity) > (column2.date ?? -.infinity)
                     case .none:
                         return true
                     }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -173,6 +173,15 @@ struct TableModalView : View {
                     case .none:
                         return true
                     }
+                case .date:
+                    switch viewModel.tableDataModel.sortModel.order {
+                    case .ascending:
+                        return (column1.date ?? 0) < (column2.date ?? 0)
+                    case .descending:
+                        return (column1.date ?? 0) > (column2.date ?? 0)
+                    case .none:
+                        return true
+                    }
                 default:
                     return false
                 }
@@ -289,7 +298,7 @@ struct TableModalView : View {
                             .imageScale(.small)
                     }
                     
-                    if ![.image, .block, .date, .progress, .signature].contains(viewModel.tableDataModel.getColumnType(columnId: column.id ?? "")) {
+                    if ![.image, .block, .progress, .signature].contains(viewModel.tableDataModel.getColumnType(columnId: column.id ?? "")) {
                         Image(systemName: "line.3.horizontal.decrease.circle")
                             .foregroundColor(viewModel.tableDataModel.filterModels[index].filterText.isEmpty ? Color.gray : Color.blue)
                     }
@@ -307,7 +316,7 @@ struct TableModalView : View {
                 .accessibilityIdentifier("ColumnButtonIdentifier")
                 .zIndex(currentSelectedCol == index ? 1 : 0)
                 .onTapGesture {
-                    if !([.image, .block, .date, .progress, .signature].contains(viewModel.tableDataModel.getColumnType(columnId: column.id ?? "")) || viewModel.tableDataModel.rowOrder.count == 0) {
+                    if !([.image, .block, .progress, .signature].contains(viewModel.tableDataModel.getColumnType(columnId: column.id ?? "")) || viewModel.tableDataModel.rowOrder.count == 0) {
                         currentSelectedCol = currentSelectedCol == index ? Int.min : index
                     }
                 }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -356,6 +356,12 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                     cellValues[columnId] = ValueUnion.string(change)
                 case .signature:
                     cellValues[columnId] = ValueUnion.string(change)
+                case .date:
+                    if let doubleChange = Double(change) {
+                        cellValues[columnId] = ValueUnion.double(doubleChange)
+                    } else {
+                        cellValues[columnId] = ValueUnion.null
+                    }
                 default:
                     break
                 }

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -414,7 +414,7 @@ struct TableDataModel {
             case .barcode:
                 match = (column.title ?? "").localizedCaseInsensitiveContains(filter.filterText)
             case .date:
-                if filter.filterText == "null" {
+                if filter.filterText == FilterModel.emptyDateSentinel {
                     match = column.date == nil      // empty filter → only rows with no date
                 } else if let date = column.date,
                           let filterDate = Double(filter.filterText) {

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -414,7 +414,10 @@ struct TableDataModel {
             case .barcode:
                 match = (column.title ?? "").localizedCaseInsensitiveContains(filter.filterText)
             case .date:
-                if let date = column.date, let filterDate = Double(filter.filterText) {
+                if filter.filterText == "null" {
+                    match = column.date == nil      // empty filter → only rows with no date
+                } else if let date = column.date,
+                          let filterDate = Double(filter.filterText) {
                     match = date == filterDate
                 } else {
                     match = false
@@ -783,9 +786,17 @@ struct TableDataModel {
         cellModels[rowIndex].cells[colIndex] = cellModel
     }
     
-    func getDummyCell(col: Int, selectedOptionText: String = "") -> CellDataModel? {
+    func getDummyCell(col: Int, selectedOptionText: String = "", empty: Bool) -> CellDataModel? {
         var dummyCell = cellModels.first?.cells[col].data
         dummyCell?.selectedOptionText = selectedOptionText
+        if empty {
+            dummyCell?.title = ""
+            dummyCell?.defaultDropdownSelectedId = nil
+            dummyCell?.valueElements = []
+            dummyCell?.number = nil
+            dummyCell?.date = nil
+            dummyCell?.multiSelectValues = nil
+        }
         return dummyCell
     }
     

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -413,6 +413,12 @@ struct TableDataModel {
                 match = column.multiSelectValues?.contains(filter.filterText) ?? false
             case .barcode:
                 match = (column.title ?? "").localizedCaseInsensitiveContains(filter.filterText)
+            case .date:
+                if let date = column.date {
+                    match = String(date) == filter.filterText
+                } else {
+                    match = false
+                }
             default:
                 match = false
             }
@@ -807,7 +813,7 @@ struct TableDataModel {
             title: column.title,
             number: column.number,
             date: column.date,
-            format: column.getFormat(from: fieldPositionTableColumns),
+            format: DateFormatType(rawValue: column.format ?? ""),
             multiSelectValues: column.multiSelectValues,
             multi: column.multi)
     }

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -414,8 +414,8 @@ struct TableDataModel {
             case .barcode:
                 match = (column.title ?? "").localizedCaseInsensitiveContains(filter.filterText)
             case .date:
-                if let date = column.date {
-                    match = String(date) == filter.filterText
+                if let date = column.date, let filterDate = Double(filter.filterText) {
+                    match = date == filterDate
                 } else {
                     match = false
                 }


### PR DESCRIPTION
## Context

Table and Collection views support filtering and sorting rows by column type. Date/time columns were previously excluded from this — the filter icon was hidden, tap gesture was blocked, and no sort/filter logic existed for `.date` type. This PR brings date columns to parity with other filterable column types (text, dropdown, number, barcode, etc.).

## What Changed

**`TableModalView.swift`**
- Removed `.date` from the excluded types list for the filter icon and column tap gesture — date columns now show the filter button and respond to taps.
- Added ascending/descending sort logic for date columns using epoch value comparison.

**`CollectionViewModel.swift`**
- Added `.date` to the list of filterable column types (`filterTableColumns`).
- Added ascending/descending sort case for date columns (epoch-based).
- Added `.date` case in the cell value change handler — stores epoch as `ValueUnion.double`, falls back to `ValueUnion.null` if the string is not a valid number.

**`TableViewModel.swift`**
- Added `.date` case in the cell value change handler (mirrors `CollectionViewModel`) — converts epoch string to `ValueUnion.double`, falls back to `ValueUnion.null`.

**`SearchBar.swift` & `CollectionSearchBar.swift`**
- Added `.date` case to extract epoch from `cellDataModel.date` as the `filterText` string (stores raw epoch, not a formatted display string).
- Added `.date` case in the search bar UI to render a `TableDateView` picker inline (instead of a text field).

**`TableDateView.swift`**
- Added `initialFilterText: String = ""` parameter to `init` to support pre-populating the date picker when used in filter context.
- Extracted a local `setupDate(dateValue:)` helper to deduplicate the date string/selectedDate initialization logic used for both filter and normal cell edit modes.
- Moved `datePickerComponent` assignment before the conditional block (was after — order matters for init).
- Fixed a state-overwrite bug: changed second `if` to `else if` so the cell's own date data no longer overwrites the filter's pre-populated date when `initialFilterText` is provided.

**`Models.swift`**
- Added `.date` case in row filter matching: parses `filter.filterText` back to `Double` and compares numeric values directly against `column.date`. Both sides are explicitly unwrapped — if either is `nil` (missing date or invalid filter string), `match` is `false`. This avoids `Optional` string interpolation pitfalls and float-to-string formatting edge cases.
- Fixed a bug: `getFormat(from:)` was being called in `filterTableColumnsToCellModel` where `DateFormatType(rawValue:)` should be used directly — avoids an unnecessary lookup.

## Design Decisions

- **Epoch string as filter key**: The filter text for dates is stored as the raw epoch string (e.g. `"1710000000.0"`). This avoids locale/format/timezone ambiguity when comparing — the epoch is the source of truth. The `TableDateView` picker handles display formatting independently.
- **Exact match for date filter**: Unlike text columns that use `localizedCaseInsensitiveContains`, date filtering uses exact epoch equality. `filter.filterText` is parsed back to `Double` and compared directly against `column.date` — no string formatting involved. Both values must be non-nil for a match; a missing cell date or an invalid filter string both correctly produce no match.
- **Reusing `TableDateView` in search bar**: Rather than building a separate filter-only date picker, `TableDateView` was extended with `initialFilterText` so it works in both edit and filter contexts, keeping UI consistent.

## Screenshot / Demo

> A short screen recording would be ideal here — filter icon now appears on date columns, tapping opens the date picker inline in the search bar, and rows filter to the selected date.

## Public API

No public API changes. `TableDateView.init` gained an optional parameter with a default value — fully backwards compatible.

Docs do not need to be updated.

## Tests

No automated tests added in this PR. The filter/sort logic follows the same pattern as existing column types. Manual testing covers:
- Filter icon visible on date columns
- Date picker renders in search bar
- Rows filter correctly by selected date
- Ascending/descending sort works on date columns

Tests for date column filtering can be added in a follow-up.

## Reviewer Notes

- The `Models.swift` `getFormat` → `DateFormatType(rawValue:)` fix is a pre-existing bug caught while working in the area — low risk, but worth a second look.
- Both `SearchBar.swift` (TableView) and `CollectionSearchBar.swift` (CollectionView) received identical changes — they share no common base currently, so changes had to be duplicated.
- `TableViewModel.swift` and `CollectionViewModel.swift` both received identical `.date` cell value handler changes for the same reason.