### PR TITLE
NO-1959: Path-scoped validation (validate(path:))

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		E225D1C92F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E225D1C82F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift */; };
 		E2459A7D2F442B4B000504A3 /* ColumnConditionalLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */; };
 		E254BF802D410F990083C3E4 /* ConditionLogicUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */; };
+		E26315E42F76AEA70008B89B /* ValidatePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26315E32F76AEA70008B89B /* ValidatePathTests.swift */; };
 		E26A54642DFADD04006E05E9 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = E26A54632DFADD04006E05E9 /* JoyfillModel */; };
 		E26A54662DFADD72006E05E9 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = E26A54652DFADD72006E05E9 /* JoyfillModel */; };
 		E27061C82E797E56006BAD18 /* TableViewModelDocumentEditorDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27061C72E797E56006BAD18 /* TableViewModelDocumentEditorDelegateTests.swift */; };
@@ -571,6 +572,7 @@
 		E225D1C82F3B19F3000674CF /* DocumentEditor+ChangeHandlerMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentEditor+ChangeHandlerMetadataTests.swift"; sourceTree = "<group>"; };
 		E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnConditionalLogicTests.swift; sourceTree = "<group>"; };
 		E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionLogicUnitTests.swift; sourceTree = "<group>"; };
+		E26315E32F76AEA70008B89B /* ValidatePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePathTests.swift; sourceTree = "<group>"; };
 		E27061C72E797E56006BAD18 /* TableViewModelDocumentEditorDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewModelDocumentEditorDelegateTests.swift; sourceTree = "<group>"; };
 		E27061C92E797E5F006BAD18 /* CollectionViewModelDocumentEditorDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewModelDocumentEditorDelegateTests.swift; sourceTree = "<group>"; };
 		E27061CB2E797E68006BAD18 /* DocumentEditor+ChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentEditor+ChangeHandlerTests.swift"; sourceTree = "<group>"; };
@@ -844,6 +846,7 @@
 				E2CC9FEC2E375DE500797331 /* SchemaValidation */,
 				E2B8E3BC2E4361DF00AC6018 /* Formula */,
 				0448AE082D0C45AD00754EA0 /* ValidationTestCase.swift */,
+				E26315E32F76AEA70008B89B /* ValidatePathTests.swift */,
 				36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */,
 				1307CF132BE1292900B19FBA /* JoyDoc+Assert.swift */,
 				E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */,
@@ -1975,6 +1978,7 @@
 				361164DA2DD70625003DEB4F /* WisdomTests.swift in Sources */,
 				1307CF122BE1290800B19FBA /* JoyDoc+DummyModel.swift in Sources */,
 				36F4DB782E6F394500C9AD4A /* LicenseValidatorTests.swift in Sources */,
