### PR TITLE
Fix: goto() cross-table row form navigation (sheet blocking modal dismiss)

### DIFF
--- a/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
+++ b/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
@@ -59,6 +59,9 @@ struct ChartDetailView: View {
                 UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             }
         }
+        .onDisappear {
+            chartDataModel.documentEditor?.setOpenNavigationFieldID(nil)
+        }
     }
 
     func updateValueElements(valueElements: [ValueElement]) {

--- a/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
+++ b/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
@@ -6,6 +6,7 @@
 
 import SwiftUI
 import JoyfillModel
+import Combine
 
 struct ChartDetailView: View {
 //    var chartData: MultiLineChartData
@@ -13,6 +14,7 @@ struct ChartDetailView: View {
     @State var valueElements: [ValueElement] = []
     @State var isCoordinateVisible: Bool = false
     @State var chartCoordinatesData: ChartAxisConfiguration
+    @Environment(\.dismiss) private var dismiss
     
 //    public init(chartData: MultiLineChartData,fieldDependency: FieldDependency) {
     public init(chartDataModel: ChartDataModel) {
@@ -61,6 +63,11 @@ struct ChartDetailView: View {
         }
         .onDisappear {
             chartDataModel.documentEditor?.setOpenNavigationFieldID(nil)
+        }
+        .onReceive(chartDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { targetFieldID in
+            if targetFieldID == chartDataModel.fieldIdentifier.fieldID {
+                dismiss()
+            }
         }
     }
 

--- a/Sources/JoyfillUI/View/Fields/ChartView/ChartView.swift
+++ b/Sources/JoyfillUI/View/Fields/ChartView/ChartView.swift
@@ -59,6 +59,7 @@ struct ChartView: View {
                 if chartDataModel.mode == .fill {
                     eventHandler.onFocus(event: chartDataModel.fieldIdentifier)
                 }
+                chartDataModel.documentEditor?.setOpenNavigationFieldID(chartDataModel.fieldIdentifier.fieldID)
             }, label: {
                 HStack {
                     Image(systemName: "chart.xyaxis.line")

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -104,8 +104,10 @@ struct CollectionModalView : View {
                 }
             }
         }
-        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            dismiss()
+        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { targetFieldID in
+            if targetFieldID == viewModel.tableDataModel.fieldIdentifier.fieldID {
+                dismiss()
+            }
         }
         .onDisappear(perform: {
             viewModel.sendEventsIfNeeded()

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -104,6 +104,9 @@ struct CollectionModalView : View {
                 }
             }
         }
+        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
+            dismiss()
+        }
         .onDisappear(perform: {
             viewModel.sendEventsIfNeeded()
         })

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionQuickView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionQuickView.swift
@@ -89,6 +89,7 @@ struct CollectionQuickView : View {
     
     func openCollection() {
         isTableModalViewPresented = true
+        tableDataModel.documentEditor?.setOpenNavigationFieldID(tableDataModel.fieldIdentifier.fieldID)
         if tableDataModel.mode == .fill {
             eventHandler.onFocus(event: tableDataModel.fieldIdentifier)
         }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -1809,6 +1809,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         if tableDataModel.mode == .fill {
             tableDataModel.documentEditor?.onChange(fieldIdentifier: tableDataModel.fieldIdentifier)
         }
+        tableDataModel.documentEditor?.setOpenNavigationFieldID(nil)
     }
     
     func getFilteredColumns(for schemaKey: String) -> [FieldTableColumn] {

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import JoyfillModel
 
 struct SignatureView: View {
@@ -72,7 +73,7 @@ struct SignatureView: View {
             .accessibilityIdentifier("SignatureIdentifier")
             .padding(.top, 6)
             
-            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable, documentEditor: signatureDataModel.documentEditor), isActive: $showCanvasSignatureView) {
+            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable, documentEditor: signatureDataModel.documentEditor, fieldID: signatureDataModel.fieldIdentifier.fieldID), isActive: $showCanvasSignatureView) {
                 EmptyView()
             }
             .frame(width: 0, height: 0)
@@ -205,6 +206,7 @@ struct CanvasSignatureView: View {
     @Binding var showError: Bool
     @Binding var isEditable: Bool
     var documentEditor: DocumentEditor?
+    var fieldID: String?
     @Environment(\.presentationMode) private var presentationMode
     let screenWidth = UIScreen.main.bounds.width
     
@@ -338,6 +340,11 @@ struct CanvasSignatureView: View {
         }
         .onDisappear {
             documentEditor?.setOpenNavigationFieldID(nil)
+        }
+        .onReceive(documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { targetFieldID in
+            if targetFieldID == fieldID {
+                presentationMode.wrappedValue.dismiss()
+            }
         }
         .padding(.horizontal, 16.0)
     }

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -56,6 +56,7 @@ struct SignatureView: View {
             
             Button(action: {
                 showCanvasSignatureView = true
+                signatureDataModel.documentEditor?.setOpenNavigationFieldID(signatureDataModel.fieldIdentifier.fieldID)
                 eventHandler.onFocus(event: signatureDataModel.fieldIdentifier)
             }, label: {
                 Text("\(!signatureURL.isEmpty ? "Edit Signature" : "Add Signature")")
@@ -71,7 +72,7 @@ struct SignatureView: View {
             .accessibilityIdentifier("SignatureIdentifier")
             .padding(.top, 6)
             
-            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable), isActive: $showCanvasSignatureView) {
+            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable, documentEditor: signatureDataModel.documentEditor), isActive: $showCanvasSignatureView) {
                 EmptyView()
             }
             .frame(width: 0, height: 0)
@@ -203,6 +204,7 @@ struct CanvasSignatureView: View {
     @Binding var signatureURL: String
     @Binding var showError: Bool
     @Binding var isEditable: Bool
+    var documentEditor: DocumentEditor?
     @Environment(\.presentationMode) private var presentationMode
     let screenWidth = UIScreen.main.bounds.width
     
@@ -333,6 +335,9 @@ struct CanvasSignatureView: View {
         .onAppear {
             signatureCanvasImage = signatureImage
             showCanvasError = showError
+        }
+        .onDisappear {
+            documentEditor?.setOpenNavigationFieldID(nil)
         }
         .padding(.horizontal, 16.0)
     }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -94,6 +94,9 @@ struct TableModalView : View {
                 }
             }
         }
+        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
+            dismiss()
+        }
         .onDisappear(perform: {
             viewModel.sendEventsIfNeeded()
             clearFilter()

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -94,8 +94,10 @@ struct TableModalView : View {
                 }
             }
         }
-        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            dismiss()
+        .onReceive(viewModel.tableDataModel.documentEditor?.dismissNavigationPublisher.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { targetFieldID in
+            if targetFieldID == viewModel.tableDataModel.fieldIdentifier.fieldID {
+                dismiss()
+            }
         }
         .onDisappear(perform: {
             viewModel.sendEventsIfNeeded()

--- a/Sources/JoyfillUI/View/Fields/TableView/TableQuickView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableQuickView.swift
@@ -29,7 +29,7 @@ struct TableQuickView : View {
         
     fileprivate func openTable() {
         isTableModalViewPresented = true
-        
+        tableDataModel.documentEditor?.setOpenNavigationFieldID(tableDataModel.fieldIdentifier.fieldID)
         if tableDataModel.mode == .fill {
             eventHandler.onFocus(event: tableDataModel.fieldIdentifier)
         }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -482,6 +482,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         if tableDataModel.mode == .fill {
             tableDataModel.documentEditor?.onChange(fieldIdentifier: tableDataModel.fieldIdentifier)
         }
+        tableDataModel.documentEditor?.setOpenNavigationFieldID(nil)
     }
     
     func getParenthPath(rowId: String) -> (String, String) {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
@@ -79,8 +79,8 @@ extension DocumentEditor {
         runOnMain { self.navigationPublisher.send(event) }
     }
 
-    func sendDismissNavigation() {
-        runOnMain { self.dismissNavigationPublisher.send() }
+    func sendDismissNavigation(fieldID: String) {
+        runOnMain { self.dismissNavigationPublisher.send(fieldID) }
     }
     
     func changePageAndNavigate(pageId: String, event: NavigationTarget) {
@@ -95,7 +95,7 @@ extension DocumentEditor {
     func executeNavigation(pageId: String, event: NavigationTarget, status: NavigationStatus, pageChanged: Bool) -> NavigationStatus {
         if let currentFieldID = openedNavigationFieldID,
            currentFieldID != event.fieldID {
-            sendDismissNavigation()
+            sendDismissNavigation(fieldID: currentFieldID)
             let execute = { [self] in
                 if pageChanged { self.currentPageID = pageId }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.65) {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
@@ -76,39 +76,18 @@ extension EnvironmentValues {
 
 extension DocumentEditor {
     func sendNavigation(_ event: NavigationTarget) {
-        if Thread.isMainThread {
-            navigationPublisher.send(event)
-        } else {
-            DispatchQueue.main.async {
-                self.navigationPublisher.send(event)
-            }
-        }
+        runOnMain { self.navigationPublisher.send(event) }
     }
 
     func sendDismissNavigation() {
-        if Thread.isMainThread {
-            dismissNavigationPublisher.send()
-        } else {
-            DispatchQueue.main.async {
-                self.dismissNavigationPublisher.send()
-            }
-        }
+        runOnMain { self.dismissNavigationPublisher.send() }
     }
     
     func changePageAndNavigate(pageId: String, event: NavigationTarget) {
-        let execute = { [self] in
+        runOnMain {
             self.currentPageID = pageId
-            
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 self.navigationPublisher.send(event)
-            }
-        }
-
-        if Thread.isMainThread {
-            execute()
-        } else {
-            DispatchQueue.main.async {
-                execute()
             }
         }
     }
@@ -123,7 +102,7 @@ extension DocumentEditor {
                     self.sendNavigation(event)
                 }
             }
-            if Thread.isMainThread { execute() } else { DispatchQueue.main.async { execute() } }
+            runOnMain(execute)
             return status
         }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
@@ -84,6 +84,16 @@ extension DocumentEditor {
             }
         }
     }
+
+    func sendDismissNavigation() {
+        if Thread.isMainThread {
+            dismissNavigationPublisher.send()
+        } else {
+            DispatchQueue.main.async {
+                self.dismissNavigationPublisher.send()
+            }
+        }
+    }
     
     func changePageAndNavigate(pageId: String, event: NavigationTarget) {
         let execute = { [self] in
@@ -104,6 +114,19 @@ extension DocumentEditor {
     }
     
     func executeNavigation(pageId: String, event: NavigationTarget, status: NavigationStatus, pageChanged: Bool) -> NavigationStatus {
+        if let currentFieldID = openedNavigationFieldID,
+           currentFieldID != event.fieldID {
+            sendDismissNavigation()
+            let execute = { [self] in
+                if pageChanged { self.currentPageID = pageId }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.65) {
+                    self.sendNavigation(event)
+                }
+            }
+            if Thread.isMainThread { execute() } else { DispatchQueue.main.async { execute() } }
+            return status
+        }
+
         if pageChanged {
             changePageAndNavigate(pageId: pageId, event: event)
         } else {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -735,12 +735,16 @@ extension DocumentEditor {
         return dataModelType
     }
     
-    func setOpenNavigationFieldID(_ fieldID: String?) {
+    func runOnMain(_ block: @escaping () -> Void) {
         if Thread.isMainThread {
-            openedNavigationFieldID = fieldID
+            block()
         } else {
-            DispatchQueue.main.async { self.openedNavigationFieldID = fieldID }
+            DispatchQueue.main.async { block() }
         }
+    }
+
+    func setOpenNavigationFieldID(_ fieldID: String?) {
+        runOnMain { self.openedNavigationFieldID = fieldID }
     }
 }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -45,6 +45,8 @@ public class DocumentEditor: ObservableObject {
     @Published var currentPageOrder: [String] = []
     @Published var navigationFocusFieldId: String?
     let navigationPublisher = PassthroughSubject<NavigationTarget, Never>()
+    let dismissNavigationPublisher = PassthroughSubject<Void, Never>()
+    public private(set) var openedNavigationFieldID: String? = nil
     public private(set) var isCollectionFieldEnabled: Bool = false
 
     public var mode: Mode = .fill
@@ -465,6 +467,14 @@ extension DocumentEditor {
         return files.first?.views?.contains(where: { $0.type == "mobile" }) ?? false
     }
     
+    public func setOpenNavigationFieldID(_ fieldID: String?) {
+        if Thread.isMainThread {
+            openedNavigationFieldID = fieldID
+        } else {
+            DispatchQueue.main.async { self.openedNavigationFieldID = fieldID }
+        }
+    }
+
     public func firstValidPageFor(currentPageID: String) -> Page? {
         return document.pagesForCurrentView.first { currentPage in
             currentPage.id == currentPageID && shouldShow(page: currentPage)

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -45,7 +45,7 @@ public class DocumentEditor: ObservableObject {
     @Published var currentPageOrder: [String] = []
     @Published var navigationFocusFieldId: String?
     let navigationPublisher = PassthroughSubject<NavigationTarget, Never>()
-    let dismissNavigationPublisher = PassthroughSubject<Void, Never>()
+    let dismissNavigationPublisher = PassthroughSubject<String, Never>()
     public private(set) var openedNavigationFieldID: String? = nil
     public private(set) var isCollectionFieldEnabled: Bool = false
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -467,14 +467,6 @@ extension DocumentEditor {
         return files.first?.views?.contains(where: { $0.type == "mobile" }) ?? false
     }
     
-    public func setOpenNavigationFieldID(_ fieldID: String?) {
-        if Thread.isMainThread {
-            openedNavigationFieldID = fieldID
-        } else {
-            DispatchQueue.main.async { self.openedNavigationFieldID = fieldID }
-        }
-    }
-
     public func firstValidPageFor(currentPageID: String) -> Page? {
         return document.pagesForCurrentView.first { currentPage in
             currentPage.id == currentPageID && shouldShow(page: currentPage)
@@ -741,6 +733,14 @@ extension DocumentEditor {
             dataModelType = .none
         }
         return dataModelType
+    }
+    
+    func setOpenNavigationFieldID(_ fieldID: String?) {
+        if Thread.isMainThread {
+            openedNavigationFieldID = fieldID
+        } else {
+            DispatchQueue.main.async { self.openedNavigationFieldID = fieldID }
+        }
     }
 }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -679,7 +679,8 @@ extension DocumentEditor {
         case .signature:
             let model = SignatureDataModel(fieldIdentifier: fieldIdentifier,
                                            signatureURL: fieldData?.value?.signatureURL ?? "",
-                                           fieldHeaderModel: fieldHeaderModel)
+                                           fieldHeaderModel: fieldHeaderModel,
+                                           documentEditor: self)
             dataModelType = .signature(model)
         case .number:
             let model = NumberDataModel(fieldIdentifier: fieldIdentifier,

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -1270,6 +1270,7 @@ struct SignatureDataModel {
     var fieldIdentifier: FieldIdentifier
     var signatureURL: String?
     var fieldHeaderModel: FieldHeaderModel?
+    var documentEditor: DocumentEditor?
 }
 
 struct TextDataModel {


### PR DESCRIPTION
## Context

The \`goto()\` method supports navigating to a specific table field, row, and optionally opening the row form sheet (\`open: true\`). A bug existed where calling \`goto()\` targeting a **different table** while a row form sheet was already open would navigate back to the form but fail to open the new table's row form — leaving the user stranded.

## Root Cause

\`TableModalView\` and \`CollectionModalView\` both had an \`onReceive(navigationPublisher)\` guard that called \`dismiss()\` when a cross-table event fired. This silently failed because **iOS will not pop a view controller that is currently presenting a sheet** — the \`EditMultipleRowsSheetView\` (the row form) was blocking the navigation pop.

Additionally, even if the pop succeeded, the incoming table's modal would try to push at the exact same moment the old one was dismissing, causing a simultaneous pop+push race on the navigation stack.

## What Changed

| File | Change |
|---|---|
| \`DocumentEditor.swift\` | Added \`dismissNavigationPublisher\` (fires targeted dismiss signal carrying fieldID) and \`openedNavigationFieldID\` (tracks which field's modal is open). Added \`runOnMain\` helper to remove repeated main-thread dispatch boilerplate. |
| \`DocumentEditor+Navigation.swift\` | \`executeNavigation()\` detects cross-field navigation: fires dismiss signal first, then delays the navigation event 0.65s to let the sheet (~0.3s) + modal pop (~0.3s) finish animating. Page change happens immediately so new page models are ready before navigation fires. |
| \`TableQuickView\` / \`CollectionQuickView\` | \`openTable()\` / \`openCollection()\` call \`setOpenNavigationFieldID()\` so the coordinator knows which modal is open |
| \`TableViewModel\` / \`CollectionViewModel\` | \`sendEventsIfNeeded()\` calls \`setOpenNavigationFieldID(nil)\` — called from \`onDisappear\` of both modal views, clearing the field ID when the user presses back normally |
| \`TableModalView\` / \`CollectionModalView\` | Subscribe to \`dismissNavigationPublisher\` and call \`dismiss()\` only when \`targetFieldID\` matches their own fieldID |
| \`SignatureView\` / \`CanvasSignatureView\` | Extended the same pattern to Signature: \`openedNavigationFieldID\` is set when canvas opens, cleared on disappear, and \`dismissNavigationPublisher\` triggers dismiss when targeted |

## Why the 0.65s Delay

Sheet dismiss is ~0.3s and nav pop is ~0.3s, so 0.65s is a safe threshold. The page change is intentionally immediate (not delayed) — this gives the new page time to build its table/collection models before \`sendNavigation\` fires. Same-field navigation (different row or column) falls through to immediate navigation with no delay.

## Test Cases Covered

- ✅ \`goto(table1/row1, open: true)\` → row form opens normally
- ✅ \`goto(table2/row2, open: true)\` **from inside table1's row form** → sheet closes, table1 modal pops, table2 modal opens with row form
- ✅ \`goto(table1/row2, open: true)\` from inside table1's row form (same table, different row) → modal stays open, row updates in place, no dismiss/reopen
- ✅ \`goto(table1/row1/colA, open: true)\` from inside table1's row form (same table, different column) → modal stays open, column focus updates
- ✅ Pressing back from table/signature modal → \`openedNavigationFieldID\` correctly cleared via \`onDisappear\`
- ✅ Cross-field goto while \`CanvasSignatureView\` is open → signature canvas dismissed, target field navigated
- ⬜ Automated UI tests — not written yet, manual testing only

## Notes for Reviewer

- \`openedNavigationFieldID\` is tracked for **Table, Collection, and Signature** fields — all three use \`NavigationLink\` push modals
- \`dismissNavigationPublisher\` carries the \`fieldID\` of the target modal so only the correct view dismisses
- Page change fires immediately alongside \`sendDismissNavigation\` — this is intentional so the new page's models are initialized within the 0.65s window before navigation fires
- \`dismissNavigationPublisher\` and \`openedNavigationFieldID\` are \`internal\` — implementation details of the navigation system, not part of the public \`goto()\` API
- No public API surface changes. No docs update needed.