+				E26315E42F76AEA70008B89B /* ValidatePathTests.swift in Sources */,
 				E2B8E3C42E436F3300AC6018 /* FormulaTemplate_MultiSelectFieldTests.swift in Sources */,
 				0448AE092D0C45AD00754EA0 /* ValidationTestCase.swift in Sources */,
 				134FC07A2BDA82E9008B7030 /* JoyfillTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
@@ -251,6 +251,21 @@ final class ValidatePathTests: XCTestCase {
         }
     }
 
+    // MARK: - Path page must own the field position
+
+    func testValidatePath_WrongPageIDWithValidFieldPositionID_FallsBackToPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "non-existent-page-id/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .page(let validation) = result {
+            XCTAssertEqual(validation.status, .valid)
+            XCTAssertTrue(validation.fieldValidities.isEmpty)
+        } else {
+            XCTFail("Expected .page when path page does not own the field position")
+        }
+    }
+
     // MARK: - 7. Required field without value → .invalid
 
     func testValidatePath_RequiredFieldWithoutValue_IsInvalid() {

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
@@ -1,0 +1,765 @@
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class ValidatePathTests: XCTestCase {
+
+    // MARK: - Known IDs (from existing test data builders)
+
+    let pageID            = "6629fab320fca7c8107a6cf6"
+    let imageFieldID      = "6629fab36e8925135f0cdd4f"
+    let imagePositionID   = "6629fab82ddb5cdd73a2f27f"
+    let textFieldID       = "6629fb1d92a76d06750ca4a1"
+    let textPositionID    = "6629fb203149d1c34cc6d6f8"
+    let multilineFieldID  = "6629fb2b9a487ce1c1f35f6c"
+    let multilinePositionID = "6629fb2fca14b3e2ef978349"
+
+    // MARK: - Helpers
+
+    func documentEditor(document: JoyDoc) -> DocumentEditor {
+        DocumentEditor(document: document, validateSchema: false)
+    }
+
+    func makeDocumentWithHiddenRequiredImageField() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithoutValue(hidden: true)
+            .setImageFieldPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    func makeDocumentWithTwoRequiredFields() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithoutValue()
+            .setImageFieldPositionInMobile()
+            .setRequiredTextFieldWithoutValue()
+            .setTextPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    func makeDocumentWithRequiredMultilineField(hasValue: Bool) -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+        let withField = hasValue
+            ? document.setRequiredMultilineTextFieldWithValue()
+            : document.setRequiredMultilineTextFieldWithoutValue()
+        return documentEditor(document: withField.setMultilinePositionInMobile())
+    }
+
+    func makeDocumentWithRequiredImageFieldWithoutValue() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithoutValue()
+            .setImageFieldPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    func makeDocumentWithRequiredImageFieldWithValue() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithValue()
+            .setImageFieldPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    func makeDocumentWithRequiredTextField(hasValue: Bool) -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+        let withField = hasValue
+            ? document.setRequiredTextFieldWithValue()
+            : document.setRequiredTextFieldWithoutValue()
+        return documentEditor(document: withField.setTextPositionInMobile())
+    }
+
+    func makeDocumentWithNonRequiredTextField() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setTextField()
+            .setTextPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    // MARK: - 1. Empty path → same result as validate()
+
+    func testValidatePath_EmptyPath_ReturnsDotPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: "")
+
+        if case .page(let validation) = result {
+            let full = editor.validate()
+            XCTAssertEqual(validation.status, full.status)
+            XCTAssertEqual(validation.fieldValidities.count, full.fieldValidities.count)
+        } else {
+            XCTFail("Expected .page for empty path")
+        }
+    }
+
+    func testValidatePath_EmptyPath_StatusMatchesFullValidate() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let pathResult = editor.validate(path: "")
+        let fullResult = editor.validate()
+
+        if case .page(let validation) = pathResult {
+            XCTAssertEqual(validation.status, fullResult.status)
+        } else {
+            XCTFail("Expected .page for empty path")
+        }
+    }
+
+    // MARK: - 2. Valid pageID only → .page scoped to that page
+
+    func testValidatePath_ValidPageID_ReturnsDotPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: pageID)
+
+        if case .page(let validation) = result {
+            XCTAssertEqual(validation.status, .invalid)
+            XCTAssertFalse(validation.fieldValidities.isEmpty)
+        } else {
+            XCTFail("Expected .page for valid pageID")
+        }
+    }
+
+    func testValidatePath_ValidPageID_FieldValiditiesOnlyBelongToThatPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: pageID)
+
+        if case .page(let validation) = result {
+            for fieldValidity in validation.fieldValidities {
+                XCTAssertEqual(fieldValidity.pageId, pageID)
+            }
+        } else {
+            XCTFail("Expected .page for valid pageID")
+        }
+    }
+
+    func testValidatePath_ValidPageID_IsSubsetOfFullValidate() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let fullValidation = editor.validate()
+        let result = editor.validate(path: pageID)
+
+        if case .page(let pageValidation) = result {
+            let fullIDs = Set(fullValidation.fieldValidities.compactMap { $0.fieldPositionId })
+            let pageIDs = Set(pageValidation.fieldValidities.compactMap { $0.fieldPositionId })
+            XCTAssertTrue(pageIDs.isSubset(of: fullIDs))
+        } else {
+            XCTFail("Expected .page for valid pageID")
+        }
+    }
+
+    // MARK: - 3. Non-existent pageID → .page with empty fieldValidities
+
+    func testValidatePath_NonExistentPageID_ReturnsEmptyValidation() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: "non-existent-page-id")
+
+        if case .page(let validation) = result {
+            XCTAssertEqual(validation.status, .valid)
+            XCTAssertTrue(validation.fieldValidities.isEmpty)
+        } else {
+            XCTFail("Expected .page for non-existent pageID")
+        }
+    }
+
+    // MARK: - 4. Valid pageId/fieldPositionId → .field(FieldValidity)
+
+    func testValidatePath_ValidFieldPositionID_ReturnsDotField() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.fieldPositionId, imagePositionID)
+        } else {
+            XCTFail("Expected .field for valid pageId/fieldPositionId")
+        }
+    }
+
+    func testValidatePath_ValidFieldPositionID_HasCorrectPageID() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.pageId, pageID)
+        } else {
+            XCTFail("Expected .field for valid pageId/fieldPositionId")
+        }
+    }
+
+    func testValidatePath_ValidFieldPositionID_HasCorrectFieldID() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.field.id, imageFieldID)
+        } else {
+            XCTFail("Expected .field for valid pageId/fieldPositionId")
+        }
+    }
+
+    // MARK: - 5. Non-existent fieldPositionId → falls back to .page
+
+    func testValidatePath_NonExistentFieldPositionID_FallsBackToPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/non-existent-position-id"
+        let result = editor.validate(path: path)
+
+        if case .page(_) = result {
+            // expected
+        } else {
+            XCTFail("Expected .page fallback for non-existent fieldPositionId")
+        }
+    }
+
+    // MARK: - 6. Extra depth path → falls back to .page (no crash)
+
+    func testValidatePath_ExtraDepthPath_DoesNotCrash() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)/future-row-id"
+        let result = editor.validate(path: path)
+
+        // maxSplits: 1 so "imagePositionID/future-row-id" is treated as unknown position
+        if case .page(_) = result {
+            // expected fallback
+        } else {
+            XCTFail("Expected .page fallback for over-depth path")
+        }
+    }
+
+    // MARK: - 7. Required field without value → .invalid
+
+    func testValidatePath_RequiredFieldWithoutValue_IsInvalid() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.status, .invalid)
+        } else {
+            XCTFail("Expected .field")
+        }
+    }
+
+    // MARK: - 8. Required field with value → .valid
+
+    func testValidatePath_RequiredFieldWithValue_IsValid() {
+        let editor = makeDocumentWithRequiredImageFieldWithValue()
+        let path = "\(pageID)/\(imagePositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.status, .valid)
+        } else {
+            XCTFail("Expected .field")
+        }
+    }
+
+    // MARK: - 9. Non-required field without value → .valid
+
+    func testValidatePath_NonRequiredFieldWithoutValue_IsValid() {
+        let editor = makeDocumentWithNonRequiredTextField()
+        let path = "\(pageID)/\(textPositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.status, .valid)
+        } else {
+            XCTFail("Expected .field")
+        }
+    }
+
+    // MARK: - 10. Text field — required without value → .invalid
+
+    func testValidatePath_RequiredTextFieldWithoutValue_IsInvalid() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: false)
+        let path = "\(pageID)/\(textPositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.status, .invalid)
+        } else {
+            XCTFail("Expected .field")
+        }
+    }
+
+    // MARK: - 11. Text field — required with value → .valid
+
+    func testValidatePath_RequiredTextFieldWithValue_IsValid() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: true)
+        let path = "\(pageID)/\(textPositionID)"
+        let result = editor.validate(path: path)
+
+        if case .field(let fieldValidity) = result {
+            XCTAssertEqual(fieldValidity.status, .valid)
+        } else {
+            XCTFail("Expected .field")
+        }
+    }
+
+    // MARK: - 12. validate(path: "") consistency with validate()
+
+    func testValidatePath_EmptyPath_FieldValiditiesCountMatchesFull() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let pathResult = editor.validate(path: "")
+        let fullResult = editor.validate()
+
+        if case .page(let validation) = pathResult {
+            XCTAssertEqual(validation.fieldValidities.count, fullResult.fieldValidities.count)
+        } else {
+            XCTFail("Expected .page")
+        }
+    }
+
+    func testValidatePath_EmptyPath_FieldPositionIDsMatchFull() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let pathResult = editor.validate(path: "")
+        let fullResult = editor.validate()
+
+        if case .page(let validation) = pathResult {
+            let pathPositionIDs = validation.fieldValidities.compactMap { $0.fieldPositionId }.sorted()
+            let fullPositionIDs = fullResult.fieldValidities.compactMap { $0.fieldPositionId }.sorted()
+            XCTAssertEqual(pathPositionIDs, fullPositionIDs)
+        } else {
+            XCTFail("Expected .page")
+        }
+    }
+
+    // MARK: - 13. getFieldIdentifier(forFieldPositionID:) — valid
+
+    func testGetFieldIdentifier_ForValidPositionID_ReturnsNonNil() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: imagePositionID)
+
+        XCTAssertNotNil(identifier)
+    }
+
+    func testGetFieldIdentifier_ForValidPositionID_HasCorrectFieldID() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: imagePositionID)
+
+        XCTAssertEqual(identifier?.fieldID, imageFieldID)
+    }
+
+    func testGetFieldIdentifier_ForValidPositionID_HasCorrectPageID() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: imagePositionID)
+
+        XCTAssertEqual(identifier?.pageID, pageID)
+    }
+
+    func testGetFieldIdentifier_ForValidPositionID_HasCorrectFieldPositionID() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: imagePositionID)
+
+        XCTAssertEqual(identifier?.fieldPositionId, imagePositionID)
+    }
+
+    // MARK: - 14. getFieldIdentifier(forFieldPositionID:) — invalid
+
+    func testGetFieldIdentifier_ForNonExistentPositionID_ReturnsNil() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: "non-existent-position-id")
+
+        XCTAssertNil(identifier)
+    }
+
+    // MARK: - 15. ComponentValidity enum — associated values are accessible
+
+    func testComponentValidity_PageCase_AssociatedValidationIsAccessible() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: pageID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page")
+            return
+        }
+        XCTAssertNotNil(validation)
+    }
+
+    func testComponentValidity_FieldCase_AssociatedFieldValidityIsAccessible() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: "\(pageID)/\(imagePositionID)")
+
+        guard case .field(let fieldValidity) = result else {
+            XCTFail("Expected .field")
+            return
+        }
+        XCTAssertNotNil(fieldValidity)
+    }
+
+    // MARK: - 16. Validate → update value → re-validate
+
+    // Helper: simulates a user entering a value into a field
+    @discardableResult
+    private func enterValue(into editor: DocumentEditor, fieldID: String, value: ValueUnion) -> DocumentEditor {
+        let fieldIdentifier = FieldIdentifier(fieldID: fieldID)
+        let event = FieldChangeData(fieldIdentifier: fieldIdentifier, updateValue: value)
+        editor.updateField(event: event, fieldIdentifier: fieldIdentifier)
+        return editor
+    }
+
+    private var sampleImageValue: ValueUnion {
+        let dict: [String: String] = [
+            "_id": "6629fad9a6d0c81c8c217fc5",
+            "url": "https://example.com/image.png",
+            "fileName": "image.png",
+            "filePath": "some/path"
+        ]
+        return .valueElementArray([ValueElement(dictionary: dict)])
+    }
+
+    // Image field: starts invalid → enter image → now valid
+    func testRevalidation_ImageField_InvalidThenFillThenValid() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let path = "\(pageID)/\(imagePositionID)"
+
+        // Step 1: confirm invalid before entering value
+        let before = editor.validate(path: path)
+        guard case .field(let beforeValidity) = before else {
+            XCTFail("Expected .field before update"); return
+        }
+        XCTAssertEqual(beforeValidity.status, .invalid)
+
+        // Step 2: enter a value
+        enterValue(into: editor, fieldID: imageFieldID, value: sampleImageValue)
+
+        // Step 3: re-validate — should now be valid
+        let after = editor.validate(path: path)
+        guard case .field(let afterValidity) = after else {
+            XCTFail("Expected .field after update"); return
+        }
+        XCTAssertEqual(afterValidity.status, .valid)
+    }
+
+    // Text field: starts invalid → enter text → now valid
+    func testRevalidation_TextField_InvalidThenFillThenValid() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: false)
+        let path = "\(pageID)/\(textPositionID)"
+
+        // Step 1: confirm invalid
+        let before = editor.validate(path: path)
+        guard case .field(let beforeValidity) = before else {
+            XCTFail("Expected .field before update"); return
+        }
+        XCTAssertEqual(beforeValidity.status, .invalid)
+
+        // Step 2: enter a value
+        enterValue(into: editor, fieldID: textFieldID, value: .string("Hello"))
+
+        // Step 3: re-validate — should now be valid
+        let after = editor.validate(path: path)
+        guard case .field(let afterValidity) = after else {
+            XCTFail("Expected .field after update"); return
+        }
+        XCTAssertEqual(afterValidity.status, .valid)
+    }
+
+    // Text field: starts valid → clear value → now invalid
+    func testRevalidation_TextField_ValidThenClearThenInvalid() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: true)
+        let path = "\(pageID)/\(textPositionID)"
+
+        // Step 1: confirm valid
+        let before = editor.validate(path: path)
+        guard case .field(let beforeValidity) = before else {
+            XCTFail("Expected .field before clear"); return
+        }
+        XCTAssertEqual(beforeValidity.status, .valid)
+
+        // Step 2: clear the value
+        enterValue(into: editor, fieldID: textFieldID, value: .string(""))
+
+        // Step 3: re-validate — should now be invalid
+        let after = editor.validate(path: path)
+        guard case .field(let afterValidity) = after else {
+            XCTFail("Expected .field after clear"); return
+        }
+        XCTAssertEqual(afterValidity.status, .invalid)
+    }
+
+    // Page scope: starts invalid → fix the field → page becomes valid
+    func testRevalidation_PageScope_InvalidThenFillFieldThenValid() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+
+        // Step 1: page is invalid
+        let before = editor.validate(path: pageID)
+        guard case .page(let beforeValidation) = before else {
+            XCTFail("Expected .page before update"); return
+        }
+        XCTAssertEqual(beforeValidation.status, .invalid)
+
+        // Step 2: enter a value for the image field
+        enterValue(into: editor, fieldID: imageFieldID, value: sampleImageValue)
+
+        // Step 3: page should now be valid
+        let after = editor.validate(path: pageID)
+        guard case .page(let afterValidation) = after else {
+            XCTFail("Expected .page after update"); return
+        }
+        XCTAssertEqual(afterValidation.status, .valid)
+    }
+
+    // Full validate(): starts invalid → fix field → overall becomes valid
+    func testRevalidation_FullValidate_InvalidThenFillFieldThenValid() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+
+        // Step 1: overall document is invalid
+        XCTAssertEqual(editor.validate().status, .invalid)
+
+        // Step 2: enter a value
+        enterValue(into: editor, fieldID: imageFieldID, value: sampleImageValue)
+
+        // Step 3: overall document should now be valid
+        XCTAssertEqual(editor.validate().status, .valid)
+    }
+
+    // validate(path:) and validate() stay in sync after update
+    func testRevalidation_PathAndFullValidate_StayInSyncAfterUpdate() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+
+        enterValue(into: editor, fieldID: imageFieldID, value: sampleImageValue)
+
+        let pathResult = editor.validate(path: "")
+        let fullResult = editor.validate()
+
+        guard case .page(let pathValidation) = pathResult else {
+            XCTFail("Expected .page from validate(path:)"); return
+        }
+        XCTAssertEqual(pathValidation.status, fullResult.status)
+    }
+
+    // MARK: - 17. Hidden required field is excluded from validation
+
+    // A hidden required field has no value but should not count as invalid
+    func testValidate_HiddenRequiredField_IsExcludedFromValidation() {
+        let editor = makeDocumentWithHiddenRequiredImageField()
+
+        let result = editor.validate()
+
+        XCTAssertEqual(result.status, .valid)
+        XCTAssertTrue(result.fieldValidities.isEmpty)
+    }
+
+    func testValidatePath_PageScope_HiddenRequiredField_PageIsValid() {
+        let editor = makeDocumentWithHiddenRequiredImageField()
+
+        let result = editor.validate(path: pageID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page"); return
+        }
+        XCTAssertEqual(validation.status, .valid)
+        XCTAssertTrue(validation.fieldValidities.isEmpty)
+    }
+
+    // MARK: - 18. Multiple required fields — partial fix keeps page invalid
+
+    func testValidatePath_TwoRequiredFields_BothMissing_PageIsInvalid() {
+        let editor = makeDocumentWithTwoRequiredFields()
+
+        let result = editor.validate(path: pageID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page"); return
+        }
+        XCTAssertEqual(validation.status, .invalid)
+        XCTAssertEqual(validation.fieldValidities.count, 2)
+    }
+
+    func testValidatePath_TwoRequiredFields_FixOnlyOne_PageStillInvalid() {
+        let editor = makeDocumentWithTwoRequiredFields()
+
+        // Fix only the text field
+        enterValue(into: editor, fieldID: textFieldID, value: .string("Hello"))
+
+        let result = editor.validate(path: pageID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page"); return
+        }
+        XCTAssertEqual(validation.status, .invalid)
+    }
+
+    func testValidatePath_TwoRequiredFields_FixBoth_PageBecomesValid() {
+        let editor = makeDocumentWithTwoRequiredFields()
+
+        // Fix both fields
+        enterValue(into: editor, fieldID: textFieldID, value: .string("Hello"))
+        enterValue(into: editor, fieldID: imageFieldID, value: sampleImageValue)
+
+        let result = editor.validate(path: pageID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page"); return
+        }
+        XCTAssertEqual(validation.status, .valid)
+    }
+
+    // MARK: - 19. Multiline field validation
+
+    func testValidatePath_RequiredMultilineField_WithoutValue_IsInvalid() {
+        let editor = makeDocumentWithRequiredMultilineField(hasValue: false)
+        let path = "\(pageID)/\(multilinePositionID)"
+
+        let result = editor.validate(path: path)
+
+        guard case .field(let fieldValidity) = result else {
+            XCTFail("Expected .field"); return
+        }
+        XCTAssertEqual(fieldValidity.status, .invalid)
+    }
+
+    func testValidatePath_RequiredMultilineField_WithValue_IsValid() {
+        let editor = makeDocumentWithRequiredMultilineField(hasValue: true)
+        let path = "\(pageID)/\(multilinePositionID)"
+
+        let result = editor.validate(path: path)
+
+        guard case .field(let fieldValidity) = result else {
+            XCTFail("Expected .field"); return
+        }
+        XCTAssertEqual(fieldValidity.status, .valid)
+    }
+
+    func testRevalidation_MultilineField_InvalidThenFillThenValid() {
+        let editor = makeDocumentWithRequiredMultilineField(hasValue: false)
+        let path = "\(pageID)/\(multilinePositionID)"
+
+        // Step 1: confirm invalid
+        let before = editor.validate(path: path)
+        guard case .field(let beforeValidity) = before else {
+            XCTFail("Expected .field before update"); return
+        }
+        XCTAssertEqual(beforeValidity.status, .invalid)
+
+        // Step 2: enter a value
+        enterValue(into: editor, fieldID: multilineFieldID, value: .string("Some text"))
+
+        // Step 3: re-validate — should now be valid
+        let after = editor.validate(path: path)
+        guard case .field(let afterValidity) = after else {
+            XCTFail("Expected .field after update"); return
+        }
+        XCTAssertEqual(afterValidity.status, .valid)
+    }
+
+    // MARK: - 20. getFieldIdentifier for other field types
+
+    func testGetFieldIdentifier_ForTextPositionID_ReturnsNonNil() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: false)
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: textPositionID)
+
+        XCTAssertNotNil(identifier)
+    }
+
+    func testGetFieldIdentifier_ForTextPositionID_HasCorrectFieldID() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: false)
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: textPositionID)
+
+        XCTAssertEqual(identifier?.fieldID, textFieldID)
+    }
+
+    func testGetFieldIdentifier_ForMultilinePositionID_ReturnsNonNil() {
+        let editor = makeDocumentWithRequiredMultilineField(hasValue: false)
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: multilinePositionID)
+
+        XCTAssertNotNil(identifier)
+    }
+
+    func testGetFieldIdentifier_ForMultilinePositionID_HasCorrectFieldID() {
+        let editor = makeDocumentWithRequiredMultilineField(hasValue: false)
+        let identifier = editor.getFieldIdentifier(forFieldPositionID: multilinePositionID)
+
+        XCTAssertEqual(identifier?.fieldID, multilineFieldID)
+    }
+
+    // MARK: - 21. ComponentValidity.fieldValidity computed property
+
+    // .page case → fieldValidity must be nil
+    func testComponentValidity_PageCase_FieldValidityIsNil() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: pageID)
+
+        XCTAssertNil(result.fieldValidity)
+    }
+
+    // .field case → fieldValidity must be non-nil and match
+    func testComponentValidity_FieldCase_FieldValidityIsNonNil() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: "\(pageID)/\(imagePositionID)")
+
+        XCTAssertNotNil(result.fieldValidity)
+    }
+
+    func testComponentValidity_FieldCase_FieldValidityMatchesDirectAccess() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: "\(pageID)/\(imagePositionID)")
+
+        guard case .field(let direct) = result else {
+            XCTFail("Expected .field"); return
+        }
+        XCTAssertEqual(result.fieldValidity?.fieldPositionId, direct.fieldPositionId)
+        XCTAssertEqual(result.fieldValidity?.status, direct.status)
+    }
+
+    // MARK: - 22. Edge case paths
+
+    // Bare fieldPositionID with no slash → treated as unknown pageID → empty .page
+    func testValidatePath_BarePositionID_NoSlash_ReturnsEmptyPage() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let result = editor.validate(path: imagePositionID)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page for bare positionID"); return
+        }
+        XCTAssertEqual(validation.status, .valid)
+        XCTAssertTrue(validation.fieldValidities.isEmpty)
+    }
+
+    // Page-level revalidation reverse: valid → clear field → page invalid
+    func testRevalidation_PageScope_ValidThenClearThenInvalid() {
+        let editor = makeDocumentWithRequiredTextField(hasValue: true)
+
+        // Step 1: page is valid
+        let before = editor.validate(path: pageID)
+        guard case .page(let beforeValidation) = before else {
+            XCTFail("Expected .page before clear"); return
+        }
+        XCTAssertEqual(beforeValidation.status, .valid)
+
+        // Step 2: clear the text value
+        enterValue(into: editor, fieldID: textFieldID, value: .string(""))
+
+        // Step 3: page should now be invalid
+        let after = editor.validate(path: pageID)
+        guard case .page(let afterValidation) = after else {
+            XCTFail("Expected .page after clear"); return
+        }
+        XCTAssertEqual(afterValidation.status, .invalid)
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
@@ -8,6 +8,8 @@ final class ValidatePathTests: XCTestCase {
     // MARK: - Known IDs (from existing test data builders)
 
     let pageID            = "6629fab320fca7c8107a6cf6"
+    /// Second page from `addSecondPage()` / `addSecondPageInMobileView()` in JoyDoc+DummyModel.
+    let secondPageID      = "second_page_id_12345"
     let imageFieldID      = "6629fab36e8925135f0cdd4f"
     let imagePositionID   = "6629fab82ddb5cdd73a2f27f"
     let textFieldID       = "6629fb1d92a76d06750ca4a1"
@@ -99,6 +101,20 @@ final class ValidatePathTests: XCTestCase {
             .setPageField()
             .setTextField()
             .setTextPositionInMobile()
+        return documentEditor(document: document)
+    }
+
+    /// First page has required image (mobile layout); a real second page exists so paths can use a wrong but existing `pageId`.
+    func makeDocumentWithRequiredImageFirstPageAndSecondPage() -> DocumentEditor {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithoutValue()
+            .setImageFieldPositionInMobile()
+            .addSecondPage()
+            .addSecondPageInMobileView()
         return documentEditor(document: document)
     }
 
@@ -264,6 +280,33 @@ final class ValidatePathTests: XCTestCase {
         } else {
             XCTFail("Expected .page when path page does not own the field position")
         }
+    }
+
+    /// Locks `fieldIdentifier.pageID == pageId` prefix: position exists on page 1 but path uses another real page id → `.page` for that other page, not `.field` for the image on page 1.
+    func testValidatePath_RealOtherPageIDWithPositionFromFirstPage_FallsBackToPage() {
+        let editor = makeDocumentWithRequiredImageFirstPageAndSecondPage()
+
+        let correctPath = "\(pageID)/\(imagePositionID)"
+        guard case .field(let fieldValidityForCorrectPath) = editor.validate(path: correctPath) else {
+            XCTFail("Sanity check: valid page + position should return .field"); return
+        }
+        XCTAssertEqual(fieldValidityForCorrectPath.fieldPositionId, imagePositionID)
+        XCTAssertEqual(fieldValidityForCorrectPath.pageId, pageID)
+
+        let wrongPath = "\(secondPageID)/\(imagePositionID)"
+        let result = editor.validate(path: wrongPath)
+
+        guard case .page(let validation) = result else {
+            XCTFail("Expected .page fallback when path page id does not own the field position, got \(result)"); return
+        }
+        XCTAssertFalse(
+            validation.fieldValidities.contains { $0.fieldPositionId == imagePositionID },
+            "Page-scoped result must not include the field position from another page"
+        )
+        XCTAssertFalse(
+            validation.fieldValidities.contains { $0.field.id == imageFieldID },
+            "Page-scoped result must not validate page-1 image under wrong page prefix"
+        )
     }
 
     // MARK: - 7. Required field without value → .invalid

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift
@@ -145,6 +145,33 @@ final class ValidatePathTests: XCTestCase {
         }
     }
 
+    func testValidatePath_WhitespaceOnly_TreatedAsEmptyPath() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let pathResult = editor.validate(path: "  \n\t  ")
+        let fullResult = editor.validate()
+
+        if case .page(let validation) = pathResult {
+            XCTAssertEqual(validation.status, fullResult.status)
+            XCTAssertEqual(validation.fieldValidities.count, fullResult.fieldValidities.count)
+        } else {
+            XCTFail("Expected .page for whitespace-only path")
+        }
+    }
+
+    func testValidatePath_TrimsSurroundingAndSegmentWhitespace() {
+        let editor = makeDocumentWithRequiredImageFieldWithoutValue()
+        let trimmedEquivalent = " \(pageID) / \(imagePositionID) \n"
+        let tight = "\(pageID)/\(imagePositionID)"
+
+        guard case .field(let a) = editor.validate(path: trimmedEquivalent),
+              case .field(let b) = editor.validate(path: tight) else {
+            XCTFail("Expected .field for both paths"); return
+        }
+        XCTAssertEqual(a.fieldPositionId, b.fieldPositionId)
+        XCTAssertEqual(a.pageId, b.pageId)
+        XCTAssertEqual(a.status, b.status)
+    }
+
     // MARK: - 2. Valid pageID only → .page scoped to that page
 
     func testValidatePath_ValidPageID_ReturnsDotPage() {

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -161,7 +161,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fab82ddb5cdd73a2f27f").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid image field - result - valid
@@ -185,7 +185,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fab82ddb5cdd73a2f27f").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Text Field - Result - InValid
@@ -209,7 +209,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb203149d1c34cc6d6f8").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Text Field - Result - Valid
@@ -233,7 +233,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb203149d1c34cc6d6f8").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Multiline Field - Result - InValid
@@ -257,7 +257,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb2fca14b3e2ef978349")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb2fca14b3e2ef978349").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Multiline Field - Result - Valid
@@ -281,7 +281,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb2fca14b3e2ef978349")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb2fca14b3e2ef978349").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Number Field - Result - InValid
@@ -304,7 +304,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb3df03de10b26270ab3")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb3f2eff74a9ca322bb5").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Number Field - Result - Valid
@@ -327,7 +327,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb3df03de10b26270ab3")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb3f2eff74a9ca322bb5").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Date Field - Result - InValid
@@ -350,7 +350,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb44c79bb16ce072d233")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb4451f3bf2eb2f46567").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Date Field - Result - Valid
@@ -373,7 +373,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb44c79bb16ce072d233")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb4451f3bf2eb2f46567").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Time Field - Result - InValid
@@ -396,7 +396,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb638e230f348d0a8682")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb66420b995d026e480b").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Time Field - Result - Valid
@@ -419,7 +419,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb638e230f348d0a8682")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb66420b995d026e480b").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid dateTime Field - Result - InValid
@@ -442,7 +442,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb6ec5d88d3aadf548ca")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb749d0c1af5e94dbac7").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid dateTime Field - Result - Valid
@@ -465,7 +465,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb6ec5d88d3aadf548ca")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb749d0c1af5e94dbac7").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Dropdown Field - Result - InValid
@@ -488,7 +488,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb77593e3791638628bb")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb77593e3791638628bb")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb8ea500024170241af3").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Dropdown Field - Result - Valid
@@ -511,7 +511,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb77593e3791638628bb")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb77593e3791638628bb")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb8ea500024170241af3").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Multiselect Field - Result - InValid
@@ -534,7 +534,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb9f4d912053577652b1")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb06e14e0bcaeabf05b").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Multiselect Field - Result - Valid
@@ -557,7 +557,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb9f4d912053577652b1")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb06e14e0bcaeabf05b").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Single Field - Result - InValid
@@ -580,7 +580,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb2bf4f965b9d04f153")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb5daa40d68bf26525f").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Single Field - Result - Valid
@@ -603,7 +603,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb2bf4f965b9d04f153")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb5daa40d68bf26525f").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Signature Field - Result - InValid
@@ -626,7 +626,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb8cd16c0c4d308a252")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbbc88ec687f865a53da").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Signature Field - Result - Valid
@@ -649,7 +649,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb8cd16c0c4d308a252")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbbc88ec687f865a53da").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Chart Field - Result - InValid
@@ -672,7 +672,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbd957d928a973b1b42b")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbddabbd2a54f548bb95").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Chart Field - Result - Valid
@@ -695,7 +695,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbd957d928a973b1b42b")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbddabbd2a54f548bb95").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Hidden Field Test cases - result always - valid
@@ -721,7 +721,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa2520173f61daed286798").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredHiddenNumberFieldWithValue() {
@@ -746,7 +746,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa2520173f61daed286798").fieldValidity?.status, validationResult.fieldValidities.first?.status)
 
     }
 
@@ -774,7 +774,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
         XCTAssertEqual(validationResult.fieldValidities[1].status, .invalid)
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")?.status, validationResult.fieldValidities[1].status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa29136c6f17d56a2d9f67").fieldValidity?.status, validationResult.fieldValidities[1].status)
     }
 
     func testRequiredShowHiddenFieldWithValue() {
@@ -801,7 +801,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
         XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")?.status, validationResult.fieldValidities[1].status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa29136c6f17d56a2d9f67").fieldValidity?.status, validationResult.fieldValidities[1].status)
 
     }
 
@@ -828,8 +828,8 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
-        XCTAssertNil(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c"), "Field hidden by conditional logic should return nil")
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa2520173f61daed286798").fieldValidity?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertNil(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa29136c6f17d56a2d9f67").fieldValidity, "Field hidden by conditional logic should return nil")
     }
 
     func testRequiredHideNumberFieldWithValues() {
@@ -856,8 +856,8 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
 //        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
 //        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
-        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
-        XCTAssertNil(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c"), "Field hidden by conditional logic should return nil")
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa2520173f61daed286798").fieldValidity?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertNil(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa29136c6f17d56a2d9f67").fieldValidity, "Field hidden by conditional logic should return nil")
 
     }
 
@@ -878,7 +878,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     //Zero columns
@@ -899,7 +899,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Zero rows
@@ -920,7 +920,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     // table is required , columns are required , cells are empty should be invalid
@@ -941,7 +941,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredTableFieldIfHidden() {
@@ -961,7 +961,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testNonRequiredTableField() {
@@ -982,7 +982,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testNonRequiredTableField_RowValiditiesPopulated() {
@@ -1011,7 +1011,7 @@ final class ValidationTestCase: XCTestCase {
             XCTAssertEqual(row.cellValidities.count, 3)
             XCTAssertTrue(row.cellValidities.allSatisfy { $0.status == .valid })
         }
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredTableFieldNonRequiredColumns() {
@@ -1031,7 +1031,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertEqual(documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity?.status, validationResult.fieldValidities.first?.status)
     }
 
         // Test Case for duplicate the page
@@ -1360,7 +1360,7 @@ final class ValidationTestCase: XCTestCase {
         }
     }
 
-    // MARK: - validate(fieldID:) Tests
+    // MARK: - validate(path:) Tests
 
     // Unknown fieldID → nil
     func testValidateSingleFieldID_unknownFieldID_returnsNil() {
@@ -1375,7 +1375,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "nonexistent_field_id")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/nonexistent_position_id").fieldValidity
 
         XCTAssertNil(result, "Unknown fieldID should return nil")
     }
@@ -1396,7 +1396,7 @@ final class ValidationTestCase: XCTestCase {
             .setSingleSelectPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/66aa29136c6f17d56a2d9f67").fieldValidity
 
         XCTAssertNil(result, "A field hidden by conditional logic should return nil")
     }
@@ -1428,7 +1428,7 @@ final class ValidationTestCase: XCTestCase {
         document.files = [file]
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "nr_text_001")
+        let result = documentEditor.validate(path: "page_nr_1/fp_nr_001").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1436,7 +1436,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(result?.pageId, "page_nr_1")
     }
 
-    // Cross-check: validate(fieldID:) matches corresponding entry in validate()
+    // Cross-check: validate(path:) matches corresponding entry in validate()
     func testValidateSingleFieldID_result_matchesFullValidation() {
         let fieldID = "6629fb1d92a76d06750ca4a1"
         let document = JoyDoc()
@@ -1451,7 +1451,7 @@ final class ValidationTestCase: XCTestCase {
 
         let documentEditor = documentEditor(document: document)
         let fullValidation = documentEditor.validate()
-        let singleResult = documentEditor.validate(fieldID: fieldID)
+        let singleResult = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb203149d1c34cc6d6f8").fieldValidity
 
         let matching = fullValidation.fieldValidities.first(where: { $0.fieldId == fieldID })
         XCTAssertNotNil(singleResult, "Single-field result should not be nil for a known field")
@@ -1475,7 +1475,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fab82ddb5cdd73a2f27f").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1496,7 +1496,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fab82ddb5cdd73a2f27f").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1519,7 +1519,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb203149d1c34cc6d6f8").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1540,7 +1540,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb203149d1c34cc6d6f8").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1563,7 +1563,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb2fca14b3e2ef978349").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1584,7 +1584,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb2fca14b3e2ef978349").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1607,7 +1607,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb3f2eff74a9ca322bb5").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1627,7 +1627,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb3f2eff74a9ca322bb5").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1649,7 +1649,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb4451f3bf2eb2f46567").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1669,7 +1669,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb4451f3bf2eb2f46567").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1691,7 +1691,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb66420b995d026e480b").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1711,7 +1711,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb66420b995d026e480b").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1733,7 +1733,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb749d0c1af5e94dbac7").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1753,7 +1753,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb749d0c1af5e94dbac7").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1775,7 +1775,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb77593e3791638628bb")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb8ea500024170241af3").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1795,7 +1795,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb77593e3791638628bb")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fb8ea500024170241af3").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1817,7 +1817,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb06e14e0bcaeabf05b").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1837,7 +1837,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb06e14e0bcaeabf05b").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1859,7 +1859,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb5daa40d68bf26525f").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1879,7 +1879,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbb5daa40d68bf26525f").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1901,7 +1901,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbbc88ec687f865a53da").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1921,7 +1921,7 @@ final class ValidationTestCase: XCTestCase {
             .setChartPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbbc88ec687f865a53da").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1943,7 +1943,7 @@ final class ValidationTestCase: XCTestCase {
             .setSingleSelectPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbddabbd2a54f548bb95").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -1963,7 +1963,7 @@ final class ValidationTestCase: XCTestCase {
             .setSingleSelectPosition()
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbddabbd2a54f548bb95").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -1984,7 +1984,7 @@ final class ValidationTestCase: XCTestCase {
             .setTableFieldPosition(hideColumn: false)
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)
@@ -2004,7 +2004,7 @@ final class ValidationTestCase: XCTestCase {
             .setTableFieldPosition(hideColumn: false)
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .valid)
@@ -2024,7 +2024,7 @@ final class ValidationTestCase: XCTestCase {
             .setTableFieldPosition(hideColumn: false)
 
         let documentEditor = documentEditor(document: document)
-        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+        let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/6629fbc736d179b9014abae0").fieldValidity
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.status, .invalid)

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -1362,8 +1362,8 @@ final class ValidationTestCase: XCTestCase {
 
     // MARK: - validate(path:) Tests
 
-    // Unknown fieldID → nil
-    func testValidateSingleFieldID_unknownFieldID_returnsNil() {
+    // Unknown field position id in path → fieldValidity is nil
+    func testValidatePath_unknownFieldPositionId_fieldValidityIsNil() {
         let document = JoyDoc()
             .setFile()
             .setMobileView()
@@ -1377,7 +1377,7 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let result = documentEditor.validate(path: "6629fab320fca7c8107a6cf6/nonexistent_position_id").fieldValidity
 
-        XCTAssertNil(result, "Unknown fieldID should return nil")
+        XCTAssertNil(result, "Unknown field position id should not produce fieldValidity")
     }
 
     // Hidden-by-logic field → nil

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -161,6 +161,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid image field - result - valid
@@ -184,6 +185,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Text Field - Result - InValid
@@ -207,6 +209,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Text Field - Result - Valid
@@ -230,6 +233,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Multiline Field - Result - InValid
@@ -253,6 +257,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb2fca14b3e2ef978349")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Multiline Field - Result - Valid
@@ -276,6 +281,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities.first?.fieldPositionId, "6629fb2fca14b3e2ef978349")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Number Field - Result - InValid
@@ -298,6 +304,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb3df03de10b26270ab3")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Number Field - Result - Valid
@@ -320,6 +327,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb3df03de10b26270ab3")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Date Field - Result - InValid
@@ -342,6 +350,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb44c79bb16ce072d233")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Date Field - Result - Valid
@@ -364,6 +373,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb44c79bb16ce072d233")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Time Field - Result - InValid
@@ -386,6 +396,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb638e230f348d0a8682")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Time Field - Result - Valid
@@ -408,6 +419,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb638e230f348d0a8682")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid dateTime Field - Result - InValid
@@ -430,6 +442,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb6ec5d88d3aadf548ca")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid dateTime Field - Result - Valid
@@ -452,6 +465,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb6ec5d88d3aadf548ca")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Dropdown Field - Result - InValid
@@ -474,6 +488,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb77593e3791638628bb")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb77593e3791638628bb")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Dropdown Field - Result - Valid
@@ -496,6 +511,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb77593e3791638628bb")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb77593e3791638628bb")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Multiselect Field - Result - InValid
@@ -518,6 +534,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb9f4d912053577652b1")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Multiselect Field - Result - Valid
@@ -540,6 +557,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fb9f4d912053577652b1")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Single Field - Result - InValid
@@ -562,6 +580,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb2bf4f965b9d04f153")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Single Field - Result - Valid
@@ -584,6 +603,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb2bf4f965b9d04f153")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Signature Field - Result - InValid
@@ -606,6 +626,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb8cd16c0c4d308a252")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Signature Field - Result - Valid
@@ -628,6 +649,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbb8cd16c0c4d308a252")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Invalid Chart Field - Result - InValid
@@ -650,6 +672,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbd957d928a973b1b42b")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Valid Chart Field - Result - Valid
@@ -672,6 +695,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "6629fbd957d928a973b1b42b")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Hidden Field Test cases - result always - valid
@@ -697,6 +721,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredHiddenNumberFieldWithValue() {
@@ -721,7 +746,8 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
-        
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
+
     }
 
     // Show Hidden Field Test Cases
@@ -748,6 +774,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
         XCTAssertEqual(validationResult.fieldValidities[1].status, .invalid)
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")?.status, validationResult.fieldValidities[1].status)
     }
 
     func testRequiredShowHiddenFieldWithValue() {
@@ -774,6 +801,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
         XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
         XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")?.status, validationResult.fieldValidities[1].status)
 
     }
 
@@ -800,6 +828,8 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "66aa2865da10ac1c7b7acb1d")
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertNil(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c"), "Field hidden by conditional logic should return nil")
     }
 
     func testRequiredHideNumberFieldWithValues() {
@@ -826,9 +856,11 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
 //        XCTAssertEqual(validationResult.fieldValidities[1].field.id, "66aa28f805a4900ae643db9c")
 //        XCTAssertEqual(validationResult.fieldValidities[1].status, .valid)
-        
+        XCTAssertEqual(documentEditor.validate(fieldID: "66aa2865da10ac1c7b7acb1d")?.status, validationResult.fieldValidities.first?.status)
+        XCTAssertNil(documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c"), "Field hidden by conditional logic should return nil")
+
     }
-    
+
     func testRequiredTableField() {
         let document = JoyDoc()
             .setDocument()
@@ -846,6 +878,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     //Zero columns
@@ -866,6 +899,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // Zero rows
@@ -886,6 +920,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     // table is required , columns are required , cells are empty should be invalid
@@ -906,6 +941,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredTableFieldIfHidden() {
@@ -925,6 +961,7 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testNonRequiredTableField() {
@@ -940,11 +977,12 @@ final class ValidationTestCase: XCTestCase {
         let documentEditor = documentEditor(document: document)
         let validationResult = documentEditor.validate()
         //if table/collection is not required , but some internal things are req and not filled , whole table is invalid
-        
+
         XCTAssertEqual(validationResult.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .invalid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testNonRequiredTableField_RowValiditiesPopulated() {
@@ -973,6 +1011,7 @@ final class ValidationTestCase: XCTestCase {
             XCTAssertEqual(row.cellValidities.count, 3)
             XCTAssertTrue(row.cellValidities.allSatisfy { $0.status == .valid })
         }
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
 
     func testRequiredTableFieldNonRequiredColumns() {
@@ -992,8 +1031,9 @@ final class ValidationTestCase: XCTestCase {
         XCTAssertEqual(validationResult.fieldValidities.first?.status, .valid)
         XCTAssertEqual(validationResult.fieldValidities.first?.field.id, "67612793c4e6a5e6a05e64a3")
         XCTAssertEqual(validationResult.fieldValidities.first?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")?.status, validationResult.fieldValidities.first?.status)
     }
-        
+
         // Test Case for duplicate the page
         func testPageDuplication() {
             let document = JoyDoc()
@@ -1309,6 +1349,680 @@ final class ValidationTestCase: XCTestCase {
             XCTAssertNotNil(changeDict["page"], "page.create change should include page.")
             XCTAssertNotNil(changeDict["targetIndex"], "page.create change should include targetIndex.")
         }
+    }
+
+    // MARK: - validate(fieldID:) Tests
+
+    // Unknown fieldID → nil
+    func testValidateSingleFieldID_unknownFieldID_returnsNil() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTextFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTextPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "nonexistent_field_id")
+
+        XCTAssertNil(result, "Unknown fieldID should return nil")
+    }
+
+    // Hidden-by-logic field → nil
+    func testValidateSingleFieldID_hiddenByLogicField_returnsNil() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTextField()
+            .setRequiredHideNumberFieldByLogicWithoutValue()
+            .setRequiredSingleChoiceFieldWithoutValue()
+            .setRequiredTextFieldInMobile()
+            .setRequiredHideNumberFieldByLogicWithoutValuePositionInMobile()
+            .setSingleSelectPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "66aa28f805a4900ae643db9c")
+
+        XCTAssertNil(result, "A field hidden by conditional logic should return nil")
+    }
+
+    // Non-required field without value → valid (not nil)
+    func testValidateSingleFieldID_nonRequiredField_withoutValue_isValid() {
+        var field = JoyDocField()
+        field.id = "nr_text_001"
+        field.fieldType = .text
+        field.required = false
+        field.value = nil
+        field.file = "file_nr_1"
+
+        var fp = FieldPosition()
+        fp.id = "fp_nr_001"
+        fp.field = "nr_text_001"
+
+        var page = Page()
+        page.id = "page_nr_1"
+        page.fieldPositions = [fp]
+
+        var file = File()
+        file.id = "file_nr_1"
+        file.pages = [page]
+        file.pageOrder = ["page_nr_1"]
+
+        var document = JoyDoc()
+        document.fields = [field]
+        document.files = [file]
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "nr_text_001")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "nr_text_001")
+        XCTAssertEqual(result?.pageId, "page_nr_1")
+    }
+
+    // Cross-check: validate(fieldID:) matches corresponding entry in validate()
+    func testValidateSingleFieldID_result_matchesFullValidation() {
+        let fieldID = "6629fb1d92a76d06750ca4a1"
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTextFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTextPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let fullValidation = documentEditor.validate()
+        let singleResult = documentEditor.validate(fieldID: fieldID)
+
+        let matching = fullValidation.fieldValidities.first(where: { $0.fieldId == fieldID })
+        XCTAssertNotNil(singleResult, "Single-field result should not be nil for a known field")
+        XCTAssertEqual(singleResult?.status, matching?.status)
+        XCTAssertEqual(singleResult?.fieldId, matching?.fieldId)
+        XCTAssertEqual(singleResult?.pageId, matching?.pageId)
+        XCTAssertEqual(singleResult?.fieldPositionId, matching?.fieldPositionId)
+    }
+
+    // MARK: Image Field
+
+    func testValidateSingleFieldID_requiredImageField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setImageFieldPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fab36e8925135f0cdd4f")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
+    }
+
+    func testValidateSingleFieldID_requiredImageField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredImagefieldsWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setImageFieldPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fab36e8925135f0cdd4f")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fab36e8925135f0cdd4f")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fab82ddb5cdd73a2f27f")
+    }
+
+    // MARK: Text Field
+
+    func testValidateSingleFieldID_requiredTextField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTextFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTextPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb1d92a76d06750ca4a1")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
+    }
+
+    func testValidateSingleFieldID_requiredTextField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTextFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTextPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb1d92a76d06750ca4a1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb1d92a76d06750ca4a1")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fb203149d1c34cc6d6f8")
+    }
+
+    // MARK: Multiline Field
+
+    func testValidateSingleFieldID_requiredMultilineTextField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredMultilineTextFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setMultilinePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb2b9a487ce1c1f35f6c")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fb2fca14b3e2ef978349")
+    }
+
+    func testValidateSingleFieldID_requiredMultilineTextField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredMultilineTextFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setMultilinePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb2b9a487ce1c1f35f6c")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb2b9a487ce1c1f35f6c")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.fieldPositionId, "6629fb2fca14b3e2ef978349")
+    }
+
+    // MARK: Number Field
+
+    func testValidateSingleFieldID_requiredNumberField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredNumberFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setNumberPosition()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb3df03de10b26270ab3")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredNumberField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredNumberFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setNumberPosition()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb3df03de10b26270ab3")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb3df03de10b26270ab3")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Date Field
+
+    func testValidateSingleFieldID_requiredDateField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDateFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDatePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb44c79bb16ce072d233")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredDateField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDateFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDatePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb44c79bb16ce072d233")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb44c79bb16ce072d233")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Time Field
+
+    func testValidateSingleFieldID_requiredTimeField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTimeFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTimePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb638e230f348d0a8682")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredTimeField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTimeFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setTimePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb638e230f348d0a8682")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb638e230f348d0a8682")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: DateTime Field
+
+    func testValidateSingleFieldID_requiredDateTimeField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDateTimeFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDateTimePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb6ec5d88d3aadf548ca")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredDateTimeField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDateTimeFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDateTimePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb6ec5d88d3aadf548ca")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb6ec5d88d3aadf548ca")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Dropdown Field
+
+    func testValidateSingleFieldID_requiredDropdownField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDropdownFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDropdownPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb77593e3791638628bb")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb77593e3791638628bb")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredDropdownField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredDropdownFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setDropdownPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb77593e3791638628bb")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb77593e3791638628bb")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: MultiSelect Field
+
+    func testValidateSingleFieldID_requiredMultiSelectField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredMultipleChoiceFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setMultiselectPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fb9f4d912053577652b1")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredMultiSelectField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredMultipleChoiceFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setMultiselectPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fb9f4d912053577652b1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fb9f4d912053577652b1")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: SingleChoice Field
+
+    func testValidateSingleFieldID_requiredSingleChoiceField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredSingleChoiceFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setSingleSelectPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fbb2bf4f965b9d04f153")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredSingleChoiceField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredSingleChoiceFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setSingleSelectPositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbb2bf4f965b9d04f153")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fbb2bf4f965b9d04f153")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Signature Field
+
+    func testValidateSingleFieldID_requiredSignatureField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredSignatureFieldWithoutValue()
+            .setRequiredChartFieldWithoutValue()
+            .setSignaturePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fbb8cd16c0c4d308a252")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredSignatureField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredSignatureFieldWithValue()
+            .setRequiredChartFieldWithoutValue()
+            .setSignaturePositionInMobile()
+            .setChartPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbb8cd16c0c4d308a252")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fbb8cd16c0c4d308a252")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Chart Field
+
+    func testValidateSingleFieldID_requiredChartField_withoutValue_isInvalid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredChartFieldWithoutValue()
+            .setRequiredSingleChoiceFieldWithoutValue()
+            .setChartPositionInMobile()
+            .setSingleSelectPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "6629fbd957d928a973b1b42b")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    func testValidateSingleFieldID_requiredChartField_withValue_isValid() {
+        let document = JoyDoc()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredChartFieldWithValue()
+            .setRequiredSingleChoiceFieldWithoutValue()
+            .setChartPositionInMobile()
+            .setSingleSelectPosition()
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "6629fbd957d928a973b1b42b")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "6629fbd957d928a973b1b42b")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+    }
+
+    // MARK: Table Field
+
+    func testValidateSingleFieldID_requiredTableField_zeroRows_isInvalid() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTableField(hideColumn: false, isTableRequired: true, isColumnRequired: true, areCellsEmpty: false, isZeroRows: true, isColumnsZero: false, isRowOrderNil: false)
+            .setTableFieldPosition(hideColumn: false)
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "67612793c4e6a5e6a05e64a3")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertEqual(result?.rowValidities?.count, 0)
+    }
+
+    func testValidateSingleFieldID_tableField_nonRequiredColumns_isValid() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTableField(hideColumn: false, isTableRequired: true, isColumnRequired: false, areCellsEmpty: false, isZeroRows: false, isColumnsZero: false, isRowOrderNil: false)
+            .setTableFieldPosition(hideColumn: false)
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .valid)
+        XCTAssertEqual(result?.fieldId, "67612793c4e6a5e6a05e64a3")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        XCTAssertNotNil(result?.rowValidities)
+    }
+
+    func testValidateSingleFieldID_tableField_withRequiredEmptyCells_isInvalid() {
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setRequiredTableField(hideColumn: false, isTableRequired: true, isColumnRequired: true, areCellsEmpty: true, isZeroRows: false, isColumnsZero: false, isRowOrderNil: false)
+            .setTableFieldPosition(hideColumn: false)
+
+        let documentEditor = documentEditor(document: document)
+        let result = documentEditor.validate(fieldID: "67612793c4e6a5e6a05e64a3")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, .invalid)
+        XCTAssertEqual(result?.fieldId, "67612793c4e6a5e6a05e64a3")
+        XCTAssertEqual(result?.pageId, "6629fab320fca7c8107a6cf6")
+        let invalidRows = result?.rowValidities?.filter { $0.status == .invalid } ?? []
+        XCTAssertFalse(invalidRows.isEmpty, "Should have at least one invalid row when required cells are empty")
     }
 
     /// isPageDuplicateEnabled is false in readonly mode; true when explicitly enabled in fill mode.

--- a/Sources/JoyfillModel/Validator.swift
+++ b/Sources/JoyfillModel/Validator.swift
@@ -65,3 +65,15 @@ public struct FieldValidity {
         self.rowValidities = rowValidities
     }
 }
+
+public enum ComponentValidity {
+    case page(Validation)
+    case field(FieldValidity)
+    case row(RowValidity)      // future
+    case cell(CellValidity)    // future
+
+    public var fieldValidity: FieldValidity? {
+        if case .field(let fv) = self { return fv }
+        return nil
+    }
+}

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -155,9 +155,28 @@ public class DocumentEditor: ObservableObject {
         return validationHandler.validate()
     }
 
-    public func validate(fieldID: String) -> FieldValidity? {
-        let fieldIdentifier = getFieldIdentifier(for: fieldID)
-        return validationHandler.validate(fieldIdentifier: fieldIdentifier)
+    /// Validates based on a path string, returning a result scoped to the path depth.
+    /// - `""`: validates all pages and fields → `.page(Validation)`
+    /// - `"pageId"`: validates all fields on the given page → `.page(Validation)`
+    /// - `"pageId/fieldPositionId"`: validates the specific field → `.field(FieldValidity)`
+    public func validate(path: String) -> ComponentValidity {
+        guard !path.isEmpty else {
+            return .page(validationHandler.validate())
+        }
+
+        let components = path.split(separator: "/", maxSplits: 1).map(String.init)
+        let pageID = components[0]
+
+        if components.count == 1 {
+            return .page(validationHandler.validate(pageID: pageID))
+        }
+
+        let fieldPositionID = components[1]
+        if let fieldIdentifier = getFieldIdentifier(forFieldPositionID: fieldPositionID),
+           let fieldValidity = validationHandler.validate(fieldIdentifier: fieldIdentifier) {
+            return .field(fieldValidity)
+        }
+        return .page(validationHandler.validate(pageID: pageID))
     }
     
     public func shouldShow(fieldID: String?) -> Bool {
@@ -495,6 +514,17 @@ extension DocumentEditor {
         }
 
         return FieldIdentifier(_id: documentID, identifier: documentIdentifier, fieldID: fieldID, fieldIdentifier: fieldIdentifier, fileID: fileID)
+    }
+
+    public func getFieldIdentifier(forFieldPositionID fieldPositionID: String) -> FieldIdentifier? {
+        for page in pagesForCurrentView {
+            if let position = page.fieldPositions?.first(where: { $0.id == fieldPositionID }),
+               let fieldID = position.field {
+                let field = field(fieldID: fieldID)
+                return FieldIdentifier(_id: documentID, identifier: documentIdentifier, fieldID: fieldID, fieldIdentifier: field?.identifier, pageID: page.id, fileID: field?.file, fieldPositionId: position.id)
+            }
+        }
+        return nil
     }
 }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -156,16 +156,23 @@ public class DocumentEditor: ObservableObject {
     }
 
     /// Validates based on a path string, returning a result scoped to the path depth.
-    /// - `""`: validates all pages and fields → `.page(Validation)`
+    /// - `""` (or only whitespace): validates all pages and fields → `.page(Validation)`
     /// - `"pageId"`: validates all fields on the given page → `.page(Validation)`
     /// - `"pageId/fieldPositionId"`: validates the specific field → `.field(FieldValidity)` only when `pageId` matches the page that contains that field position; otherwise falls back to `.page` for `pageId`.
+    /// - Parameter path: Leading, trailing, and segment-adjacent whitespace (per segment) are ignored; other characters must match ids exactly.
     public func validate(path: String) -> ComponentValidity {
-        guard !path.isEmpty else {
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else {
             return .page(validationHandler.validate())
         }
 
-        let components = path.split(separator: "/", maxSplits: 1).map(String.init)
+        let components = trimmedPath.split(separator: "/", maxSplits: 1).map {
+            String($0).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         let pageID = components[0]
+        guard !pageID.isEmpty else {
+            return .page(validationHandler.validate())
+        }
 
         if components.count == 1 {
             return .page(validationHandler.validate(pageID: pageID))

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -158,7 +158,7 @@ public class DocumentEditor: ObservableObject {
     /// Validates based on a path string, returning a result scoped to the path depth.
     /// - `""`: validates all pages and fields → `.page(Validation)`
     /// - `"pageId"`: validates all fields on the given page → `.page(Validation)`
-    /// - `"pageId/fieldPositionId"`: validates the specific field → `.field(FieldValidity)`
+    /// - `"pageId/fieldPositionId"`: validates the specific field → `.field(FieldValidity)` only when `pageId` matches the page that contains that field position; otherwise falls back to `.page` for `pageId`.
     public func validate(path: String) -> ComponentValidity {
         guard !path.isEmpty else {
             return .page(validationHandler.validate())
@@ -173,6 +173,7 @@ public class DocumentEditor: ObservableObject {
 
         let fieldPositionID = components[1]
         if let fieldIdentifier = getFieldIdentifier(forFieldPositionID: fieldPositionID),
+           fieldIdentifier.pageID == pageID,
            let fieldValidity = validationHandler.validate(fieldIdentifier: fieldIdentifier) {
             return .field(fieldValidity)
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -152,6 +152,11 @@ public class DocumentEditor: ObservableObject {
     public func validate() -> Validation {
         return validationHandler.validate()
     }
+
+    public func validate(fieldID: String) -> FieldValidity? {
+        let fieldIdentifier = getFieldIdentifier(for: fieldID)
+        return validationHandler.validate(fieldIdentifier: fieldIdentifier)
+    }
     
     public func shouldShow(fieldID: String?) -> Bool {
         return conditionalLogicHandler.shouldShow(fieldID: fieldID)

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -15,6 +15,45 @@ class ValidationHandler {
         self.documentEditor = documentEditor
     }
 
+    fileprivate func validatePage(_ page: Page, _ documentEditor: DocumentEditor, _ isValid: inout Bool, _ fieldValidities: inout [FieldValidity]) {
+        let pageID = page.id
+        let isPageVisible = documentEditor.shouldShow(page: page)
+        
+        let fieldPositions = documentEditor.mapWebViewToMobileViewIfNeeded(
+            fieldPositions: page.fieldPositions ?? [],
+            isMobileViewActive: false
+        )
+        
+        for fieldPosition in fieldPositions {
+            guard let id = fieldPosition.field,
+                  let field = documentEditor.fieldMap[id] else {
+                continue
+            }
+            
+            guard field.fieldType != .unknown else {
+                continue
+            }
+            
+            if !isPageVisible {
+                continue
+            }
+            if !documentEditor.shouldShow(fieldID: field.id) {
+                continue
+            }
+            
+            guard let fieldID = field.id else {
+                Log("Missing field ID", type: .error)
+                continue
+            }
+            
+            guard let validity = validateField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageID, fieldPositionId: fieldPosition.id) else {
+                continue
+            }
+            if validity.status == .invalid { isValid = false }
+            fieldValidities.append(validity)
+        }
+    }
+    
     func validate() -> Validation {
         guard let documentEditor = documentEditor else {
             return Validation(status: .valid, fieldValidities: [])
@@ -23,43 +62,22 @@ class ValidationHandler {
         var isValid = true
 
         for page in documentEditor.pagesForCurrentView {
-            let pageID = page.id
-            let isPageVisible = documentEditor.shouldShow(page: page)
-
-            let fieldPositions = documentEditor.mapWebViewToMobileViewIfNeeded(
-                fieldPositions: page.fieldPositions ?? [],
-                isMobileViewActive: false
-            )
-
-            for fieldPosition in fieldPositions {
-                guard let id = fieldPosition.field,
-                      let field = documentEditor.fieldMap[id] else {
-                    continue
-                }
-
-                guard field.fieldType != .unknown else {
-                    continue
-                }
-
-                if !isPageVisible {
-                    continue
-                }
-                if !documentEditor.shouldShow(fieldID: field.id) {
-                    continue
-                }
-
-                guard let fieldID = field.id else {
-                    Log("Missing field ID", type: .error)
-                    continue
-                }
-
-                guard let validity = validateField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageID, fieldPositionId: fieldPosition.id) else {
-                    continue
-                }
-                if validity.status == .invalid { isValid = false }
-                fieldValidities.append(validity)
-            }
+            validatePage(page, documentEditor, &isValid, &fieldValidities)
         }
+        return Validation(status: isValid ? .valid : .invalid, fieldValidities: fieldValidities)
+    }
+
+    func validate(pageID: String) -> Validation {
+        guard let documentEditor = documentEditor else {
+            return Validation(status: .valid, fieldValidities: [])
+        }
+
+        guard let page = documentEditor.pagesForCurrentView.first(where: { $0.id == pageID }) else {
+            return Validation(status: .valid, fieldValidities: [])
+        }
+        var fieldValidities = [FieldValidity]()
+        var isValid = true
+        validatePage(page, documentEditor, &isValid, &fieldValidities)
         return Validation(status: isValid ? .valid : .invalid, fieldValidities: fieldValidities)
     }
 

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -41,8 +41,6 @@ class ValidationHandler {
                     continue
                 }
 
-                let fieldPositionId = fieldPosition.id
-
                 if !isPageVisible {
                     continue
                 }
@@ -55,32 +53,54 @@ class ValidationHandler {
                     continue
                 }
 
-                let isRequired = field.required ?? false
-
-                if field.fieldType == .table {
-                    let validity = validateTableField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageID, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
-                    if validity.status == .invalid { isValid = false }
-                    fieldValidities.append(validity)
-                } else if field.fieldType == .collection {
-                    if !documentEditor.isCollectionFieldEnabled {
-                        continue
-                    }
-                    let validity = validateCollectionField(field: field, fieldID: fieldID, pageId: pageID, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
-                    if validity.status == .invalid { isValid = false }
-                    fieldValidities.append(validity)
-                } else if !isRequired {
-                    fieldValidities.append(FieldValidity(field: field, status: .valid, pageId: pageID, fieldId: fieldID, fieldPositionId: fieldPositionId))
-                } else {
-                    if let value = field.value, !value.isEmpty {
-                        fieldValidities.append(FieldValidity(field: field, status: .valid, pageId: pageID, fieldId: fieldID, fieldPositionId: fieldPositionId))
-                    } else {
-                        isValid = false
-                        fieldValidities.append(FieldValidity(field: field, status: .invalid, pageId: pageID, fieldId: fieldID, fieldPositionId: fieldPositionId))
-                    }
+                guard let validity = validateField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageID, fieldPositionId: fieldPosition.id) else {
+                    continue
                 }
+                if validity.status == .invalid { isValid = false }
+                fieldValidities.append(validity)
             }
         }
         return Validation(status: isValid ? .valid : .invalid, fieldValidities: fieldValidities)
+    }
+
+    func validate(fieldIdentifier: FieldIdentifier) -> FieldValidity? {
+        guard let documentEditor = documentEditor else { return nil }
+
+        let fieldID = fieldIdentifier.fieldID
+        let pageID = fieldIdentifier.pageID
+
+        guard let field = documentEditor.field(fieldID: fieldID),
+              field.fieldType != .unknown,
+              documentEditor.shouldShow(pageID: pageID),
+              documentEditor.shouldShow(fieldID: fieldID),
+              let fieldPosition = documentEditor.fieldPosition(fieldID: fieldID) else { return nil }
+
+        return validateField(
+            field: field,
+            fieldID: fieldID,
+            fieldPosition: fieldPosition,
+            pageId: pageID,
+            fieldPositionId: fieldIdentifier.fieldPositionId ?? fieldPosition.id
+        )
+    }
+
+    // MARK: - Per-field validation helper
+
+    private func validateField(field: JoyDocField, fieldID: String, fieldPosition: FieldPosition, pageId: String?, fieldPositionId: String?) -> FieldValidity? {
+        guard let documentEditor = documentEditor else { return nil }
+        let isRequired = field.required ?? false
+
+        if field.fieldType == .table {
+            return validateTableField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageId, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
+        } else if field.fieldType == .collection {
+            guard documentEditor.isCollectionFieldEnabled else { return nil }
+            return validateCollectionField(field: field, fieldID: fieldID, pageId: pageId, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
+        } else if !isRequired {
+            return FieldValidity(field: field, status: .valid, pageId: pageId, fieldId: fieldID, fieldPositionId: fieldPositionId)
+        } else {
+            let status: ValidationStatus = (field.value.map { !$0.isEmpty } ?? false) ? .valid : .invalid
+            return FieldValidity(field: field, status: status, pageId: pageId, fieldId: fieldID, fieldPositionId: fieldPositionId)
+        }
     }
 
     // MARK: - Table Validation


### PR DESCRIPTION
## Context (spec)

Implements **path-based validation** so callers can validate the whole document, a single page, or one field layout (`pageId` / `pageId/fieldPositionId`) without always running full `validate()`. Aligns with form/fill flows that need targeted invalid state (e.g. after edits, focus on one field, or page-level submit).

## What changed

| Area | Files |
|------|--------|
| API & routing | `Sources/JoyfillUI/ViewModels/DocumentEditor.swift` — `validate(path:)`, path parsing (`maxSplits: 1` for field segment), page id must match resolved field for `.field`; uses existing `getFieldIdentifier(forFieldPositionID:)` + `ValidationHandler` |
| Validation | `Sources/JoyfillUI/ViewModels/ValidationHandler.swift` — `validate(pageID:)`, `validate(fieldIdentifier:)` refactored to share per-field logic with full `validate()` |
| Model | `Sources/JoyfillModel/Validator.swift` — `ComponentValidity` (`.page` / `.field`; `.row` / `.cell` reserved), `fieldValidity` convenience |
| Tests | `JoyfillSwiftUIExample/JoyfillTests/ValidatePathTests.swift` (new), `ValidationTestCase.swift` (path + per-field coverage across field types), `project.pbxproj` — register new test file |

## Design decisions

- **`mapWebViewToMobileViewIfNeeded`** stays in **`validatePage`** for **ordering / deduped** field lists in full & page-scoped `Validation`. **Single-field** path validation resolves **`getFieldIdentifier`** from **raw** `page.fieldPositions` so the path’s layout id is the one reflected in the result (no forced canonical id from the mapper).
- **Empty path** is equivalent to **`validate()`** → `.page(Validation)`.
- **Unknown `pageId`** → `.page` with empty validities (no throw).
- **Unknown or over-long field segment** → fall back to **`.page(validate(pageID:))`** for the path’s page.
- **`pageId` in path must match** the page that owns the resolved field position before returning **`.field`**; avoids validating the right field under the wrong page prefix.

## Media

No UI change in this PR (library / editor API + XCTest). **Screenshot or screen recording not applicable.** Optional: record a quick demo only if a host app is updated to surface path validation.

## Public API & docs

**New / updated public API** (consumers of `Joyfill` / `JoyfillModel`):

- `DocumentEditor.validate(path: String) -> ComponentValidity`
- `ComponentValidity` and `ComponentValidity.fieldValidity`

**Docs:** If you publish SDK or integration guides, add a short section for `validate(path:)`, path formats, and `ComponentValidity` vs `Validation`. Inline doc comments added on `validate(path:)`; external doc site TBD.

## Tests

- **Included in this PR:** `ValidatePathTests` (paths, empty path parity, wrong page fallback, revalidation, hidden required, multi-field, multiline, `getFieldIdentifier` smoke), plus **`ValidationTestCase`** extensions for `validate(path:)` across field types / tables / conditional cases.
- **Follow-up:** None required for the feature itself; fix or extend only if product adds row/cell paths or new field types.

## Notes for reviewers / AI-assisted review

- Prefer **behavior + tests** over noisy line comments; inline comments only where non-obvious.
- **Security:** Do **not** commit real `licenseKey` / JWT values in `ValidationTestCase` (keep empty or CI secret). There is currently an **uncommitted local** edit with a filled key—**revert before commit**.
- Run **`ValidatePathTests`** and **`ValidationTestCase`** in **Xcode** (example scheme) before merge.
- Ticket: **NO-1959**.
