### PR TITLE
Add dynamic decorator API with live table/collection updates

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		9EAAC7E02EAB3EF4000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
 		9EAAC7E12EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */; };
 		9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
+		E20E53022F876E500088A4E4 /* DecoratorAPIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */; };
 		E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */; };
 		E22516882E8BA4C60089E2D2 /* UserJsonTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */; };
 		E225D1C52F3AE626000674CF /* HiddenViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E225D1C42F3AE626000674CF /* HiddenViewsTests.swift */; };
@@ -570,6 +571,7 @@
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
 		9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyModeUITestCases.swift; sourceTree = "<group>"; };
+		E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorAPIDemoView.swift; sourceTree = "<group>"; };
 		E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableValidationTests.swift; sourceTree = "<group>"; };
 		E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJsonTextFieldView.swift; sourceTree = "<group>"; };
 		E225D1C42F3AE626000674CF /* HiddenViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenViewsTests.swift; sourceTree = "<group>"; };
@@ -981,6 +983,14 @@
 				9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */,
 			);
 			path = ReadonlyMode;
+			sourceTree = "<group>";
+		};
+		E20E53012F876E500088A4E4 /* Decorator Example */ = {
+			isa = PBXGroup;
+			children = (
+				E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */,
+			);
+			path = "Decorator Example";
 			sourceTree = "<group>";
 		};
 		E24089FE2F7CEFA1005C4885 /* Navigation Goto tests */ = {
@@ -1405,6 +1415,7 @@
 				36CE14682DB7F90100799B25 /* JoyDoc+helper.swift */,
 				E29FF8502F1F77C10079A614 /* SimpleNavigationTestView.swift */,
 				048149FE2CDA901F0061FBDC /* UserAccessTokenTextFieldView.swift */,
+				E20E53012F876E500088A4E4 /* Decorator Example */,
 				E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */,
 				E295FA792F73DAEF00C3C8C1 /* Footer Example */,
 				E22516822E8B9C610089E2D2 /* Public Apis Example */,
@@ -2041,6 +2052,7 @@
 				364615AE2E29694800F237F6 /* SchemaValidationExampleView.swift in Sources */,
 				E2FBBAC42E682139001FBF5B /* ValidationResultsView.swift in Sources */,
 				FA28C9672BB4345C00A2D65C /* FormContainerView.swift in Sources */,
+				E20E53022F876E500088A4E4 /* DecoratorAPIDemoView.swift in Sources */,
 				FA28C96B2BB4359600A2D65C /* ChangeManager.swift in Sources */,
 				369D45042E0E4C3F00677280 /* AllSampleJSONs.swift in Sources */,
 				FA529C7D2BA1D28B000200F5 /* TemplateListView.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -401,6 +401,11 @@
 		E2C8BD2E2E462A8F00B93B9E /* FieldTitleNotDisplayed.json in Resources */ = {isa = PBXBuildFile; fileRef = E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */; };
 		E2C8BD2F2E462A8F00B93B9E /* FieldTitleNotDisplayed.json in Resources */ = {isa = PBXBuildFile; fileRef = E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */; };
 		E2CC9FEE2E375E0400797331 /* SchemaValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */; };
+		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
+		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
+		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
+		DEC000B400000000000000A4 /* DecoratorErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */; };
+		DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */; };
 		E2CC9FF02E377AA800797331 /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = E2CC9FEF2E377AA800797331 /* JSONSchema */; };
 		E2E27C882E7AF4E60041FF1F /* CreateRowUISample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E27C872E7AF4E60041FF1F /* CreateRowUISample.swift */; };
 		E2E27D022E8C10000041FF1F /* MetadataChangeAPIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E27D012E8C10000041FF1F /* MetadataChangeAPIDemoView.swift */; };
@@ -680,6 +685,11 @@
 		E2C8BD282E462A8800B93B9E /* AllFieldTitleDispalayed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = AllFieldTitleDispalayed.json; sourceTree = "<group>"; };
 		E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FieldTitleNotDisplayed.json; sourceTree = "<group>"; };
 		E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationTests.swift; sourceTree = "<group>"; };
+		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
+		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
+		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
+		DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorErrorHandlingTests.swift; sourceTree = "<group>"; };
+		DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorLiveUpdateTests.swift; sourceTree = "<group>"; };
 		E2E27C872E7AF4E60041FF1F /* CreateRowUISample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRowUISample.swift; sourceTree = "<group>"; };
 		E2E27D012E8C10000041FF1F /* MetadataChangeAPIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataChangeAPIDemoView.swift; sourceTree = "<group>"; };
 		E2E3E7622E8450A3002A10C2 /* OnChangeHandler.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = OnChangeHandler.json; sourceTree = "<group>"; };
@@ -855,6 +865,7 @@
 				E27061C62E797E12006BAD18 /* OnChangeHandler */,
 				134FC0792BDA82E9008B7030 /* JoyfillTests.swift */,
 				E2CC9FEC2E375DE500797331 /* SchemaValidation */,
+				DEC000A000000000000000A0 /* DecoratorAPI */,
 				E2B8E3BC2E4361DF00AC6018 /* Formula */,
 				0448AE082D0C45AD00754EA0 /* ValidationTestCase.swift */,
 				E26315E32F76AEA70008B89B /* ValidatePathTests.swift */,
@@ -1212,6 +1223,18 @@
 				E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */,
 			);
 			path = SchemaValidation;
+			sourceTree = "<group>";
+		};
+		DEC000A000000000000000A0 /* DecoratorAPI */ = {
+			isa = PBXGroup;
+			children = (
+				DEC000F100000000000000A1 /* DecoratorTestSupport.swift */,
+				DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */,
+				DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */,
+				DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */,
+				DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */,
+			);
+			path = DecoratorAPI;
 			sourceTree = "<group>";
 		};
 		E2E3E7772E856105002A10C2 /* Simple Form Example */ = {
@@ -2011,6 +2034,11 @@
 				E2B8E3C22E436F2D00AC6018 /* FormulaTemplate_TextareaFieldTests.swift in Sources */,
 				E27061CC2E797E68006BAD18 /* DocumentEditor+ChangeHandlerTests.swift in Sources */,
 				E2CC9FEE2E375E0400797331 /* SchemaValidationTests.swift in Sources */,
+				DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */,
+				DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */,
+				DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */,
+				DEC000B400000000000000A4 /* DecoratorErrorHandlingTests.swift in Sources */,
+				DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */,
 				E2459A7D2F442B4B000504A3 /* ColumnConditionalLogicTests.swift in Sources */,
 				3682A4CC2E158D21005B73C3 /* FormulaTemplate_Write_ChartField.swift in Sources */,
 				362746762E26E266005B0FA7 /* FormulaTemplate_DateFieldTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
@@ -59,6 +59,8 @@ extension ChangeManager: FormChangeEvent {
             print("❌ Schema Error: \(schemaError)")
         case .schemaVersionError(let versionError):
             print("❌ Schema Error: \(versionError)")
+        case .decoratorError(let decoratorError):
+            print("❌ Decorator Error: \(decoratorError.message)")
         }
         print("Error occurred: \(error)")
     }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -241,7 +241,11 @@ struct DecoratorManagerView: View {
             else { return nil }
             return "\(base)/\(rowID)/\(columnID)"
         }
-        return "\(base)/-/\(columnID)"
+        // Table fields: use a real rowId from rowOrder so the path resolver
+        // can validate it. Column decorators are row-independent for tables,
+        // but the 4-segment path format still requires a valid rowId.
+        guard let rowID = selectedField?.rowOrder?.first else { return nil }
+        return "\(base)/\(rowID)/\(columnID)"
     }
 
     /// Returns the first rowId that belongs to the given schemaKey in a field's value tree.

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -1,0 +1,854 @@
+//
+//  DecoratorAPIDemoView.swift
+//  JoyfillExample
+//
+//  Contains:
+//    • DecoratorManagerView   — sheet listing all fields with their decorators; add / edit / delete
+//    • DecoratorEditView      — add-or-edit sheet with icon grid, colour swatches and live preview
+//    • DecoratorAPIDemoView   — standalone demo screen (entry in the option list)
+//
+//  DecoratorManagerView is also used directly by FormDestinationView so the same
+//  UI works whether launched from the menu or from the changelogs toolbar.
+//
+
+import SwiftUI
+import Joyfill
+import JoyfillModel
+
+// MARK: - Icon catalogue (matches DecoratorIcon mapping in the SDK)
+
+private struct IconOption: Identifiable, Hashable {
+    let id: String       // value stored in Decorator.icon
+    let symbol: String   // SF Symbol name
+}
+
+private let iconCatalogue: [IconOption] = [
+    .init(id: "camera",      symbol: "camera.fill"),
+    .init(id: "upload",      symbol: "arrow.up.square.fill"),
+    .init(id: "download",    symbol: "arrow.down.square.fill"),
+    .init(id: "image",       symbol: "photo.fill"),
+    .init(id: "file",        symbol: "doc.fill"),
+    .init(id: "comment",     symbol: "message.fill"),
+    .init(id: "comments",    symbol: "bubble.left.and.bubble.right.fill"),
+    .init(id: "flag",        symbol: "flag.fill"),
+    .init(id: "share",       symbol: "square.and.arrow.up.fill"),
+    .init(id: "eye",         symbol: "eye.fill"),
+    .init(id: "print",       symbol: "printer.fill"),
+    .init(id: "folder",      symbol: "folder.fill"),
+    .init(id: "paperclip",   symbol: "paperclip"),
+    .init(id: "plus",        symbol: "plus.circle.fill"),
+    .init(id: "cloud",       symbol: "cloud.fill"),
+    .init(id: "circle-info", symbol: "info.circle.fill"),
+    .init(id: "filter",      symbol: "line.3.horizontal.decrease.circle.fill"),
+    .init(id: "paper-plane", symbol: "paperplane.fill"),
+]
+
+// MARK: - Colour presets
+
+private struct ColourPreset: Identifiable, Hashable {
+    let id: String   // hex used in Decorator.color
+    let color: Color
+}
+
+private let colourPresets: [ColourPreset] = [
+    .init(id: "#3B82F6", color: Color(red: 0.232, green: 0.510, blue: 0.965)),
+    .init(id: "#10B981", color: Color(red: 0.063, green: 0.725, blue: 0.506)),
+    .init(id: "#EF4444", color: Color(red: 0.937, green: 0.267, blue: 0.267)),
+    .init(id: "#8B5CF6", color: Color(red: 0.545, green: 0.361, blue: 0.965)),
+    .init(id: "#F97316", color: Color(red: 0.976, green: 0.451, blue: 0.086)),
+    .init(id: "#14B8A6", color: Color(red: 0.078, green: 0.722, blue: 0.651)),
+]
+
+// MARK: - Helpers
+
+private func resolvedColor(hex: String?) -> Color {
+    colourPresets.first { $0.id.lowercased() == hex?.lowercased() }?.color
+        ?? colourPresets[0].color
+}
+
+private func resolvedSymbol(iconKey: String?) -> String {
+    iconCatalogue.first { $0.id == iconKey }?.symbol ?? "questionmark.circle"
+}
+
+private func fieldTypeMeta(_ type: String?) -> (label: String, color: Color) {
+    switch type {
+    case "text":       return ("Text",       .blue)
+    case "number":     return ("Number",     .green)
+    case "date":       return ("Date",       .orange)
+    case "dropdown":   return ("Dropdown",   .purple)
+    case "checkbox":   return ("Checkbox",   Color(red: 0.2, green: 0.7, blue: 0.6))
+    case "table":      return ("Table",      .red)
+    case "collection": return ("Collection", .red)
+    case "image":      return ("Image",      .indigo)
+    case "signature":  return ("Signature",  .pink)
+    case "chart":      return ("Chart",      .cyan)
+    default:
+        let t = type ?? ""
+        return (t.isEmpty ? "Field" : t.capitalized, .secondary)
+    }
+}
+
+// MARK: - Draft model (Identifiable so .sheet(item:) works)
+
+struct DecoratorDraft: Identifiable {
+    let id:         UUID   = UUID()
+    let path:       String  // full decorator path (field / row / column level)
+    let editAction: String? // nil → adding new; non-nil → editing existing (matched by action)
+    var icon:       String
+    var label:      String
+    var color:      String
+    var action:     String
+}
+
+// MARK: - DecoratorManagerView
+
+/// Full-screen decorator manager sheet.
+/// Pass the live `DocumentEditor` — changes reflect immediately in the form.
+struct DecoratorManagerView: View {
+    @ObservedObject var editor: DocumentEditor
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: DecoratorDraft?         = nil
+    @State private var selectedPageID:          String = ""
+    @State private var selectedFieldPositionID: String = ""
+    @State private var selectedSchemaKey:       String = ""  // collection fields only
+    @State private var selectedColumnID:        String = ""
+
+    // MARK: Derived — pages
+
+    private var sortedPages: [Page] {
+        editor.pagesForCurrentView.filter { $0.id != nil }
+    }
+
+    private var selectedPage: Page? {
+        sortedPages.first { $0.id == selectedPageID }
+    }
+
+    // MARK: Derived — field entries (loaded explicitly from the selected page)
+
+    /// (fieldPositionId, field) pairs for the selected page, in layout order.
+    private var fieldEntries: [(fieldPositionId: String, field: JoyDocField)] {
+        fieldEntriesForPage(selectedPageID)
+    }
+
+    /// Local helper: builds (fieldPositionId, field) pairs for any page using only
+    /// public DocumentEditor APIs — no SDK-side method needed.
+    private func fieldEntriesForPage(_ pageID: String) -> [(fieldPositionId: String, field: JoyDocField)] {
+        guard !pageID.isEmpty,
+              let page = editor.pagesForCurrentView.first(where: { $0.id == pageID })
+        else { return [] }
+        return (page.fieldPositions ?? []).compactMap { pos in
+            guard let posID   = pos.id,
+                  let fieldID = pos.field,
+                  let field   = editor.field(fieldID: fieldID) else { return nil }
+            return (posID, field)
+        }
+    }
+
+    private var selectedField: JoyDocField? {
+        fieldEntries.first { $0.fieldPositionId == selectedFieldPositionID }?.field
+    }
+
+    private var isCollection: Bool { selectedField?.fieldType == .collection }
+    private var isTable:      Bool { selectedField?.fieldType == .table }
+
+    // MARK: Derived — schemas (collection fields only)
+
+    /// All schemas for the selected collection field, root first then children in declared order.
+    private var sortedSchemas: [(key: String, schema: Schema)] {
+        guard let schemas = selectedField?.schema else { return [] }
+        var result: [(String, Schema)] = []
+        if let rootEntry = schemas.first(where: { $0.value.root == true }) {
+            result.append((rootEntry.key, rootEntry.value))
+            for childKey in rootEntry.value.children ?? [] {
+                if let child = schemas[childKey] { result.append((childKey, child)) }
+            }
+        }
+        // Append any schemas not reachable from root's children list
+        for (key, schema) in schemas where !result.contains(where: { $0.0 == key }) {
+            result.append((key, schema))
+        }
+        return result
+    }
+
+    private var selectedSchema: Schema? {
+        selectedField?.schema?[selectedSchemaKey]
+    }
+
+    // MARK: Derived — columns
+
+    /// Columns for the currently active scope:
+    /// - Collection: columns from the selected schema entry
+    /// - Table:      columns directly on the field
+    private var sortedColumns: [FieldTableColumn] {
+        let cols: [FieldTableColumn]?
+        if isCollection {
+            cols = selectedSchema?.tableColumns
+        } else {
+            cols = selectedField?.tableColumns
+        }
+        return (cols ?? []).filter { $0.id != nil }
+    }
+
+    private var selectedColumn: FieldTableColumn? {
+        sortedColumns.first { $0.id == selectedColumnID }
+    }
+
+    // MARK: Path helpers
+
+    /// Resolves the pageID that the SDK will actually use for this fieldPositionId.
+    /// The Navigation JSON (and similar documents) reuse the same fieldPosition _id across
+    /// multiple pages (copied page templates). getFieldIdentifier always returns the first
+    /// matching page, so we use its pageID in every path to stay consistent with the SDK.
+    private var resolvedPageID: String? {
+        guard !selectedFieldPositionID.isEmpty else { return nil }
+        return editor.getFieldIdentifier(forFieldPositionID: selectedFieldPositionID)?.pageID
+    }
+
+    /// "pageId/fieldPositionId"
+    private var fieldPath: String? {
+        guard let pageID = resolvedPageID else { return nil }
+        return "\(pageID)/\(selectedFieldPositionID)"
+    }
+
+    /// "pageId/fieldPositionId/rowId"
+    /// For collections: uses the first row that belongs to the selected schema so the
+    /// path resolver can derive the correct schemaKey.
+    /// For tables: uses the first root row (schema resolution short-circuits to nil anyway).
+    private var rowPath: String? {
+        guard let base = fieldPath else { return nil }
+        let rowID: String?
+        if isCollection {
+            rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField)
+        } else {
+            rowID = selectedField?.valueToValueElements?.first?.id
+        }
+        guard let rowID = rowID else { return nil }
+        return "\(base)/\(rowID)"
+    }
+
+    /// "pageId/fieldPositionId/rowId/columnId"
+    /// For collections: uses a real rowId from the selected schema so the resolver
+    /// returns the correct schemaKey for column lookup.
+    /// For tables: uses "-" as a positional placeholder (rowId is ignored for table columns).
+    private func columnPath(columnID: String) -> String? {
+        guard let base = fieldPath else { return nil }
+        if isCollection {
+            guard let rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField)
+            else { return nil }
+            return "\(base)/\(rowID)/\(columnID)"
+        }
+        return "\(base)/-/\(columnID)"
+    }
+
+    /// Returns the first rowId that belongs to the given schemaKey in a field's value tree.
+    /// - Root schema: first root-level row.
+    /// - Child schema: first child row found under any parent that has that schema.
+    private func firstRowID(forSchemaKey schemaKey: String, in field: JoyDocField?) -> String? {
+        guard let field = field else { return nil }
+        let rootSchemaKey = field.schema?.first { $0.value.root == true }?.key
+        if schemaKey == rootSchemaKey {
+            return field.valueToValueElements?.first?.id
+        }
+        return findFirstChildRow(forSchemaKey: schemaKey, in: field.valueToValueElements ?? [])
+    }
+
+    private func findFirstChildRow(forSchemaKey targetKey: String, in rows: [ValueElement]) -> String? {
+        for row in rows {
+            if let children = row.childrens?[targetKey],
+               let firstID  = children.valueToValueElements?.first?.id {
+                return firstID
+            }
+            if let childrens = row.childrens {
+                for (_, childGroup) in childrens {
+                    if let found = findFirstChildRow(forSchemaKey: targetKey, in: childGroup.valueToValueElements ?? []) {
+                        return found
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if sortedPages.isEmpty {
+                    VStack(spacing: 12) {
+                        Image(systemName: "doc.text.magnifyingglass")
+                            .font(.system(size: 40))
+                            .foregroundColor(.secondary)
+                        Text("No pages in this document.")
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List {
+                        // ── Page picker ──────────────────────────────────────
+                        Section {
+                            pagePickerRow
+                        } header: { Text("Select Page").textCase(nil) }
+
+                        // ── Field picker ─────────────────────────────────────
+                        Section {
+                            fieldPickerRow
+                        } header: { Text("Select Field").textCase(nil) }
+
+                        if let path = fieldPath {
+
+                            // ── Field-level decorators ───────────────────────
+                            let fieldDecs = editor.getDecorators(path: path)
+                            Section {
+                                ForEach(fieldDecs, id: \.action) { decoratorRow($0, path: path) }
+                                if fieldDecs.isEmpty { emptyHint("No decorators — tap + to add one") }
+                                addButton(badge: .blue) {
+                                    draft = DecoratorDraft(path: path, editAction: nil,
+                                                          icon: "camera", label: "", color: "#3B82F6", action: "")
+                                }
+                            } header: {
+                                decoratorSectionHeader(title: "Field Decorators", symbol: "tag.fill",
+                                                       count: fieldDecs.count, badge: .blue)
+                            }
+
+                            // ── Table / Collection only ──────────────────────
+                            if isTable || isCollection {
+
+                                // Schema picker (collection only)
+                                if isCollection {
+                                    Section {
+                                        schemaPickerRow
+                                    } header: { Text("Select Schema").textCase(nil) }
+                                }
+
+                                // Row decorators
+                                if let rPath = rowPath {
+                                    let rowDecs = editor.getDecorators(path: rPath)
+                                    Section {
+                                        ForEach(rowDecs, id: \.action) { decoratorRow($0, path: rPath) }
+                                        if rowDecs.isEmpty { emptyHint("No row decorators — tap + to add one") }
+                                        addButton(badge: .orange) {
+                                            draft = DecoratorDraft(path: rPath, editAction: nil,
+                                                                   icon: "flag", label: "", color: "#F97316", action: "")
+                                        }
+                                    } header: {
+                                        decoratorSectionHeader(title: "Row Decorators", symbol: "list.bullet.rectangle",
+                                                               count: rowDecs.count, badge: .orange)
+                                    }
+                                } else {
+                                    Section {
+                                        emptyHint("Add at least one row to manage row decorators.")
+                                    } header: {
+                                        decoratorSectionHeader(title: "Row Decorators", symbol: "list.bullet.rectangle",
+                                                               count: 0, badge: .orange)
+                                    }
+                                }
+
+                                // Column picker + column decorators
+                                if !sortedColumns.isEmpty {
+                                    Section {
+                                        columnPickerRow
+                                    } header: { Text("Select Column").textCase(nil) }
+
+                                    if let col = selectedColumn, let colID = col.id,
+                                       let cPath = columnPath(columnID: colID) {
+                                        let colDecs = editor.getDecorators(path: cPath)
+                                        Section {
+                                            ForEach(colDecs, id: \.action) { decoratorRow($0, path: cPath) }
+                                            if colDecs.isEmpty { emptyHint("No column decorators — tap + to add one") }
+                                            addButton(badge: .purple) {
+                                                draft = DecoratorDraft(path: cPath, editAction: nil,
+                                                                       icon: "circle-info", label: "", color: "#8B5CF6", action: "")
+                                            }
+                                        } header: {
+                                            decoratorSectionHeader(title: "Column Decorators", symbol: "tablecells",
+                                                                   count: colDecs.count, badge: .purple)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                    .onAppear {
+                        if selectedPageID.isEmpty {
+                            selectedPageID = sortedPages.first?.id ?? ""
+                        }
+                        if selectedFieldPositionID.isEmpty {
+                            selectedFieldPositionID = fieldEntriesForPage(selectedPageID).first?.fieldPositionId ?? ""
+                        }
+                        if selectedSchemaKey.isEmpty { selectedSchemaKey = sortedSchemas.first?.key ?? "" }
+                        if selectedColumnID.isEmpty  { selectedColumnID  = sortedColumns.first?.id  ?? "" }
+                    }
+                    .onChange(of: selectedPageID) { newPageID in
+                        // Page changed: reload field list for the new page, reset downstream
+                        let entries = fieldEntriesForPage(newPageID)
+                        selectedFieldPositionID = entries.first?.fieldPositionId ?? ""
+                        selectedSchemaKey       = ""
+                        selectedColumnID        = ""
+                    }
+                    .onChange(of: selectedFieldPositionID) { _ in
+                        selectedSchemaKey = sortedSchemas.first?.key ?? ""
+                        selectedColumnID  = sortedColumns.first?.id ?? ""
+                    }
+                    .onChange(of: selectedSchemaKey) { _ in
+                        selectedColumnID = sortedColumns.first?.id ?? ""
+                    }
+                }
+            }
+            .navigationTitle("Decorator Manager")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } }
+            }
+        }
+        .sheet(item: $draft) { d in
+            DecoratorEditView(draft: d, onSave: applyDraft(_:))
+        }
+    }
+
+    // MARK: Pickers
+
+    private var pagePickerRow: some View {
+        Menu {
+            ForEach(sortedPages, id: \.id) { page in
+                Button {
+                    let pageID = page.id ?? ""
+                    selectedPageID          = pageID
+                    selectedFieldPositionID = fieldEntriesForPage(pageID).first?.fieldPositionId ?? ""
+                    selectedSchemaKey       = ""
+                    selectedColumnID        = ""
+                } label: {
+                    Label(page.name ?? page.id ?? "",
+                          systemImage: selectedPageID == page.id ? "checkmark" : "doc.text")
+                }
+            }
+        } label: {
+            pickerLabel(icon: "doc.text", color: .blue, text: selectedPage?.name ?? "Select a page")
+        }
+    }
+
+    private var fieldPickerRow: some View {
+        let meta = fieldTypeMeta(selectedField?.type)
+        return Menu {
+            ForEach(fieldEntries, id: \.fieldPositionId) { entry in
+                Button {
+                    selectedFieldPositionID = entry.fieldPositionId
+                } label: {
+                    Label(entry.field.title ?? entry.field.id ?? "",
+                          systemImage: selectedFieldPositionID == entry.fieldPositionId ? "checkmark" : "rectangle.and.pencil.and.ellipsis")
+                }
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Text(meta.label)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 7).padding(.vertical, 3)
+                    .background(meta.color.opacity(0.15))
+                    .foregroundColor(meta.color)
+                    .cornerRadius(5)
+                Text(selectedField?.title ?? "Select a field")
+                    .font(.subheadline).foregroundColor(.primary)
+                Spacer()
+                Image(systemName: "chevron.up.chevron.down").font(.caption).foregroundColor(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+    }
+
+    private var schemaPickerRow: some View {
+        Menu {
+            ForEach(sortedSchemas, id: \.key) { entry in
+                Button {
+                    selectedSchemaKey = entry.key
+                } label: {
+                    Label(entry.schema.title ?? entry.key,
+                          systemImage: selectedSchemaKey == entry.key ? "checkmark" : "square.stack.3d.up")
+                }
+            }
+        } label: {
+            pickerLabel(
+                icon:  "square.stack.3d.up",
+                color: .teal,
+                text:  selectedSchema?.title ?? (selectedSchemaKey.isEmpty ? "Select a schema" : selectedSchemaKey)
+            )
+        }
+    }
+
+    private var columnPickerRow: some View {
+        Menu {
+            ForEach(sortedColumns, id: \.id) { col in
+                Button {
+                    selectedColumnID = col.id ?? ""
+                } label: {
+                    Label(col.title.isEmpty ? (col.id ?? "") : col.title,
+                          systemImage: selectedColumnID == col.id ? "checkmark" : "tablecells")
+                }
+            }
+        } label: {
+            pickerLabel(
+                icon:  "tablecells",
+                color: .purple,
+                text:  selectedColumn.map { $0.title.isEmpty ? ($0.id ?? "Column") : $0.title } ?? "Select a column"
+            )
+        }
+    }
+
+    /// Shared chevron-picker label layout.
+    private func pickerLabel(icon: String, color: Color, text: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon).font(.caption.weight(.semibold)).foregroundColor(color)
+            Text(text).font(.subheadline).foregroundColor(.primary)
+            Spacer()
+            Image(systemName: "chevron.up.chevron.down").font(.caption).foregroundColor(.secondary)
+        }
+        .contentShape(Rectangle())
+    }
+
+    // MARK: Section header / row helpers
+
+    private func decoratorSectionHeader(title: String, symbol: String, count: Int, badge: Color) -> some View {
+        HStack(spacing: 6) {
+            Label(title, systemImage: symbol).textCase(nil)
+            Spacer()
+            if count > 0 {
+                Text("\(count)")
+                    .font(.caption2.weight(.bold)).foregroundColor(.white)
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(badge).clipShape(Capsule())
+            }
+        }
+    }
+
+    private func addButton(badge: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label("Add Decorator", systemImage: "plus.circle.fill")
+                .foregroundColor(badge).font(.subheadline.weight(.medium))
+        }
+    }
+
+    private func emptyHint(_ text: String) -> some View {
+        Text(text).font(.caption).foregroundColor(.secondary).padding(.vertical, 2)
+    }
+
+    // MARK: Decorator row
+
+    private func decoratorRow(_ deco: Decorator, path: String) -> some View {
+        let accent    = resolvedColor(hex: deco.color)
+        let symbol    = resolvedSymbol(iconKey: deco.icon)
+        let hasAction = !(deco.action ?? "").isEmpty
+
+        return HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(accent.opacity(0.15)).frame(width: 38, height: 38)
+                Image(systemName: symbol).foregroundColor(accent).font(.system(size: 16))
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(deco.label ?? "(no label)").font(.subheadline.weight(.medium))
+                if let action = deco.action, !action.isEmpty {
+                    Text(action).font(.caption).foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            Button {
+                draft = DecoratorDraft(path: path, editAction: deco.action,
+                                       icon: deco.icon ?? "camera", label: deco.label ?? "",
+                                       color: deco.color ?? "#3B82F6", action: deco.action ?? "")
+            } label: {
+                Image(systemName: "pencil.circle").font(.title3)
+                    .foregroundColor(hasAction ? .blue : .secondary)
+            }
+            .buttonStyle(.plain).disabled(!hasAction)
+
+            Button(role: .destructive) {
+                if let action = deco.action { editor.removeDecorator(path: path, action: action) }
+            } label: {
+                Image(systemName: "trash.circle").font(.title3)
+                    .foregroundColor(hasAction ? .red : .secondary)
+            }
+            .buttonStyle(.plain).disabled(!hasAction)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: Mutations
+
+    private func applyDraft(_ d: DecoratorDraft) {
+        var deco = Decorator()
+        deco.icon   = d.icon
+        deco.label  = d.label.isEmpty  ? nil : d.label
+        deco.color  = d.color
+        deco.action = d.action.isEmpty ? nil : d.action
+
+        if let existingAction = d.editAction {
+            editor.updateDecorator(path: d.path, action: existingAction, decorator: deco)
+        } else {
+            editor.addDecorators(path: d.path, decorators: [deco])
+        }
+    }
+}
+
+// MARK: - DecoratorEditView
+
+struct DecoratorEditView: View {
+    let draft:  DecoratorDraft
+    let onSave: (DecoratorDraft) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var icon:   String
+    @State private var label:  String
+    @State private var color:  String
+    @State private var action: String
+
+    init(draft: DecoratorDraft, onSave: @escaping (DecoratorDraft) -> Void) {
+        self.draft  = draft
+        self.onSave = onSave
+        _icon   = State(initialValue: draft.icon)
+        _label  = State(initialValue: draft.label)
+        _color  = State(initialValue: draft.color)
+        _action = State(initialValue: draft.action)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Preview") { previewCard }
+                Section("Icon")    { iconGrid    }
+                Section("Label")   { labelField  }
+                Section("Colour")  { colourRow   }
+                Section {
+                    actionField
+                } header: {
+                    Text("Action")
+                } footer: {
+                    Text("Sent via onFocus(event:) when the decorator button is tapped.")
+                }
+            }
+            .navigationTitle(draft.editAction == nil ? "Add Decorator" : "Edit Decorator")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { save() }
+//                        .fontWeight(.bold)
+                        .disabled(icon.isEmpty)
+                }
+            }
+        }
+    }
+
+    // MARK: Live Preview
+
+    private var previewCard: some View {
+        let accent = resolvedColor(hex: color)
+        let sym    = resolvedSymbol(iconKey: icon)
+
+        return HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(accent.opacity(0.15))
+                    .frame(width: 46, height: 46)
+                Image(systemName: sym)
+                    .foregroundColor(accent)
+                    .font(.system(size: 22))
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(label.isEmpty ? "Label" : label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(label.isEmpty ? .secondary : .primary)
+                if !action.isEmpty {
+                    Text(action)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            Capsule()
+                .fill(accent)
+                .frame(width: 4, height: 32)
+        }
+        .padding(.vertical, 4)
+        .animation(.easeInOut(duration: 0.15), value: icon)
+        .animation(.easeInOut(duration: 0.15), value: color)
+        .animation(.easeInOut(duration: 0.15), value: label)
+    }
+
+    // MARK: Icon grid
+
+    private var iconGrid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 6),
+            spacing: 10
+        ) {
+            ForEach(iconCatalogue) { opt in
+                let selected = icon == opt.id
+                let accent   = resolvedColor(hex: color)
+
+                Button { icon = opt.id } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(selected ? accent.opacity(0.18) : Color(.systemGray6))
+                            .frame(width: 44, height: 44)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(selected ? accent : Color.clear, lineWidth: 2)
+                            )
+                        Image(systemName: opt.symbol)
+                            .foregroundColor(selected ? accent : .secondary)
+                            .font(.system(size: 18))
+                    }
+                }
+                .buttonStyle(.plain)
+                .animation(.easeInOut(duration: 0.12), value: selected)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: Label
+
+    private var labelField: some View {
+        TextField("e.g. Take Photo, Flag Row", text: $label)
+    }
+
+    // MARK: Colour swatches
+
+    private var colourRow: some View {
+        HStack(spacing: 14) {
+            ForEach(colourPresets) { preset in
+                let selected = color.lowercased() == preset.id.lowercased()
+                Button { color = preset.id } label: {
+                    ZStack {
+                        Circle().fill(preset.color).frame(width: 32, height: 32)
+                        if selected {
+                            Circle()
+                                .stroke(Color.primary, lineWidth: 2.5)
+                                .frame(width: 40, height: 40)
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundColor(.white)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .animation(.easeInOut(duration: 0.12), value: selected)
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    // MARK: Action
+
+    private var actionField: some View {
+        TextField("e.g. open_camera, flag_row", text: $action)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+    }
+
+    // MARK: Save
+
+    private func save() {
+        let saved = DecoratorDraft(
+            path:       draft.path,
+            editAction: draft.editAction,
+            icon:       icon,
+            label:      label,
+            color:      color,
+            action:     action
+        )
+        onSave(saved)
+        dismiss()
+    }
+}
+
+// MARK: - DecoratorAPIDemoView  (standalone entry from the option list)
+
+struct DecoratorAPIDemoView: View, FormChangeEvent {
+    @StateObject private var editor: DocumentEditor
+
+    @State private var showDecoratorManager = false
+    @State private var lastAction: String   = ""
+    @State private var showBanner: Bool     = false
+
+    init() {
+        _editor = StateObject(wrappedValue: DocumentEditor(
+            document: sampleJSONDocument(fileName: "Navigation"),
+            events: nil,
+            validateSchema: false,
+            license: licenseKey
+        ))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Floating action banner
+            ZStack(alignment: .bottom) {
+                Form(documentEditor: editor)
+                    .tint(.blue)
+
+                if showBanner {
+                    bannerView
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .padding(.bottom, 28)
+                        .zIndex(1)
+                }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.75), value: showBanner)
+        }
+        .navigationTitle("Decorator API Demo")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showDecoratorManager = true
+                } label: {
+                    Label("Decorators", systemImage: "paintbrush.pointed.fill")
+                }
+            }
+        }
+        .sheet(isPresented: $showDecoratorManager) {
+            DecoratorManagerView(editor: editor)
+        }
+        .onAppear {
+            editor.events = self
+        }
+    }
+
+    // MARK: Banner
+
+    private var bannerView: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "cursorarrow.rays")
+            Text("Action fired: \"\(lastAction)\"")
+                .font(.subheadline.weight(.medium))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.black.opacity(0.82))
+        .cornerRadius(24)
+    }
+
+    // MARK: FormChangeEvent
+
+    func onFocus(event: Event) {
+        guard let action = event.fieldEvent?.type, !action.isEmpty else { return }
+        lastAction = action
+        showBanner = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { showBanner = false }
+    }
+
+    func onChange(changes: [Change], document: JoyDoc) { }
+    func onBlur(event: Event)       { }
+    func onUpload(event: UploadEvent) { }
+    func onCapture(event: CaptureEvent) { }
+    func onError(error: JoyfillError) { }
+}
+
+// MARK: - JoyDocField + Identifiable (local)
+
+extension JoyDocField: @retroactive Identifiable { }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -931,7 +931,3 @@ struct DecoratorAPIDemoView: View {
     }
 
 }
-
-// MARK: - JoyDocField + Identifiable (local)
-
-extension JoyDocField: @retroactive Identifiable { }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -108,11 +108,14 @@ struct DecoratorManagerView: View {
     @ObservedObject var editor: DocumentEditor
     @Environment(\.dismiss) private var dismiss
 
-    @State private var draft: DecoratorDraft?         = nil
-    @State private var selectedPageID:          String = ""
-    @State private var selectedFieldPositionID: String = ""
-    @State private var selectedSchemaKey:       String = ""  // collection fields only
-    @State private var selectedColumnID:        String = ""
+    // Lifted to the parent so selection survives sheet dismiss/re-open.
+    @Binding var selectedPageID:          String
+    @Binding var selectedFieldPositionID: String
+
+    // Schema / column reset on each open — less critical to persist.
+    @State private var draft:           DecoratorDraft? = nil
+    @State private var selectedSchemaKey: String = ""
+    @State private var selectedColumnID:  String = ""
 
     // MARK: Derived — pages
 
@@ -196,19 +199,10 @@ struct DecoratorManagerView: View {
 
     // MARK: Path helpers
 
-    /// Resolves the pageID that the SDK will actually use for this fieldPositionId.
-    /// The Navigation JSON (and similar documents) reuse the same fieldPosition _id across
-    /// multiple pages (copied page templates). getFieldIdentifier always returns the first
-    /// matching page, so we use its pageID in every path to stay consistent with the SDK.
-    private var resolvedPageID: String? {
-        guard !selectedFieldPositionID.isEmpty else { return nil }
-        return editor.getFieldIdentifier(forFieldPositionID: selectedFieldPositionID)?.pageID
-    }
-
     /// "pageId/fieldPositionId"
     private var fieldPath: String? {
-        guard let pageID = resolvedPageID else { return nil }
-        return "\(pageID)/\(selectedFieldPositionID)"
+        guard !selectedPageID.isEmpty, !selectedFieldPositionID.isEmpty else { return nil }
+        return "\(selectedPageID)/\(selectedFieldPositionID)"
     }
 
     /// "pageId/fieldPositionId/rowId"
@@ -291,10 +285,12 @@ struct DecoratorManagerView: View {
                             pagePickerRow
                         } header: { Text("Select Page").textCase(nil) }
 
-                        // ── Field picker ─────────────────────────────────────
-                        Section {
-                            fieldPickerRow
-                        } header: { Text("Select Field").textCase(nil) }
+                        // ── Field picker — only shown once a page is selected ─
+                        if !selectedPageID.isEmpty {
+                            Section {
+                                fieldPickerRow
+                            } header: { Text("Select Field").textCase(nil) }
+                        }
 
                         if let path = fieldPath {
 
@@ -372,19 +368,14 @@ struct DecoratorManagerView: View {
                     }
                     .listStyle(.insetGrouped)
                     .onAppear {
-                        if selectedPageID.isEmpty {
-                            selectedPageID = sortedPages.first?.id ?? ""
-                        }
-                        if selectedFieldPositionID.isEmpty {
-                            selectedFieldPositionID = fieldEntriesForPage(selectedPageID).first?.fieldPositionId ?? ""
-                        }
+                        // Do not auto-select page — user must pick explicitly so
+                        // paths are always built from a deliberate page choice.
                         if selectedSchemaKey.isEmpty { selectedSchemaKey = sortedSchemas.first?.key ?? "" }
                         if selectedColumnID.isEmpty  { selectedColumnID  = sortedColumns.first?.id  ?? "" }
                     }
-                    .onChange(of: selectedPageID) { newPageID in
-                        // Page changed: reload field list for the new page, reset downstream
-                        let entries = fieldEntriesForPage(newPageID)
-                        selectedFieldPositionID = entries.first?.fieldPositionId ?? ""
+                    .onChange(of: selectedPageID) { _ in
+                        // Page changed: clear field selection so user explicitly picks from fresh list
+                        selectedFieldPositionID = ""
                         selectedSchemaKey       = ""
                         selectedColumnID        = ""
                     }
@@ -415,8 +406,9 @@ struct DecoratorManagerView: View {
             ForEach(sortedPages, id: \.id) { page in
                 Button {
                     let pageID = page.id ?? ""
+                    // Reset all downstream selections when page changes
                     selectedPageID          = pageID
-                    selectedFieldPositionID = fieldEntriesForPage(pageID).first?.fieldPositionId ?? ""
+                    selectedFieldPositionID = ""
                     selectedSchemaKey       = ""
                     selectedColumnID        = ""
                 } label: {
@@ -770,9 +762,12 @@ struct DecoratorEditView: View {
 struct DecoratorAPIDemoView: View, FormChangeEvent {
     @StateObject private var editor: DocumentEditor
 
-    @State private var showDecoratorManager = false
-    @State private var lastAction: String   = ""
-    @State private var showBanner: Bool     = false
+    @State private var showDecoratorManager      = false
+    @State private var lastAction: String        = ""
+    @State private var showBanner: Bool          = false
+    // Persisted across sheet dismissals so the user doesn't have to re-select
+    @State private var decoratorPageID:          String = ""
+    @State private var decoratorFieldPositionID: String = ""
 
     init() {
         _editor = StateObject(wrappedValue: DocumentEditor(
@@ -811,7 +806,11 @@ struct DecoratorAPIDemoView: View, FormChangeEvent {
             }
         }
         .sheet(isPresented: $showDecoratorManager) {
-            DecoratorManagerView(editor: editor)
+            DecoratorManagerView(
+                editor: editor,
+                selectedPageID: $decoratorPageID,
+                selectedFieldPositionID: $decoratorFieldPositionID
+            )
         }
         .onAppear {
             editor.events = self

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -88,6 +88,13 @@ private func fieldTypeMeta(_ type: String?) -> (label: String, color: Color) {
     }
 }
 
+// MARK: - Error alert model (Identifiable so .alert(item:) works)
+
+struct DecoratorErrorAlert: Identifiable {
+    let id = UUID()
+    let message: String
+}
+
 // MARK: - Draft model (Identifiable so .sheet(item:) works)
 
 struct DecoratorDraft: Identifiable {
@@ -111,6 +118,8 @@ struct DecoratorManagerView: View {
     // Lifted to the parent so selection survives sheet dismiss/re-open.
     @Binding var selectedPageID:          String
     @Binding var selectedFieldPositionID: String
+    // Shared error alert state (alert attached here so it renders over this sheet)
+    @Binding var decoratorError:          DecoratorErrorAlert?
 
     // Schema / column reset on each open — less critical to persist.
     @State private var draft:           DecoratorDraft? = nil
@@ -395,7 +404,12 @@ struct DecoratorManagerView: View {
             }
         }
         .sheet(item: $draft) { d in
-            DecoratorEditView(draft: d, onSave: applyDraft(_:))
+            DecoratorEditView(draft: d, decoratorError: $decoratorError, onSave: applyDraft(_:))
+        }
+        .alert(item: $decoratorError) { err in
+            Alert(title: Text("Decorator Error"),
+                  message: Text(err.message),
+                  dismissButton: .default(Text("OK")))
         }
     }
 
@@ -585,6 +599,7 @@ struct DecoratorManagerView: View {
 
 struct DecoratorEditView: View {
     let draft:  DecoratorDraft
+    @Binding var decoratorError: DecoratorErrorAlert?
     let onSave: (DecoratorDraft) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -594,8 +609,11 @@ struct DecoratorEditView: View {
     @State private var color:  String
     @State private var action: String
 
-    init(draft: DecoratorDraft, onSave: @escaping (DecoratorDraft) -> Void) {
+    init(draft: DecoratorDraft,
+         decoratorError: Binding<DecoratorErrorAlert?>,
+         onSave: @escaping (DecoratorDraft) -> Void) {
         self.draft  = draft
+        self._decoratorError = decoratorError
         self.onSave = onSave
         _icon   = State(initialValue: draft.icon)
         _label  = State(initialValue: draft.label)
@@ -629,6 +647,11 @@ struct DecoratorEditView: View {
 //                        .fontWeight(.bold)
                         .disabled(icon.isEmpty)
                 }
+            }
+            .alert(item: $decoratorError) { err in
+                Alert(title: Text("Decorator Error"),
+                      message: Text(err.message),
+                      dismissButton: .default(Text("OK")))
             }
         }
     }
@@ -759,23 +782,81 @@ struct DecoratorEditView: View {
 
 // MARK: - DecoratorAPIDemoView  (standalone entry from the option list)
 
-struct DecoratorAPIDemoView: View, FormChangeEvent {
+private class DecoratorEventHandler: FormChangeEvent {
+    weak var editor: DocumentEditor?
+    var onDecoratorAction: ((String) -> Void)?
+    var onDecoratorError: ((String) -> Void)?
+
+    func onFocus(event: Event) {
+        guard let fieldEvent = event.fieldEvent,
+              let action = fieldEvent.type, !action.isEmpty else { return }
+
+        onDecoratorAction?(action)
+
+        // Build the decorator path from the event
+        guard let editor = editor,
+              let pageID = fieldEvent.pageID,
+              let fieldPositionId = fieldEvent.fieldPositionId else { return }
+
+        let basePath = "\(pageID)/\(fieldPositionId)"
+        let path: String
+        if let columnID = fieldEvent.columnId {
+            let rowID = fieldEvent.rowIds?.first ?? "-"
+            path = "\(basePath)/\(rowID)/\(columnID)"
+        } else if let rowID = fieldEvent.rowIds?.first {
+            path = "\(basePath)/\(rowID)"
+        } else {
+            path = basePath
+        }
+
+        // Update the tapped decorator to show it was viewed
+        var updated = Decorator()
+        updated.action = action
+        updated.icon   = "eye"
+        updated.label  = "Viewed"
+        updated.color  = "#10B981"
+        editor.updateDecorator(path: path, action: action, decorator: updated)
+    }
+
+    func onChange(changes: [Change], document: JoyDoc) { }
+    func onBlur(event: Event) { }
+    func onUpload(event: UploadEvent) { }
+    func onCapture(event: CaptureEvent) { }
+    func onError(error: JoyfillError) {
+        if case .decoratorError(let e) = error {
+            DispatchQueue.main.async { [weak self] in
+                self?.onDecoratorError?(e.message)
+            }
+        }
+    }
+}
+
+struct DecoratorAPIDemoView: View {
     @StateObject private var editor: DocumentEditor
 
     @State private var showDecoratorManager      = false
     @State private var lastAction: String        = ""
     @State private var showBanner: Bool          = false
+    @State private var decoratorError: DecoratorErrorAlert? = nil
     // Persisted across sheet dismissals so the user doesn't have to re-select
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
 
     init() {
-        _editor = StateObject(wrappedValue: DocumentEditor(
+        let handler = DecoratorEventHandler()
+        let editor = DocumentEditor(
             document: sampleJSONDocument(fileName: "Navigation"),
-            events: nil,
+            events: handler,
             validateSchema: false,
             license: licenseKey
-        ))
+        )
+        handler.editor = editor
+        _editor = StateObject(wrappedValue: editor)
+    }
+
+    /// The event handler stored inside the editor, cast back to our concrete type.
+    private var eventHandler: DecoratorEventHandler? {
+        editor.events as? DecoratorEventHandler
     }
 
     var body: some View {
@@ -809,11 +890,24 @@ struct DecoratorAPIDemoView: View, FormChangeEvent {
             DecoratorManagerView(
                 editor: editor,
                 selectedPageID: $decoratorPageID,
-                selectedFieldPositionID: $decoratorFieldPositionID
+                selectedFieldPositionID: $decoratorFieldPositionID,
+                decoratorError: $decoratorError
             )
         }
         .onAppear {
-            editor.events = self
+            eventHandler?.onDecoratorAction = { action in
+                lastAction = action
+                showBanner = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { showBanner = false }
+            }
+            eventHandler?.onDecoratorError = { message in
+                decoratorError = DecoratorErrorAlert(message: message)
+            }
+        }
+        .alert(item: $decoratorError) { err in
+            Alert(title: Text("Decorator Error"),
+                  message: Text(err.message),
+                  dismissButton: .default(Text("OK")))
         }
     }
 
@@ -832,20 +926,6 @@ struct DecoratorAPIDemoView: View, FormChangeEvent {
         .cornerRadius(24)
     }
 
-    // MARK: FormChangeEvent
-
-    func onFocus(event: Event) {
-        guard let action = event.fieldEvent?.type, !action.isEmpty else { return }
-        lastAction = action
-        showBanner = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { showBanner = false }
-    }
-
-    func onChange(changes: [Change], document: JoyDoc) { }
-    func onBlur(event: Event)       { }
-    func onUpload(event: UploadEvent) { }
-    func onCapture(event: CaptureEvent) { }
-    func onError(error: JoyfillError) { }
 }
 
 // MARK: - JoyDocField + Identifiable (local)

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -235,6 +235,7 @@ struct FormDestinationView: View {
     @State private var showDecoratorManager      = false
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
+    @State private var decoratorError:           DecoratorErrorAlert? = nil
     let enableChangelogs: Bool
     @State var validateSchema: Bool = false
     @State var isPageDuplicated: Bool = true
@@ -380,7 +381,8 @@ struct FormDestinationView: View {
                 DecoratorManagerView(
                     editor: editor,
                     selectedPageID: $decoratorPageID,
-                    selectedFieldPositionID: $decoratorFieldPositionID
+                    selectedFieldPositionID: $decoratorFieldPositionID,
+                    decoratorError: $decoratorError
                 )
             }
         }

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -232,7 +232,9 @@ struct FormDestinationView: View {
     @Binding var showPublicApis: Bool
     @State private var lastValidation: Validation? = nil
     @State private var documentEditor: DocumentEditor? = nil
-    @State private var showDecoratorManager = false
+    @State private var showDecoratorManager      = false
+    @State private var decoratorPageID:          String = ""
+    @State private var decoratorFieldPositionID: String = ""
     let enableChangelogs: Bool
     @State var validateSchema: Bool = false
     @State var isPageDuplicated: Bool = true
@@ -375,7 +377,11 @@ struct FormDestinationView: View {
         }
         .sheet(isPresented: $showDecoratorManager) {
             if let editor = documentEditor {
-                DecoratorManagerView(editor: editor)
+                DecoratorManagerView(
+                    editor: editor,
+                    selectedPageID: $decoratorPageID,
+                    selectedFieldPositionID: $decoratorFieldPositionID
+                )
             }
         }
         .sheet(isPresented: $showPublicApis) {

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -232,6 +232,7 @@ struct FormDestinationView: View {
     @Binding var showPublicApis: Bool
     @State private var lastValidation: Validation? = nil
     @State private var documentEditor: DocumentEditor? = nil
+    @State private var showDecoratorManager = false
     let enableChangelogs: Bool
     @State var validateSchema: Bool = false
     @State var isPageDuplicated: Bool = true
@@ -313,7 +314,16 @@ struct FormDestinationView: View {
                     .buttonStyle(.bordered)
                     .padding(.trailing, 16)
                     .padding(.top, 8)
-                    
+
+                    Button(action: {
+                        showDecoratorManager = true
+                    }) {
+                        Image(systemName: "paintbrush.pointed.fill")
+                    }
+                    .buttonStyle(.bordered)
+                    .padding(.trailing, 16)
+                    .padding(.top, 8)
+
                     Button(action: {
                         showChangelogView = true
                     }) {
@@ -362,6 +372,11 @@ struct FormDestinationView: View {
         }
         .sheet(isPresented: $showChangelogView) {
             ChangelogView(changeManager: changeManager)
+        }
+        .sheet(isPresented: $showDecoratorManager) {
+            if let editor = documentEditor {
+                DecoratorManagerView(editor: editor)
+            }
         }
         .sheet(isPresented: $showPublicApis) {
             PublicApiExamples(documentEditor: $documentEditor, licenseKey: $license, validateSchema: $validateSchema, isPageDuplicate: $isPageDuplicated, isPageDelete: $isPageDelete, singleClickRowEdit: $singleClickRowEdit, document: documentEditor?.document ?? JoyDoc())
@@ -478,6 +493,7 @@ struct OptionSelectionView: View {
         case manipulateDataOnChangeView
         case createRowUISample
         case metadataChangeAPIDemo
+        case decoratorAPIDemo
         case simpleForm
         case simpleNavigationTest
         case footerExample
@@ -510,6 +526,8 @@ struct OptionSelectionView: View {
                 return "Create Row UI Sample"
             case .metadataChangeAPIDemo:
                 return "Metadata Change API Demo"
+            case .decoratorAPIDemo:
+                return "Decorator API Demo"
             case .simpleForm:
                 return "Simple example Form"
             case .simpleNavigationTest:
@@ -547,6 +565,8 @@ struct OptionSelectionView: View {
                 return "Create a row UI sample"
             case .metadataChangeAPIDemo:
                 return "Set field and row metadata via Change API (field.update, rowCreate, rowUpdate)"
+            case .decoratorAPIDemo:
+                return "Add, remove and update decorators on any field at runtime"
             case .simpleForm:
                 return "Simple example Form"
             case .simpleNavigationTest:
@@ -584,6 +604,8 @@ struct OptionSelectionView: View {
                 return "slider.horizontal.3"
             case .metadataChangeAPIDemo:
                 return "tag.fill"
+            case .decoratorAPIDemo:
+                return "paintbrush.pointed.fill"
             case .simpleForm:
                 return "slider.horizontal.3"
             case .simpleNavigationTest:
@@ -621,6 +643,8 @@ struct OptionSelectionView: View {
                 return .red
             case .metadataChangeAPIDemo:
                 return .orange
+            case .decoratorAPIDemo:
+                return .blue
             case .simpleForm:
                 return .blue
             case .simpleNavigationTest:
@@ -770,6 +794,8 @@ struct OptionSelectionView: View {
             CreateRowUISample()
         case .metadataChangeAPIDemo:
             MetadataChangeAPIDemoView()
+        case .decoratorAPIDemo:
+            DecoratorAPIDemoView()
         case .simpleForm:
             SimpleFormExampleView()
         case .simpleNavigationTest:

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
@@ -76,6 +76,24 @@ final class DecoratorErrorHandlingTests: XCTestCase {
         XCTAssertEqual(editor.getDecorators(path: path).first?.label, "Real")
     }
 
+    // MARK: - Empty batch
+
+    func testAddDecorators_emptyArray_isNoOp() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        // Seed one decorator so we can verify the list is untouched.
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "existing")])
+        mock.reset()
+
+        editor.addDecorators(path: path, decorators: [])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 0,
+                       "empty batch must not fire an error")
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1,
+                       "existing decorators must be untouched")
+        XCTAssertEqual(editor.getDecorators(path: path).first?.action, "existing")
+    }
+
     // MARK: - Decorator validation: action
 
     func testValidation_addDecorator_nilAction_firesOnErrorAndBlocks() {

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
@@ -1,0 +1,296 @@
+//
+//  DecoratorErrorHandlingTests.swift
+//  JoyfillTests
+//
+//  Tests every onError emission path in the decorator API:
+//    - Path resolution failures
+//    - Action-not-found in remove/update
+//    - Decorator validation (action required, color must be #RRGGBB)
+//
+
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorErrorHandlingTests: XCTestCase {
+
+    // MARK: - Path-resolution errors
+
+    func testGetDecorators_invalidPath_firesOnErrorAndReturnsEmpty() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "bogusPage/bogusFp"
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains(path) ?? false)
+    }
+
+    func testAddDecorators_invalidPath_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.addDecorators(path: "bogus/path", decorators: [makeDecorator(action: "x")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+    }
+
+    func testRemoveDecorator_invalidPath_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.removeDecorator(path: "bogus/path", action: "x")
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+    }
+
+    func testUpdateDecorator_invalidPath_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.updateDecorator(path: "bogus/path", action: "x", decorator: makeDecorator(action: "x"))
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+    }
+
+    // MARK: - Action-not-found errors
+
+    func testRemoveDecorator_unknownAction_firesOnError_listUnchanged() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "real")])
+        mock.reset()
+
+        editor.removeDecorator(path: path, action: "ghost")
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to remove decorator with action") ?? false)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("ghost") ?? false)
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["real"])
+    }
+
+    func testUpdateDecorator_unknownAction_firesOnError_listUnchanged() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "real", label: "Real")])
+        mock.reset()
+
+        editor.updateDecorator(path: path, action: "ghost", decorator: makeDecorator(action: "ghost"))
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to update decorator with action") ?? false)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("ghost") ?? false)
+        // Original decorator unchanged
+        XCTAssertEqual(editor.getDecorators(path: path).first?.label, "Real")
+    }
+
+    // MARK: - Decorator validation: action
+
+    func testValidation_addDecorator_nilAction_firesOnErrorAndBlocks() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        var bad = Decorator(); bad.icon = "flag"; bad.label = "X"; bad.color = "#FF0000"
+        editor.addDecorators(path: path, decorators: [bad])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("action") ?? false)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0, "blocked: nothing should persist")
+    }
+
+    func testValidation_addDecorator_emptyAction_firesOnErrorAndBlocks() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+    }
+
+    // MARK: - Decorator validation: color
+
+    func testValidation_addDecorator_badHexColor_firesOnErrorAndBlocks() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x", color: "red")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("color") ?? false)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+    }
+
+    func testValidation_addDecorator_shortHexColor_firesOnErrorAndBlocks() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableFieldPath(),
+                             decorators: [makeDecorator(action: "x", color: "#12345")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+    }
+
+    func testValidation_addDecorator_invalidHexChars_firesOnErrorAndBlocks() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableFieldPath(),
+                             decorators: [makeDecorator(action: "x", color: "#ZZZZZZ")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+    }
+
+    func testValidation_addDecorator_validLowercaseHex_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x", color: "#3b82f6")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).first?.color, "#3b82f6")
+    }
+
+    func testValidation_addDecorator_validUppercaseHex_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x", color: "#ABCDEF")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).first?.color, "#ABCDEF")
+    }
+
+    func testValidation_addDecorator_nilColor_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x", color: nil)])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1)
+    }
+
+    func testValidation_addDecorator_emptyColor_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x", color: "")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1)
+    }
+
+    // MARK: - Atomicity
+
+    func testValidation_addDecorators_oneInvalidInBatch_blocksAll() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "good"),
+            makeDecorator(action: "", color: "#FF0000"), // empty action → invalid
+            makeDecorator(action: "alsoGood"),
+        ])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "one bad decorator must block the whole batch")
+    }
+
+    func testValidation_updateDecorator_badProperty_firesOnError_listUnchanged() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a", label: "Original")])
+        mock.reset()
+
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "a", color: "notHex"))
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertEqual(editor.getDecorators(path: path).first?.label, "Original",
+                       "blocked update must not mutate the existing decorator")
+    }
+
+    // MARK: - Error message shape
+
+    func testErrorMessage_includesPath() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "totally/wrong/path"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x")])
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains(path) ?? false)
+    }
+
+    func testErrorMessage_includesAction() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "real")])
+        mock.reset()
+        editor.updateDecorator(path: path, action: "ghost", decorator: makeDecorator(action: "ghost"))
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("ghost") ?? false)
+    }
+
+    func testDecoratorErrorWrapsCorrectMessage() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        editor.removeDecorator(path: "x/y", action: "z")
+        guard let captured = mock.capturedErrors.first else {
+            XCTFail("Expected an error"); return
+        }
+        switch captured {
+        case .decoratorError(let err):
+            XCTAssertFalse(err.message.isEmpty)
+            XCTAssertTrue(err.message.contains("x/y"))
+        default:
+            XCTFail("Expected .decoratorError, got \(captured)")
+        }
+    }
+
+    // MARK: - License gating (collection field requires a valid license)
+
+    func testLicense_invalid_collectionAddDecorators_firesOnError_andDoesNotPersist() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootRowPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "blocked")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("license") ?? false,
+                      "error message should mention license")
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNil(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+                       .rowDecorators?.first(where: { $0.action == "blocked" }))
+    }
+
+    func testLicense_invalid_collectionRemoveDecorator_firesOnError() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        editor.removeDecorator(path: ChangerHandlerSample.collectionRootRowPath(), action: "x")
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("license") ?? false)
+    }
+
+    func testLicense_invalid_collectionUpdateDecorator_firesOnError() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        editor.updateDecorator(path: ChangerHandlerSample.collectionRootRowPath(),
+                               action: "x", decorator: makeDecorator(action: "x"))
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("license") ?? false)
+    }
+
+    /// Reads on collection fields are NOT gated — they're harmless data inspection.
+    func testLicense_invalid_collectionGetDecorators_doesNotFireError() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        _ = editor.getDecorators(path: ChangerHandlerSample.collectionRootRowPath())
+        XCTAssertEqual(mock.decoratorErrorCount, 0,
+                       "reads should not be license-gated")
+    }
+
+    /// Table-field decorators are not collection-gated, even with no license.
+    func testLicense_invalid_tableAddDecorators_succeeds() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ok")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).first?.action, "ok")
+    }
+
+    func testLicense_invalid_collectionBatchAdd_blocksAll() {
+        let (editor, mock) = makeUnlicensedChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootRowPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+        ])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let cached = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators ?? []
+        XCTAssertTrue(cached.isEmpty, "no decorators should persist when license blocks")
+    }
+
+    // MARK: - No events handler (must not crash)
+
+    func testNoEventsHandler_noCrash_invalidPath() {
+        let editor = DocumentEditor(document: sampleJSONDocument(fileName: "ChangerHandlerUnit"),
+                                    events: nil, validateSchema: false)
+        // Should be a no-op, not a crash.
+        editor.addDecorators(path: "bogus/path", decorators: [makeDecorator(action: "x")])
+        editor.removeDecorator(path: "bogus/path", action: "x")
+        editor.updateDecorator(path: "bogus/path", action: "x", decorator: makeDecorator(action: "x"))
+        _ = editor.getDecorators(path: "bogus/path")
+    }
+
+    func testNoEventsHandler_noCrash_validation() {
+        let editor = DocumentEditor(document: sampleJSONDocument(fileName: "ChangerHandlerUnit"),
+                                    events: nil, validateSchema: false)
+        editor.addDecorators(path: ChangerHandlerSample.tableFieldPath(),
+                             decorators: [makeDecorator(action: "x", color: "notHex")])
+        XCTAssertEqual(editor.getDecorators(path: ChangerHandlerSample.tableFieldPath()).count, 0)
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorErrorHandlingTests.swift
@@ -274,6 +274,104 @@ final class DecoratorErrorHandlingTests: XCTestCase {
         XCTAssertTrue(cached.isEmpty, "no decorators should persist when license blocks")
     }
 
+    // MARK: - Duplicate action rejection (uniqueness per scope)
+
+    func testAddDecorators_duplicateOfExisting_firesOnErrorAndBlocksBatch() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "dup", label: "Original")])
+        mock.reset()
+
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "dup", label: "NewOne")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("already exists") ?? false)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("dup") ?? false)
+
+        let list = editor.getDecorators(path: path)
+        XCTAssertEqual(list.count, 1, "duplicate must not be appended")
+        XCTAssertEqual(list.first?.label, "Original", "original must remain unchanged")
+    }
+
+    func testAddDecorators_duplicateWithinBatch_firesOnErrorAndBlocksAll() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+            makeDecorator(action: "a"), // duplicate within the batch
+        ])
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.lowercased().contains("duplicate") ?? false)
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "an internal duplicate must block the whole batch")
+    }
+
+    func testAddDecorators_noDuplicates_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+            makeDecorator(action: "c"),
+        ])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["a", "b", "c"])
+    }
+
+    func testUpdateDecorator_newActionCollidesWithAnotherEntry_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a", label: "Apple"),
+            makeDecorator(action: "b", label: "Banana"),
+        ])
+        mock.reset()
+
+        // Try to rename "a" → "b" (would collide with the existing "b")
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "b", label: "Hijack"))
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("already exists") ?? false)
+
+        // Neither entry mutated
+        let list = editor.getDecorators(path: path)
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list.first(where: { $0.action == "a" })?.label, "Apple")
+        XCTAssertEqual(list.first(where: { $0.action == "b" })?.label, "Banana")
+    }
+
+    func testUpdateDecorator_keepsSameAction_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a", label: "Old"),
+            makeDecorator(action: "b", label: "Other"),
+        ])
+        mock.reset()
+
+        // Updating "a" with a new decorator that also has action "a" must NOT trigger collision.
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "a", label: "New"))
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: path).first(where: { $0.action == "a" })?.label, "New")
+    }
+
+    func testUpdateDecorator_renameToFreshAction_succeeds() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a", label: "Alpha")])
+        mock.reset()
+
+        // Rename "a" → "c" (no collision with any existing entry)
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "c", label: "Charlie"))
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        let list = editor.getDecorators(path: path)
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(list.first?.action, "c")
+        XCTAssertEqual(list.first?.label, "Charlie")
+    }
+
     // MARK: - No events handler (must not crash)
 
     func testNoEventsHandler_noCrash_invalidPath() {

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -1,0 +1,241 @@
+//
+//  DecoratorLiveUpdateTests.swift
+//  JoyfillTests
+//
+//  Verifies that when decorators change via the public API, any live
+//  TableViewModel / CollectionViewModel registered as a delegate has its
+//  cached state refreshed via `decoratorsDidChange()` — so the UI reflects
+//  the change without rebuilding the modal.
+//
+
+import XCTest
+import Foundation
+import SwiftUI
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorLiveUpdateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func waitForMainQueueToDrain() {
+        let exp = expectation(description: "Drain main queue")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    /// Polls until the delegate has been registered for the given field, or fails.
+    private func waitForDelegate(_ editor: DocumentEditor, fieldID: String, timeout: TimeInterval = 5.0) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if editor.delegateMap[fieldID]?.value != nil { return }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTFail("Delegate for fieldID \(fieldID) was not registered within \(timeout)s")
+    }
+
+    private func makeTableViewModel(editor: DocumentEditor) -> TableViewModel {
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let header = FieldHeaderModel(title: field?.title, required: field?.required,
+                                      tipDescription: field?.tipDescription,
+                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let model = TableDataModel(
+            fieldHeaderModel: header,
+            mode: .fill,
+            documentEditor: editor,
+            fieldIdentifier: FieldIdentifier(fieldID: ChangerHandlerSample.tableFieldID,
+                                             pageID: ChangerHandlerSample.pageID,
+                                             fileID: ChangerHandlerSample.fileID)
+        )
+        return TableViewModel(tableDataModel: model!)
+    }
+
+    private func makeCollectionViewModel(editor: DocumentEditor) -> CollectionViewModel {
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let header = FieldHeaderModel(title: field?.title, required: field?.required,
+                                      tipDescription: field?.tipDescription,
+                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let model = TableDataModel(
+            fieldHeaderModel: header,
+            mode: .fill,
+            documentEditor: editor,
+            fieldIdentifier: FieldIdentifier(fieldID: ChangerHandlerSample.collectionFieldID,
+                                             pageID: ChangerHandlerSample.pageID,
+                                             fileID: ChangerHandlerSample.fileID)
+        )
+        return CollectionViewModel(tableDataModel: model!)
+    }
+
+    // MARK: - TableViewModel
+
+    func testTableViewModel_addRowDecorator_updatesRowDecoratorsCache() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+        XCTAssertTrue(vm.tableDataModel.rowDecorators.isEmpty)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
+                             decorators: [makeDecorator(action: "live-row")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(vm.tableDataModel.rowDecorators.first?.action, "live-row")
+        XCTAssertTrue(vm.showRowDecorators)
+    }
+
+    func testTableViewModel_addColumnDecorator_updatesTableColumnsDecorators() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableColumnPath(),
+                             decorators: [makeDecorator(action: "live-col")])
+        waitForMainQueueToDrain()
+
+        let col = vm.tableDataModel.tableColumns.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "live-col")
+    }
+
+    func testTableViewModel_removeRowDecorator_updatesCache() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+        let path = ChangerHandlerSample.tableRowPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+        ])
+        waitForMainQueueToDrain()
+        XCTAssertEqual(vm.tableDataModel.rowDecorators.count, 2)
+
+        editor.removeDecorator(path: path, action: "a")
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(vm.tableDataModel.rowDecorators.map { $0.action }, ["b"])
+    }
+
+    func testTableViewModel_updateRowDecorator_updatesCache() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+        let path = ChangerHandlerSample.tableRowPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a", label: "Old")])
+        waitForMainQueueToDrain()
+
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "a", label: "New"))
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(vm.tableDataModel.rowDecorators.first?.label, "New")
+    }
+
+    // MARK: - CollectionViewModel
+
+    func testCollectionViewModel_addRootRowDecorator_updatesSchemaAndCache() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+                             decorators: [makeDecorator(action: "rootRow")])
+        waitForMainQueueToDrain()
+
+        // The DecoratorLocal cache used for rendering
+        let cached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionRootSchemaKey]
+        XCTAssertEqual(cached?.first?.action, "rootRow")
+
+        // The schema mirror that backs `hasAnyRowDecorators`
+        let schemaRow = vm.tableDataModel.schema[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators
+        XCTAssertEqual(schemaRow?.first?.action, "rootRow")
+    }
+
+    func testCollectionViewModel_addNestedRowDecorator_updatesNestedSchema() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowPath(),
+                             decorators: [makeDecorator(action: "nested")])
+        waitForMainQueueToDrain()
+
+        let cached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionNestedSchemaKey]
+        XCTAssertEqual(cached?.first?.action, "nested")
+        // Should not appear in the root schema cache
+        let rootCached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionRootSchemaKey] ?? []
+        XCTAssertNil(rootCached.first(where: { $0.action == "nested" }))
+    }
+
+    func testCollectionViewModel_addRootColumnDecorator_updatesRootTableColumns() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootColumnPath(),
+                             decorators: [makeDecorator(action: "rootCol")])
+        waitForMainQueueToDrain()
+
+        // Root mirror in tableDataModel.tableColumns
+        let mirroredCol = vm.tableDataModel.tableColumns.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        XCTAssertEqual(mirroredCol?.decorators?.first?.action, "rootCol")
+        // Schema-level columns
+        let schemaCol = vm.tableDataModel.schema[ChangerHandlerSample.collectionRootSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        XCTAssertEqual(schemaCol?.decorators?.first?.action, "rootCol")
+    }
+
+    func testCollectionViewModel_addNestedColumnDecorator_updatesSchemaTableColumns() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedColumnPath(),
+                             decorators: [makeDecorator(action: "nestedCol")])
+        waitForMainQueueToDrain()
+
+        let schemaCol = vm.tableDataModel.schema[ChangerHandlerSample.collectionNestedSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
+        XCTAssertEqual(schemaCol?.decorators?.first?.action, "nestedCol")
+    }
+
+    /// Regression: before the fix, `tableDataModel.schema` was not refreshed in `decoratorsDidChange()`,
+    /// so `hasAnyRowDecorators` (which reads from `schema.values`) returned false even after a row
+    /// decorator was added — meaning the row decorator column never appeared.
+    func testCollectionViewModel_hasAnyRowDecorators_flipsTrueAfterFirstAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertFalse(vm.tableDataModel.hasAnyRowDecorators, "starts with no row decorators")
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+                             decorators: [makeDecorator(action: "first")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators,
+                      "schema must be refreshed so hasAnyRowDecorators sees the new row decorator")
+        XCTAssertTrue(vm.showRowDecorators)
+    }
+
+    // MARK: - Lazy delegate creation
+
+    func testNoDelegateRegistered_lazilyCreates_noCrash_dataPersisted() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // No view model registered for the table field yet.
+        XCTAssertNil(editor.delegateMap[ChangerHandlerSample.tableFieldID]?.value)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
+                             decorators: [makeDecorator(action: "lazy")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        // Data persisted regardless of whether a UI was listening
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "lazy")
+    }
+
+    func testDelegateForOtherField_notAffected() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let tableVM = makeTableViewModel(editor: editor)
+
+        // Mutate the COLLECTION field — table VM should not be touched.
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+                             decorators: [makeDecorator(action: "collOnly")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(tableVM.tableDataModel.rowDecorators.isEmpty,
+                      "table view model must be untouched when a different field changes")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -176,6 +176,11 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let schemaCol = vm.tableDataModel.schema[ChangerHandlerSample.collectionRootSchemaKey]?
             .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
         XCTAssertEqual(schemaCol?.decorators?.first?.action, "rootCol")
+        // columnsMap (authoritative source read by CollectionModalTopNavigationView)
+        let mapKey = "\(ChangerHandlerSample.collectionRootSchemaKey)_\(ChangerHandlerSample.collectionRootColumnID)"
+        let mappedCol = vm.columnsMap[mapKey]
+        XCTAssertEqual(mappedCol?.decorators?.first?.action, "rootCol",
+                       "columnsMap must be rebuilt so the navigation view reads fresh column decorators")
     }
 
     func testCollectionViewModel_addNestedColumnDecorator_updatesSchemaTableColumns() {
@@ -190,6 +195,12 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let schemaCol = vm.tableDataModel.schema[ChangerHandlerSample.collectionNestedSchemaKey]?
             .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
         XCTAssertEqual(schemaCol?.decorators?.first?.action, "nestedCol")
+        // columnsMap — critical for nested columns, which the navigation view's old
+        // code path (RowType.header.tableColumns snapshot) left stale.
+        let mapKey = "\(ChangerHandlerSample.collectionNestedSchemaKey)_\(ChangerHandlerSample.collectionNestedColumnID)"
+        let mappedCol = vm.columnsMap[mapKey]
+        XCTAssertEqual(mappedCol?.decorators?.first?.action, "nestedCol",
+                       "nested column decorators must be reflected in columnsMap")
     }
 
     /// Regression: before the fix, `tableDataModel.schema` was not refreshed in `decoratorsDidChange()`,

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -148,6 +148,21 @@ final class DecoratorPathResolutionTests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "fieldA")
     }
 
+    // MARK: - Extra path segments
+
+    /// parsePath reads only the first 4 segments and silently discards the rest.
+    /// A 5-segment path resolves as a valid column path — the extra segment is ignored.
+    func testPathWithExtraSegments_resolvesAsColumnPath() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.tableColumnPath())/extraSegment"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "extra")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0,
+                       "extra segments are silently discarded by parsePath")
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "extra")
+    }
+
     // MARK: - Schema key resolution behaviour (verified via the public API result)
 
     // MARK: - rowId / columnId validation (resolver must reject unknown IDs)

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -150,26 +150,58 @@ final class DecoratorPathResolutionTests: XCTestCase {
 
     // MARK: - Schema key resolution behaviour (verified via the public API result)
 
-    func testSchemaKeyResolution_unknownRow_failsToResolveCollectionRow() {
-        // For collection row paths, an unknown rowId means schemaKey resolves to nil →
-        // setRowDecoratorsForPath bails out (it requires a schemaKey). Decorator should NOT persist.
-        let (editor, _) = makeChangerHandlerEditor()
+    // MARK: - rowId / columnId validation (resolver must reject unknown IDs)
+
+    func testInvalidRowId_collection_firesOnError_doesNotPersist() {
+        let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/unknownRowID"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghost")])
 
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "unknown rowId on collection must fire a decoratorError")
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        // None of the schemas should have picked up the ghost decorator.
         for (_, schema) in field?.schema ?? [:] {
             XCTAssertNil(schema.rowDecorators?.first(where: { $0.action == "ghost" }))
         }
     }
 
-    func testSchemaKeyResolution_tableRowDoesNotRequireSchema() {
-        // Even though the rowId given is bogus, the table row writer ignores schemaKey and writes
-        // to field.rowDecorators directly. This documents that table row decorators are field-scoped.
-        let (editor, _) = makeChangerHandlerEditor()
-        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/anyRowIdEvenBogus"
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableRowAny")])
-        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "tableRowAny")
+    func testInvalidRowId_table_firesOnError_doesNotPersist() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/bogusRowId"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostTableRow")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "unknown rowId on table must fire a decoratorError (no silent writes)")
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        XCTAssertNil(field?.rowDecorators?.first(where: { $0.action == "ghostTableRow" }),
+                     "the decorator must not leak into the field's global rowDecorators list")
+    }
+
+    func testInvalidColumnId_collection_firesOnError_doesNotPersist() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/bogusColId"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostCol")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        for (_, schema) in field?.schema ?? [:] {
+            for col in schema.tableColumns ?? [] {
+                XCTAssertNil(col.decorators?.first(where: { $0.action == "ghostCol" }))
+            }
+        }
+    }
+
+    func testInvalidColumnId_table_firesOnError_doesNotPersist() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/\(ChangerHandlerSample.tableRowID)/bogusColId"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostTableCol")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        for col in field?.tableColumns ?? [] {
+            XCTAssertNil(col.decorators?.first(where: { $0.action == "ghostTableCol" }))
+        }
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -1,0 +1,175 @@
+//
+//  DecoratorPathResolutionTests.swift
+//  JoyfillTests
+//
+//  Tests for the path-based decorator API: parsing, target resolution,
+//  schema-key resolution, and the cross-page shared-fp regression.
+//
+
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorPathResolutionTests: XCTestCase {
+
+    // MARK: - Field path
+
+    func testValidFieldPath_resolves() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        // No decorators yet → empty list, but no error.
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        // Round trip: write then read.
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "fieldA")])
+        XCTAssertEqual(editor.getDecorators(path: path).first?.action, "fieldA")
+    }
+
+    // MARK: - Row path
+
+    func testValidRowPath_table_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableRowPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableRow")])
+        let read = editor.getDecorators(path: path)
+        XCTAssertEqual(read.count, 1)
+        XCTAssertEqual(read.first?.action, "tableRow")
+        // Verify it landed on field.rowDecorators (table-scope).
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        XCTAssertEqual(field?.rowDecorators?.first?.action, "tableRow")
+    }
+
+    func testValidRowPath_collectionRoot_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootRowPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "rootRow")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRow")
+    }
+
+    func testValidRowPath_collectionNested_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionNestedRowPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "nestedRow")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRow")
+        // Should NOT have leaked into the root schema.
+        XCTAssertNil(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first(where: { $0.action == "nestedRow" }))
+    }
+
+    // MARK: - Column path
+
+    func testValidColumnPath_table_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableColumnPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableCol")])
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "tableCol")
+    }
+
+    func testValidColumnPath_collectionRoot_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootColumnPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "rootCol")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "rootCol")
+    }
+
+    func testValidColumnPath_collectionNested_resolves() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionNestedColumnPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "nestedCol")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let col = field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "nestedCol")
+    }
+
+    // MARK: - Shared field position regression
+
+    /// Navigation.json has `6970918d350238d0738dd5c9` as a field-position ID on BOTH page 1 and
+    /// page 2, pointing to two different text fields. Each page-scoped path must resolve to the
+    /// page's own field, not the first page's field.
+    func testSharedFieldPositionId_resolvesToCorrectPage() {
+        let (editor, _) = makeNavigationEditor()
+        let page1Path = "\(NavigationSample.page1ID)/\(NavigationSample.sharedFieldPositionID)"
+        let page2Path = "\(NavigationSample.page2ID)/\(NavigationSample.sharedFieldPositionID)"
+
+        editor.addDecorators(path: page1Path, decorators: [makeDecorator(action: "p1")])
+        editor.addDecorators(path: page2Path, decorators: [makeDecorator(action: "p2")])
+
+        XCTAssertEqual(editor.field(fieldID: NavigationSample.page1FieldID)?.decorators?.first?.action, "p1")
+        XCTAssertEqual(editor.field(fieldID: NavigationSample.page2FieldID)?.decorators?.first?.action, "p2")
+        // No cross-contamination
+        XCTAssertNil(editor.field(fieldID: NavigationSample.page1FieldID)?.decorators?.first(where: { $0.action == "p2" }))
+        XCTAssertNil(editor.field(fieldID: NavigationSample.page2FieldID)?.decorators?.first(where: { $0.action == "p1" }))
+    }
+
+    // MARK: - Invalid paths
+
+    func testInvalidPageId_returnsEmptyAndFiresOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "bogusPage/\(ChangerHandlerSample.tableFieldPositionID)"
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains(path) ?? false)
+    }
+
+    func testInvalidFieldPositionId_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/bogusFp"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+    }
+
+    func testEmptyPath_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        _ = editor.getDecorators(path: "")
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+    }
+
+    func testPathWithExtraSlashes_parsesCorrectly() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // Double slashes between segments should still parse to 2 segments → field path.
+        let path = "\(ChangerHandlerSample.pageID)//\(ChangerHandlerSample.tableFieldPositionID)"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "fieldA")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "fieldA")
+    }
+
+    func testPathWithTrailingSlash_parsesCorrectly() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.tableFieldPath())/"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "fieldA")])
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "fieldA")
+    }
+
+    // MARK: - Schema key resolution behaviour (verified via the public API result)
+
+    func testSchemaKeyResolution_unknownRow_failsToResolveCollectionRow() {
+        // For collection row paths, an unknown rowId means schemaKey resolves to nil →
+        // setRowDecoratorsForPath bails out (it requires a schemaKey). Decorator should NOT persist.
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/unknownRowID"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghost")])
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        // None of the schemas should have picked up the ghost decorator.
+        for (_, schema) in field?.schema ?? [:] {
+            XCTAssertNil(schema.rowDecorators?.first(where: { $0.action == "ghost" }))
+        }
+    }
+
+    func testSchemaKeyResolution_tableRowDoesNotRequireSchema() {
+        // Even though the rowId given is bogus, the table row writer ignores schemaKey and writes
+        // to field.rowDecorators directly. This documents that table row decorators are field-scoped.
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/anyRowIdEvenBogus"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableRowAny")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "tableRowAny")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -179,6 +179,51 @@ final class DecoratorPathResolutionTests: XCTestCase {
                      "the decorator must not leak into the field's global rowDecorators list")
     }
 
+    // MARK: - Cross-schema rowId / columnId mismatch
+
+    /// Passes a root-schema rowId with a nested-schema columnId. The column
+    /// exists in the field but belongs to a different schema than the row.
+    /// The resolver must reject this — otherwise the setter silently no-ops
+    /// because the column is not found in the row's resolved schema.
+    func testCrossSchemaColumnMismatch_rootRowNestedColumn_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // Root rowId + nested columnId → cross-schema mismatch
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/\(ChangerHandlerSample.collectionNestedColumnID)"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "crossSchema")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "cross-schema rowId/columnId mismatch must fire a decoratorError")
+        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
+
+        // Must not write to any schema
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        for (_, schema) in field?.schema ?? [:] {
+            for col in schema.tableColumns ?? [] {
+                XCTAssertNil(col.decorators?.first(where: { $0.action == "crossSchema" }),
+                             "cross-schema decorator must not leak into any schema's columns")
+            }
+        }
+    }
+
+    /// The inverse: nested-schema rowId with a root-schema columnId.
+    func testCrossSchemaColumnMismatch_nestedRowRootColumn_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // Nested rowId + root columnId → cross-schema mismatch
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionNestedRowID)/\(ChangerHandlerSample.collectionRootColumnID)"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "crossSchemaReverse")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "cross-schema rowId/columnId mismatch must fire a decoratorError")
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        for (_, schema) in field?.schema ?? [:] {
+            for col in schema.tableColumns ?? [] {
+                XCTAssertNil(col.decorators?.first(where: { $0.action == "crossSchemaReverse" }),
+                             "cross-schema decorator must not leak into any schema's columns")
+            }
+        }
+    }
+
     func testInvalidColumnId_collection_firesOnError_doesNotPersist() {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/bogusColId"

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -1,0 +1,175 @@
+//
+//  DecoratorPublicAPITests.swift
+//  JoyfillTests
+//
+//  Happy-path tests for getDecorators / addDecorators / removeDecorator / updateDecorator
+//  on field, row, and column scopes for both table and collection fields.
+//
+
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorPublicAPITests: XCTestCase {
+
+    // MARK: - getDecorators
+
+    func testGetDecorators_emptyField_returnsEmpty() {
+        let (editor, _) = makeChangerHandlerEditor()
+        XCTAssertEqual(editor.getDecorators(path: ChangerHandlerSample.tableFieldPath()).count, 0)
+    }
+
+    func testGetDecorators_returnsWhatWasWritten() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        let decs = [makeDecorator(action: "a"), makeDecorator(action: "b")]
+        editor.addDecorators(path: path, decorators: decs)
+        let read = editor.getDecorators(path: path)
+        XCTAssertEqual(read.map { $0.action }, ["a", "b"])
+    }
+
+    // MARK: - addDecorators
+
+    func testAddDecorators_toEmptyField_appendsAll() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x")])
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["x"])
+    }
+
+    func testAddDecorators_multipleInOneCall() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+            makeDecorator(action: "c"),
+        ])
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["a", "b", "c"])
+    }
+
+    func testAddDecorators_appendsToExistingList_preservesOrder() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "first")])
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "second")])
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["first", "second"])
+    }
+
+    func testAddDecorators_tableRow_persists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
+                             decorators: [makeDecorator(action: "row1")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "row1")
+    }
+
+    func testAddDecorators_collectionRootRow_persists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+                             decorators: [makeDecorator(action: "rootRow")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRow")
+    }
+
+    func testAddDecorators_collectionNestedRow_persistsToCorrectSchema() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowPath(),
+                             decorators: [makeDecorator(action: "nestedRow")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRow")
+    }
+
+    func testAddDecorators_tableColumn_persists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableColumnPath(),
+                             decorators: [makeDecorator(action: "col1")])
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "col1")
+    }
+
+    func testAddDecorators_collectionColumn_persists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootColumnPath(),
+                             decorators: [makeDecorator(action: "rootCol")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "rootCol")
+    }
+
+    // MARK: - removeDecorator
+
+    func testRemoveDecorator_existingAction_reducesList() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+        ])
+        editor.removeDecorator(path: path, action: "a")
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["b"])
+    }
+
+    func testRemoveDecorator_lastDecorator_listBecomesEmpty() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        editor.removeDecorator(path: path, action: "only")
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+    }
+
+    // MARK: - updateDecorator
+
+    func testUpdateDecorator_existingAction_replacesAtSameIndex() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a", icon: "flag", label: "Flag", color: "#FF0000"),
+            makeDecorator(action: "b", icon: "eye", label: "Eye", color: "#00FF00"),
+        ])
+        let replacement = makeDecorator(action: "a", icon: "camera", label: "Updated", color: "#0000FF")
+        editor.updateDecorator(path: path, action: "a", decorator: replacement)
+        let read = editor.getDecorators(path: path)
+        XCTAssertEqual(read.map { $0.action }, ["a", "b"]) // index preserved
+        XCTAssertEqual(read.first?.label, "Updated")
+        XCTAssertEqual(read.first?.color, "#0000FF")
+        XCTAssertEqual(read.first?.icon, "camera")
+    }
+
+    func testUpdateDecorator_preservesOtherDecorators() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+            makeDecorator(action: "c"),
+        ])
+        editor.updateDecorator(path: path, action: "b", decorator: makeDecorator(action: "b", label: "B-prime"))
+        let read = editor.getDecorators(path: path)
+        XCTAssertEqual(read.map { $0.action }, ["a", "b", "c"])
+        XCTAssertEqual(read[1].label, "B-prime")
+    }
+
+    // MARK: - End-to-end
+
+    func testMultipleConsecutiveOperations_finalStateCorrect() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableFieldPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a")])
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "b")])
+        editor.updateDecorator(path: path, action: "a", decorator: makeDecorator(action: "a", label: "AA"))
+        editor.removeDecorator(path: path, action: "b")
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "c")])
+        let read = editor.getDecorators(path: path)
+        XCTAssertEqual(read.map { $0.action }, ["a", "c"])
+        XCTAssertEqual(read.first?.label, "AA")
+    }
+
+    func testFieldMap_reflectsDecoratorChanges() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableFieldPath(),
+                             decorators: [makeDecorator(action: "live")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "live")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorTestSupport.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorTestSupport.swift
@@ -1,0 +1,125 @@
+//
+//  DecoratorTestSupport.swift
+//  JoyfillTests
+//
+//  Shared helpers and constants for the Decorator API test suite.
+//
+
+import Foundation
+import XCTest
+import JoyfillModel
+@testable import Joyfill
+
+// MARK: - Sample document constants
+
+/// Constants for `ChangerHandlerUnit.json` (table + collection with nested rows on a single page).
+enum ChangerHandlerSample {
+    static let fileID  = "685750ef698da1ab427761ba"
+    static let pageID  = "685750efeb612f4fac5819dd"
+
+    // Table
+    static let tableFieldPositionID = "6857510f4313cfbfb43c516c"
+    static let tableFieldID         = "685750f0489567f18eb8a9ec"
+    static let tableRowID           = "684c3fedfed2b76677110b19"
+    static let tableColumnID        = "684c3fedce82027a49234dd3"
+
+    // Collection (root + 1 nested schema)
+    static let collectionFieldPositionID = "68575112158ff5dbaa9f78e1"
+    static let collectionFieldID         = "6857510fbfed1553e168161b"
+    static let collectionRootRowID       = "68575bb9cdb3707c78d6b2ff"
+    static let collectionRootSchemaKey   = "collectionSchemaId"
+    static let collectionRootColumnID    = "684c3fedb0afd867adaeb3b4"
+    static let collectionNestedSchemaKey = "685753949107b403e2e4a949"
+    static let collectionNestedRowID     = "68575bc1921b69c15fad6c3f"
+    static let collectionNestedColumnID  = "68575394ffa57501fba78c4c"
+
+    // Path helpers
+    static func tableFieldPath()  -> String { "\(pageID)/\(tableFieldPositionID)" }
+    static func tableRowPath()    -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)" }
+    static func tableColumnPath() -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)/\(tableColumnID)" }
+
+    static func collectionFieldPath() -> String { "\(pageID)/\(collectionFieldPositionID)" }
+    static func collectionRootRowPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)" }
+    static func collectionNestedRowPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionNestedRowID)" }
+    static func collectionRootColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/\(collectionRootColumnID)" }
+    static func collectionNestedColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionNestedRowID)/\(collectionNestedColumnID)" }
+}
+
+/// Constants for `Navigation.json` — used only for the shared-field-position-ID regression test.
+enum NavigationSample {
+    static let fileID = "691f3762c80bfb0005c57b48"
+    static let page1ID = "69709dc281b4c8ab68c4db52"
+    static let page2ID = "691f376206195944e65eef76"
+    /// Same field position ID exists on both pages but points to different fields.
+    static let sharedFieldPositionID = "6970918d350238d0738dd5c9"
+    static let page1FieldID = "69709dc23a74ed2c22308a1d" // text
+    static let page2FieldID = "6970918d6d04413439c39d8b" // text
+}
+
+// MARK: - Mock events handler
+
+class MockDecoratorEvents: FormChangeEvent {
+    var capturedErrors: [JoyfillError] = []
+    var lastDecoratorErrorMessage: String? {
+        guard let last = capturedErrors.last else { return nil }
+        if case .decoratorError(let e) = last { return e.message }
+        return nil
+    }
+    var decoratorErrorCount: Int {
+        capturedErrors.filter { if case .decoratorError = $0 { return true } else { return false } }.count
+    }
+
+    func reset() { capturedErrors.removeAll() }
+
+    func onChange(changes: [Change], document: JoyDoc) {}
+    func onFocus(event: Joyfill.Event) {}
+    func onBlur(event: Joyfill.Event) {}
+    func onUpload(event: UploadEvent) {}
+    func onCapture(event: CaptureEvent) {}
+    func onError(error: JoyfillError) { capturedErrors.append(error) }
+}
+
+// MARK: - Decorator factory
+
+func makeDecorator(action: String,
+                   icon: String? = "flag",
+                   label: String? = "Test",
+                   color: String? = "#3B82F6") -> Decorator {
+    var d = Decorator()
+    d.action = action
+    d.icon = icon
+    d.label = label
+    d.color = color
+    return d
+}
+
+// MARK: - Editor factory
+
+func makeNavigationEditor(events: MockDecoratorEvents? = nil) -> (DocumentEditor, MockDecoratorEvents) {
+    let mock = events ?? MockDecoratorEvents()
+    let editor = DocumentEditor(document: sampleJSONDocument(fileName: "Navigation"),
+                                events: mock,
+                                validateSchema: false)
+    return (editor, mock)
+}
+
+func makeChangerHandlerEditor(events: MockDecoratorEvents? = nil) -> (DocumentEditor, MockDecoratorEvents) {
+    let mock = events ?? MockDecoratorEvents()
+    let license = (ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    let editor = DocumentEditor(document: sampleJSONDocument(fileName: "ChangerHandlerUnit"),
+                                events: mock,
+                                validateSchema: false,
+                                license: license.isEmpty ? nil : license)
+    return (editor, mock)
+}
+
+/// Editor with NO license — collection-field decorator writes are expected to fail.
+func makeUnlicensedChangerHandlerEditor(events: MockDecoratorEvents? = nil) -> (DocumentEditor, MockDecoratorEvents) {
+    let mock = events ?? MockDecoratorEvents()
+    let editor = DocumentEditor(document: sampleJSONDocument(fileName: "ChangerHandlerUnit"),
+                                events: mock,
+                                validateSchema: false,
+                                license: nil)
+    return (editor, mock)
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/ValidationTestCase.swift
@@ -4,11 +4,11 @@ import SwiftUI
 import JoyfillModel
 @testable import Joyfill
 
+let licenseKey: String = ""
+
 final class ValidationTestCase: XCTestCase {
     
     // MARK: - Test Helpers
-    let licenseKey: String = ""
-    
     /// Mock event handler to capture onChange events for testing
     class ChangeCapture: FormChangeEvent {
         var capturedChanges: [Change] = []

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -286,12 +286,8 @@ struct CollectionEditMultipleRowsSheetView: View {
         self.viewModel = viewModel
     }
     
-    private var tableColumns: [FieldTableColumn] {
-        return viewModel.getTableColumnsForSelectedRows()
-    }
-    
     @ViewBuilder
-    private func fieldTitle(_ col: FieldTableColumn, isCellFilled: Bool) -> some View {
+    private func fieldTitle(_ col: FieldTableColumn, isCellFilled: Bool, schemaKey: String) -> some View {
         HStack(alignment: .center, spacing: 4) {
             if let required = col.required, required, !isCellFilled {
                 Image(systemName: "asterisk")
@@ -302,8 +298,8 @@ struct CollectionEditMultipleRowsSheetView: View {
                 .font(.headline.bold())
             Spacer()
             if viewModel.tableDataModel.mode == .fill,
-               let decorators = col.decorators,
-               !decorators.isEmpty {
+               let liveCol = viewModel.columnsMap["\(schemaKey)_\(col.id ?? "")"],
+               let decorators = liveCol.decorators, !decorators.isEmpty {
                 let locals = decorators.compactMap { $0.isDisplayable ? DecoratorLocal(from: $0) : nil }
                 if !locals.isEmpty {
                     let parentPathForSelection: String? = {
@@ -464,7 +460,8 @@ struct CollectionEditMultipleRowsSheetView: View {
                     }
                 }
 
-                ForEach(Array(tableColumns.enumerated()), id: \.offset) { colIndex, col in
+                let header = viewModel.getHeaderForSelectedRows()
+                ForEach(Array(header.columns.enumerated()), id: \.offset) { colIndex, col in
                     let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
                     VStack(alignment: .leading, spacing: 16) {
                     if let row = viewModel.tableDataModel.selectedRows.first {
@@ -603,31 +600,31 @@ struct CollectionEditMultipleRowsSheetView: View {
 
                         switch col.type {
                         case .text:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableTextRowFormView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
                                 .frame(minHeight: 40)
                                 .cellBorder(isFocused: isFocused)
                                 .accessibilityIdentifier("EditRowsTextFieldIdentifier")
                         case .dropdown:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableDropDownOptionListView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
                                 .cellBorder(isFocused: isFocused)
                                 .accessibilityIdentifier("EditRowsDropdownFieldIdentifier")
                         case .date:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableDateView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
                                 .padding(.vertical, 2)
                                 .cellBorder(isFocused: isFocused)
                                 .accessibilityIdentifier("EditRowsDateFieldIdentifier")
                         case .number:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableNumberView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
                                 .keyboardType(.decimalPad)
                                 .frame(minHeight: 40)
                                 .cellBorder(isFocused: isFocused)
                                 .accessibilityIdentifier("EditRowsNumberFieldIdentifier")
                         case .multiSelect:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableMultiSelectView(cellModel: Binding.constant(cellModel),isUsedForBulkEdit: isUsedForBulkEdit)
                                 .padding(.vertical, 4)
                                 .cellBorder(isFocused: isFocused)
@@ -641,7 +638,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                                     cellModel = newValue
                                 }
                             )
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             HStack {
                                 Spacer()
                                 TableImageView(cellModel: bindingCellModel, isUsedForBulkEdit: isUsedForBulkEdit, viewModel: viewModel)
@@ -660,7 +657,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                                     cellModel = newValue
                                 }
                             )
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             HStack {
                                 Spacer()
                                 TableSignatureView(cellModel: bindingCellModel, isUsedForBulkEdit: isUsedForBulkEdit)
@@ -670,14 +667,14 @@ struct CollectionEditMultipleRowsSheetView: View {
                             .cellBorder(isFocused: isFocused)
                             .accessibilityIdentifier("EditRowsSignatureFieldIdentifier")
                         case .barcode:
-                            fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                            fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                             TableBarcodeView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit, viewModel: viewModel)
                                 .frame(minHeight: 40)
                                 .cellBorder(isFocused: isFocused)
                                 .accessibilityIdentifier("EditRowsBarcodeFieldIdentifier")
                         case .block:
                             if !isUsedForBulkEdit {
-                                fieldTitle(col, isCellFilled: isEffectivelyFilled)
+                                fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
                                 TableBlockView(cellModel: Binding.constant(cellModel))
                                     .frame(minHeight: 40)
                                     .cellBorder(isFocused: isFocused)

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -2036,7 +2036,42 @@ extension CollectionViewModel {
 
 // MARK: - DocumentEditorDelegate methods
 extension CollectionViewModel: DocumentEditorDelegate {
-    
+
+    func decoratorsDidChange() {
+        guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
+
+        // Row decorators per schema key
+        field.schema?.forEach { key, value in
+            tableDataModel.rowDecoratorsBySchemaKey[key] = value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+        }
+
+        // Column decorators — update schema-level columns
+        field.schema?.forEach { key, freshSchema in
+            if let freshCols = freshSchema.tableColumns {
+                if var existingSchema = tableDataModel.schema[key] {
+                    var existingCols = existingSchema.tableColumns ?? []
+                    for (i, col) in existingCols.enumerated() {
+                        if let freshCol = freshCols.first(where: { $0.id == col.id }) {
+                            existingCols[i].decorators = freshCol.decorators
+                        }
+                    }
+                    existingSchema.tableColumns = existingCols
+                    tableDataModel.schema[key] = existingSchema
+                }
+            }
+        }
+
+        // Update root-level tableColumns (mirrors root schema's columns)
+        if let rootKey = tableDataModel.schema.first(where: { $0.value.root == true })?.key,
+           let freshRootCols = field.schema?[rootKey]?.tableColumns {
+            for (i, col) in tableDataModel.tableColumns.enumerated() {
+                if let freshCol = freshRootCols.first(where: { $0.id == col.id }) {
+                    tableDataModel.tableColumns[i].decorators = freshCol.decorators
+                }
+            }
+        }
+    }
+
     func applyRowEditChanges(change: Change) {
         guard let rowID = change.change?["rowId"] as? String,
               let existingRow = rowToValueElementMap[rowID] else {

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -228,20 +228,21 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
     
     func getTableColumnsForSelectedRows() -> [FieldTableColumn] {
+        return getHeaderForSelectedRows().columns
+    }
+
+    func getHeaderForSelectedRows() -> (columns: [FieldTableColumn], schemaKey: String) {
         guard let firstSelectedRow = tableDataModel.selectedRows.first else {
             Log("No row selected", type: .error)
-            return []
+            return ([], rootSchemaKey)
         }
         
         let indexOfFirstSelectedRow = tableDataModel.filteredcellModels.firstIndex(where: { $0.rowID == firstSelectedRow } ) ?? 0
-        
-        let tableColumns = getTableColumnsByIndex(indexOfFirstSelectedRow)
-        if tableColumns.count > 0 {
-            return tableColumns
-        } else {
-            return tableDataModel.tableColumns
+        let header = getHeaderByIndex(indexOfFirstSelectedRow)
+        if !header.columns.isEmpty {
+            return header
         }
-        
+        return (tableDataModel.tableColumns, rootSchemaKey)
     }
     
     func isRootSchemaValid() -> Bool {
@@ -1026,11 +1027,15 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
     
     fileprivate func getTableColumnsByIndex(_ indexOfFirstSelectedRow: Int) -> [FieldTableColumn] {
+        return getHeaderByIndex(indexOfFirstSelectedRow).columns
+    }
+
+    fileprivate func getHeaderByIndex(_ indexOfFirstSelectedRow: Int) -> (columns: [FieldTableColumn], schemaKey: String) {
         for indexOfCurrentRow in stride(from: indexOfFirstSelectedRow, through: 0, by: -1) {
             switch tableDataModel.filteredcellModels[indexOfCurrentRow].rowType {
-            case .header(level: let level, tableColumns: let tableColumns, _):
+            case .header(level: let level, tableColumns: let tableColumns, let schemaKey):
                 if level == tableDataModel.filteredcellModels[indexOfFirstSelectedRow].rowType.level {
-                    return tableColumns
+                    return (tableColumns, schemaKey)
                 } else {
                     continue
                 }
@@ -1038,7 +1043,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                 continue
             }
         }
-        return []
+        return ([], rootSchemaKey)
     }
     
     func duplicateRow() {
@@ -2047,10 +2052,11 @@ extension CollectionViewModel: DocumentEditorDelegate {
         field.schema?.forEach { key, value in
             tableDataModel.rowDecoratorsBySchemaKey[key] = value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
         }
-
+        // Update columnsMap for decorators
+        self.columnsMap = self.getTableColumns(tableDataModel: self.tableDataModel)
+        
         // Update root-level tableColumns (mirrors root schema's columns)
-        if let rootKey = tableDataModel.schema.first(where: { $0.value.root == true })?.key,
-           let freshRootCols = field.schema?[rootKey]?.tableColumns {
+        if let freshRootCols = field.schema?[rootSchemaKey]?.tableColumns {
             for (i, col) in tableDataModel.tableColumns.enumerated() {
                 if let freshCol = freshRootCols.first(where: { $0.id == col.id }) {
                     tableDataModel.tableColumns[i].decorators = freshCol.decorators
@@ -2058,6 +2064,7 @@ extension CollectionViewModel: DocumentEditorDelegate {
             }
         }
     }
+
 
     func applyRowEditChanges(change: Change) {
         guard let rowID = change.change?["rowId"] as? String,

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -2040,25 +2040,12 @@ extension CollectionViewModel: DocumentEditorDelegate {
     func decoratorsDidChange() {
         guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
 
-        // Row decorators per schema key
+        // Refresh the entire schema so hasAnyRowDecorators and column decorators stay in sync
+        tableDataModel.schema = field.schema ?? [:]
+
+        // Row decorators per schema key (local DecoratorLocal cache)
         field.schema?.forEach { key, value in
             tableDataModel.rowDecoratorsBySchemaKey[key] = value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
-        }
-
-        // Column decorators — update schema-level columns
-        field.schema?.forEach { key, freshSchema in
-            if let freshCols = freshSchema.tableColumns {
-                if var existingSchema = tableDataModel.schema[key] {
-                    var existingCols = existingSchema.tableColumns ?? []
-                    for (i, col) in existingCols.enumerated() {
-                        if let freshCol = freshCols.first(where: { $0.id == col.id }) {
-                            existingCols[i].decorators = freshCol.decorators
-                        }
-                    }
-                    existingSchema.tableColumns = existingCols
-                    tableDataModel.schema[key] = existingSchema
-                }
-            }
         }
 
         // Update root-level tableColumns (mirrors root schema's columns)

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -2050,7 +2050,7 @@ extension CollectionViewModel: DocumentEditorDelegate {
 
         // Row decorators per schema key (local DecoratorLocal cache)
         field.schema?.forEach { key, value in
-            tableDataModel.rowDecoratorsBySchemaKey[key] = value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+            tableDataModel.setRowDecorators(value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? [], forSchemaKey: key)
         }
         // Update columnsMap for decorators
         self.columnsMap = self.getTableColumns(tableDataModel: self.tableDataModel)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -628,6 +628,24 @@ extension TableViewModel: DocumentEditorDelegate {
         }
     }
     
+    func decoratorsDidChange() {
+        guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
+
+        // Row decorators
+        if field.fieldType == .table {
+            tableDataModel.rowDecorators = field.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+        }
+
+        // Column decorators
+        if let freshColumns = field.tableColumns {
+            for (i, col) in tableDataModel.tableColumns.enumerated() {
+                if let freshCol = freshColumns.first(where: { $0.id == col.id }) {
+                    tableDataModel.tableColumns[i].decorators = freshCol.decorators
+                }
+            }
+        }
+    }
+
     func applyRowEditChanges(change: Change) {
         guard let rowID = change.change?["rowId"] as? String else {
             Log("RowID not found or no cached ValueElement", type: .error)

--- a/Sources/JoyfillUI/View/Types.swift
+++ b/Sources/JoyfillUI/View/Types.swift
@@ -321,6 +321,15 @@ public protocol FormChangeEvent {
 public enum JoyfillError: Error {
     case schemaValidationError(error: SchemaValidationError)
     case schemaVersionError(error: SchemaValidationError)
+    case decoratorError(error: DecoratorError)
+}
+
+public struct DecoratorError: Error {
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
 }
 
 public struct SchemaValidationError: Error {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -196,13 +196,17 @@ private extension DocumentEditor {
               let page = pagesForCurrentView.first(where: { $0.id == pageId }),
               let position = page.fieldPositions?.first(where: { $0.id == fieldPositionId }),
               let fieldID = position.field,
-              fieldMap[fieldID] != nil else { return nil }
+              let field = fieldMap[fieldID] else { return nil }
 
         if let columnId = parsed.columnId {
+            guard let rowId = parsed.rowId else { return nil }
+            guard rowExistsInField(fieldID: fieldID, rowId: rowId),
+                  columnExistsInField(field, columnId: columnId) else { return nil }
             // 4 segments → column decorators; rowId resolves the schema for collection fields
             let schemaKey = parsed.rowId.flatMap { resolvedSchemaKey(forRowID: $0, inFieldID: fieldID) }
             return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
         } else if let rowId = parsed.rowId {
+            guard rowExistsInField(fieldID: fieldID, rowId: rowId) else { return nil }
             // 3 segments → row decorators; resolve schemaKey from the rowId
             let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
             return .row(fieldID: fieldID, schemaKey: schemaKey)

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -19,12 +19,13 @@ public extension DocumentEditor {
 
     /// Appends one or more decorators at the given path.
     func addDecorators(path: String, decorators: [Decorator]) {
+        guard !decorators.isEmpty else { return }
         guard let target = resolveDecoratorTarget(path: path) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
         }
         guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
-        guard !decorators.isEmpty else { return }
+        
         for decorator in decorators {
             if let error = validateDecorator(decorator) {
                 events?.onError(error: .decoratorError(error: DecoratorError(message: error)))

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -11,7 +11,7 @@ public extension DocumentEditor {
     /// Returns all decorators at the given path.
     func getDecorators(path: String) -> [Decorator] {
         guard let target = resolveDecoratorTarget(path: path) else {
-            Log("getDecorators: could not resolve path '\(path)'", type: .warning)
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return []
         }
         return fetchDecorators(for: target)
@@ -20,8 +20,14 @@ public extension DocumentEditor {
     /// Appends one or more decorators at the given path.
     func addDecorators(path: String, decorators: [Decorator]) {
         guard let target = resolveDecoratorTarget(path: path) else {
-            Log("addDecorators: could not resolve path '\(path)'", type: .warning)
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
+        }
+        for decorator in decorators {
+            if let error = validateDecorator(decorator) {
+                events?.onError(error: .decoratorError(error: DecoratorError(message: error)))
+                return
+            }
         }
         var list = fetchDecorators(for: target)
         list.append(contentsOf: decorators)
@@ -31,23 +37,32 @@ public extension DocumentEditor {
     /// Removes the decorator whose `action` matches at the given path.
     func removeDecorator(path: String, action: String) {
         guard let target = resolveDecoratorTarget(path: path) else {
-            Log("removeDecorator: could not resolve path '\(path)'", type: .warning)
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
         }
         var list = fetchDecorators(for: target)
+        let countBefore = list.count
         list.removeAll { $0.action == action }
+        if list.count == countBefore {
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to remove decorator with action: '\(action)'")))
+            return
+        }
         applyDecorators(list, for: target)
     }
 
     /// Replaces the decorator whose `action` matches with the new decorator at the given path.
     func updateDecorator(path: String, action: String, decorator: Decorator) {
         guard let target = resolveDecoratorTarget(path: path) else {
-            Log("updateDecorator: could not resolve path '\(path)'", type: .warning)
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
+            return
+        }
+        if let error = validateDecorator(decorator) {
+            events?.onError(error: .decoratorError(error: DecoratorError(message: error)))
             return
         }
         var list = fetchDecorators(for: target)
         guard let index = list.firstIndex(where: { $0.action == action }) else {
-            Log("updateDecorator: no decorator with action '\(action)' found at path '\(path)'", type: .warning)
+            events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to update decorator with action: '\(action)'")))
             return
         }
         list[index] = decorator
@@ -58,6 +73,25 @@ public extension DocumentEditor {
 // MARK: - Private helpers
 
 private extension DocumentEditor {
+
+    // MARK: Decorator validation
+
+    /// Validates decorator properties. Returns an error message if invalid, nil if valid.
+    func validateDecorator(_ decorator: Decorator) -> String? {
+        if let action = decorator.action, action.isEmpty {
+            return "Invalid decorator property: 'action' must not be empty"
+        }
+        if decorator.action == nil {
+            return "Invalid decorator property: 'action' is required"
+        }
+        if let color = decorator.color, !color.isEmpty {
+            let hexPattern = "^#[0-9A-Fa-f]{6}$"
+            if color.range(of: hexPattern, options: .regularExpression) == nil {
+                return "Invalid decorator property: 'color' must be a hex string (e.g. #3B82F6), got '\(color)'"
+            }
+        }
+        return nil
+    }
 
     // MARK: Field Decorators
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -227,10 +227,10 @@ private extension DocumentEditor {
 
         if let columnId = parsed.columnId {
             guard let rowId = parsed.rowId else { return nil }
-            guard rowExistsInField(fieldID: fieldID, rowId: rowId),
-                  columnExistsInField(field, columnId: columnId) else { return nil }
+            guard rowExistsInField(fieldID: fieldID, rowId: rowId) else { return nil }
             // 4 segments → column decorators; rowId resolves the schema for collection fields
-            let schemaKey = parsed.rowId.flatMap { resolvedSchemaKey(forRowID: $0, inFieldID: fieldID) }
+            let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
+            guard columnExistsInField(field, columnId: columnId, schemaKey: schemaKey) else { return nil }
             return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
         } else if let rowId = parsed.rowId {
             guard rowExistsInField(fieldID: fieldID, rowId: rowId) else { return nil }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -129,11 +129,11 @@ private extension DocumentEditor {
         let parsed = DocumentEditor.parsePath(path)
 
         guard let pageId = parsed.pageId,
-            let fieldPositionId = parsed.fieldPositionId,
-            let fieldIdentifier = getFieldIdentifier(forFieldPositionID: fieldPositionId),
-            fieldIdentifier.pageID == pageId else { return nil }
-
-        let fieldID = fieldIdentifier.fieldID
+              let fieldPositionId = parsed.fieldPositionId,
+              let page = pagesForCurrentView.first(where: { $0.id == pageId }),
+              let position = page.fieldPositions?.first(where: { $0.id == fieldPositionId }),
+              let fieldID = position.field,
+              fieldMap[fieldID] != nil else { return nil }
 
         if let columnId = parsed.columnId {
             // 4 segments → column decorators; rowId resolves the schema for collection fields

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -7,6 +7,9 @@ public extension DocumentEditor {
     // path = "pageId/fieldPositionId"             → field decorators
     // path = "pageId/fieldPositionId/rowId"        → row decorators
     // path = "pageId/fieldPositionId/rowId/colId"  → column decorators
+    //
+    // Note: Path segments are parsed with empty-component filtering;
+    // consecutive or trailing slashes are treated as single separators.
 
     /// Returns all decorators at the given path.
     func getDecorators(path: String) -> [Decorator] {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -111,6 +111,7 @@ private extension DocumentEditor {
         }
         updateField(field: field)
         refreshField(fieldId: fieldID)
+        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
     }
 
     // MARK: Path resolution
@@ -231,6 +232,7 @@ private extension DocumentEditor {
         }
         updateField(field: field)
         refreshField(fieldId: fieldID)
+        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
     }
 
     // MARK: Generic fetch / apply routers

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -10,6 +10,9 @@ public extension DocumentEditor {
     //
     // Note: Path segments are parsed with empty-component filtering;
     // consecutive or trailing slashes are treated as single separators.
+    //
+    // All methods in this section must be called on the main thread,
+    // consistent with the DocumentEditor threading model.
 
     /// Returns all decorators at the given path.
     func getDecorators(path: String) -> [Decorator] {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -23,6 +23,7 @@ public extension DocumentEditor {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
         }
+        guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
         for decorator in decorators {
             if let error = validateDecorator(decorator) {
                 events?.onError(error: .decoratorError(error: DecoratorError(message: error)))
@@ -40,6 +41,7 @@ public extension DocumentEditor {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
         }
+        guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
         var list = fetchDecorators(for: target)
         let countBefore = list.count
         list.removeAll { $0.action == action }
@@ -56,6 +58,7 @@ public extension DocumentEditor {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
             return
         }
+        guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
         if let error = validateDecorator(decorator) {
             events?.onError(error: .decoratorError(error: DecoratorError(message: error)))
             return
@@ -73,6 +76,31 @@ public extension DocumentEditor {
 // MARK: - Private helpers
 
 private extension DocumentEditor {
+
+    // MARK: License gating
+
+    /// Returns the fieldID associated with a decorator target.
+    func fieldID(for target: DecoratorTarget) -> String {
+        switch target {
+        case .field(let fieldID): return fieldID
+        case .row(let fieldID, _): return fieldID
+        case .column(let fieldID, _, _): return fieldID
+        }
+    }
+
+    /// Blocks writes to collection-field decorators when the collection feature
+    /// is not enabled by the license. Emits a decoratorError and returns false.
+    func licenseAllowsDecoratorWrite(for target: DecoratorTarget, path: String) -> Bool {
+        let fieldID = self.fieldID(for: target)
+        guard let field = fieldMap[fieldID] else { return true }
+        if field.fieldType == .collection && !isCollectionFieldEnabled {
+            events?.onError(error: .decoratorError(error: DecoratorError(
+                message: "Collection field decorators are not available without a valid license (path '\(path)')"
+            )))
+            return false
+        }
+        return true
+    }
 
     // MARK: Decorator validation
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -31,6 +31,24 @@ public extension DocumentEditor {
             }
         }
         var list = fetchDecorators(for: target)
+        let existingActions = Set(list.compactMap { $0.action })
+        let newActions = decorators.compactMap { $0.action }
+
+        // Check duplicates within incoming batch
+        if Set(newActions).count != newActions.count {
+            events?.onError(error: .decoratorError(error: DecoratorError(
+                message: "Duplicate decorators found in the incoming batch at path '\(path)'"
+            )))
+            return
+        }
+
+        // Check duplicates against existing decorators
+        if let duplicate = newActions.first(where: { existingActions.contains($0) }) {
+            events?.onError(error: .decoratorError(error: DecoratorError(
+                message: "Decorator with action '\(duplicate)' already exists at path '\(path)'"
+            )))
+            return
+        }
         list.append(contentsOf: decorators)
         applyDecorators(list, for: target)
     }
@@ -43,12 +61,11 @@ public extension DocumentEditor {
         }
         guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
         var list = fetchDecorators(for: target)
-        let countBefore = list.count
-        list.removeAll { $0.action == action }
-        if list.count == countBefore {
+        guard let index = list.firstIndex(where: { $0.action == action }) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to remove decorator with action: '\(action)'")))
             return
         }
+        list.remove(at: index)
         applyDecorators(list, for: target)
     }
 
@@ -66,6 +83,16 @@ public extension DocumentEditor {
         var list = fetchDecorators(for: target)
         guard let index = list.firstIndex(where: { $0.action == action }) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to update decorator with action: '\(action)'")))
+            return
+        }
+        // If the new decorator's action differs from the target action, ensure it
+        // doesn't collide with a different existing entry (would create duplicates).
+        if let newAction = decorator.action,
+           newAction != action,
+           list.contains(where: { $0.action == newAction }) {
+            events?.onError(error: .decoratorError(error: DecoratorError(
+                message: "Decorator with action '\(newAction)' already exists at path '\(path)'"
+            )))
             return
         }
         list[index] = decorator

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -24,6 +24,7 @@ public extension DocumentEditor {
             return
         }
         guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
+        guard !decorators.isEmpty else { return }
         for decorator in decorators {
             if let error = validateDecorator(decorator) {
                 events?.onError(error: .decoratorError(error: DecoratorError(message: error)))

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -1,0 +1,263 @@
+import JoyfillModel
+
+public extension DocumentEditor {
+
+    // MARK: - Path-Based API
+    //
+    // path = "pageId/fieldPositionId"             → field decorators
+    // path = "pageId/fieldPositionId/rowId"        → row decorators
+    // path = "pageId/fieldPositionId/rowId/colId"  → column decorators
+
+    /// Returns all decorators at the given path.
+    func getDecorators(path: String) -> [Decorator] {
+        guard let target = resolveDecoratorTarget(path: path) else {
+            Log("getDecorators: could not resolve path '\(path)'", type: .warning)
+            return []
+        }
+        return fetchDecorators(for: target)
+    }
+
+    /// Appends one or more decorators at the given path.
+    func addDecorators(path: String, decorators: [Decorator]) {
+        guard let target = resolveDecoratorTarget(path: path) else {
+            Log("addDecorators: could not resolve path '\(path)'", type: .warning)
+            return
+        }
+        var list = fetchDecorators(for: target)
+        list.append(contentsOf: decorators)
+        applyDecorators(list, for: target)
+    }
+
+    /// Removes the decorator whose `action` matches at the given path.
+    func removeDecorator(path: String, action: String) {
+        guard let target = resolveDecoratorTarget(path: path) else {
+            Log("removeDecorator: could not resolve path '\(path)'", type: .warning)
+            return
+        }
+        var list = fetchDecorators(for: target)
+        list.removeAll { $0.action == action }
+        applyDecorators(list, for: target)
+    }
+
+    /// Replaces the decorator whose `action` matches with the new decorator at the given path.
+    func updateDecorator(path: String, action: String, decorator: Decorator) {
+        guard let target = resolveDecoratorTarget(path: path) else {
+            Log("updateDecorator: could not resolve path '\(path)'", type: .warning)
+            return
+        }
+        var list = fetchDecorators(for: target)
+        guard let index = list.firstIndex(where: { $0.action == action }) else {
+            Log("updateDecorator: no decorator with action '\(action)' found at path '\(path)'", type: .warning)
+            return
+        }
+        list[index] = decorator
+        applyDecorators(list, for: target)
+    }
+}
+
+// MARK: - Private helpers
+
+private extension DocumentEditor {
+
+    // MARK: Field Decorators
+
+    func decorators(forFieldID fieldID: String) -> [Decorator] {
+        fieldMap[fieldID]?.decorators ?? []
+    }
+
+    func setDecorators(_ decorators: [Decorator], forFieldID fieldID: String) {
+        guard var field = fieldMap[fieldID] else { return }
+        field.decorators = decorators
+        updateField(field: field)
+        refreshField(fieldId: fieldID)
+    }
+
+    // MARK: Column Decorators
+    //
+    // - Table fields:      columns live on field.tableColumns      → schemaKey is nil
+    // - Collection fields: columns live on field.schema[key].tableColumns → schemaKey is non-nil
+
+    func columnDecoratorsForPath(fieldID: String, columnID: String, schemaKey: String?) -> [Decorator] {
+        guard let field = fieldMap[fieldID] else { return [] }
+        let columns: [FieldTableColumn]?
+        if field.fieldType == .collection {
+            guard let schemaKey = schemaKey else { return [] }
+            columns = field.schema?[schemaKey]?.tableColumns
+        } else {
+            columns = field.tableColumns
+        }
+        return columns?.first(where: { $0.id == columnID })?.decorators ?? []
+    }
+
+    func setColumnDecoratorsForPath(_ decorators: [Decorator], fieldID: String, columnID: String, schemaKey: String?) {
+        guard var field = fieldMap[fieldID] else { return }
+        if field.fieldType == .collection {
+            // Collection field: update column inside the schema entry
+            guard let schemaKey = schemaKey,
+                  var schema    = field.schema,
+                  var entry     = schema[schemaKey],
+                  var columns   = entry.tableColumns,
+                  let colIndex  = columns.firstIndex(where: { $0.id == columnID }) else { return }
+            columns[colIndex].decorators = decorators
+            entry.tableColumns  = columns
+            schema[schemaKey]   = entry
+            field.schema        = schema
+        } else {
+            // Table field: update column directly on the field
+            guard var columns  = field.tableColumns,
+                  let colIndex = columns.firstIndex(where: { $0.id == columnID }) else { return }
+            columns[colIndex].decorators = decorators
+            field.tableColumns = columns
+        }
+        updateField(field: field)
+        refreshField(fieldId: fieldID)
+    }
+
+    // MARK: Path resolution
+
+    /// Resolved decorator scope from a path string.
+    enum DecoratorTarget {
+        case field(fieldID: String)
+        case row(fieldID: String, schemaKey: String?)
+        case column(fieldID: String, columnID: String, schemaKey: String?)
+    }
+
+    /// Parses the path and maps it to the correct decorator scope.
+    /// The rowId segment resolves the schemaKey for both row and column paths on
+    /// collection fields. Table fields always resolve to schemaKey = nil.
+    func resolveDecoratorTarget(path: String) -> DecoratorTarget? {
+        let parsed = DocumentEditor.parsePath(path)
+
+        guard
+            let pageId          = parsed.pageId,
+            let fieldPositionId = parsed.fieldPositionId,
+            let fieldIdentifier = getFieldIdentifier(forFieldPositionID: fieldPositionId),
+            fieldIdentifier.pageID == pageId
+        else { return nil }
+
+        let fieldID = fieldIdentifier.fieldID
+
+        if let columnId = parsed.columnId {
+            // 4 segments → column decorators; rowId resolves the schema for collection fields
+            let schemaKey = parsed.rowId.flatMap { resolvedSchemaKey(forRowID: $0, inFieldID: fieldID) }
+            return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
+        } else if let rowId = parsed.rowId {
+            // 3 segments → row decorators; resolve schemaKey from the rowId
+            let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
+            return .row(fieldID: fieldID, schemaKey: schemaKey)
+        } else {
+            // 2 segments → field decorators
+            return .field(fieldID: fieldID)
+        }
+    }
+
+    // MARK: Schema key resolution
+
+    /// Returns the schemaKey the given rowId belongs to.
+    ///
+    /// - Table fields always return nil (row decorators live at field level).
+    /// - Collection fields: root-level rows map to the schema entry where
+    ///   `root == true`; nested rows return the key found in their parent's
+    ///   `childrens` map.
+    func resolvedSchemaKey(forRowID rowID: String, inFieldID fieldID: String) -> String? {
+        guard let field = fieldMap[fieldID] else { return nil }
+
+        // Table fields store row decorators at the field level, no schemaKey needed
+        if field.fieldType == .table { return nil }
+
+        let rootRows = field.valueToValueElements ?? []
+
+        // Root schema = the schema entry flagged with root == true
+        let rootSchemaKey = field.schema?.first { $0.value.root == true }?.key
+
+        // Check root-level rows first
+        if rootRows.contains(where: { $0.id == rowID }) {
+            return rootSchemaKey
+        }
+
+        // Recursively search nested children
+        for row in rootRows {
+            if let found = schemaKey(forRowID: rowID, in: row) {
+                return found
+            }
+        }
+
+        return nil
+    }
+
+    /// Recursively walks a ValueElement's `childrens` map to find which
+    /// schemaKey contains the given rowId.
+    func schemaKey(forRowID rowID: String, in element: ValueElement) -> String? {
+        guard let childrens = element.childrens else { return nil }
+        for (schemaKey, children) in childrens {
+            let childRows = children.valueToValueElements ?? []
+            if childRows.contains(where: { $0.id == rowID }) {
+                return schemaKey
+            }
+            // Go one level deeper
+            for child in childRows {
+                if let found = self.schemaKey(forRowID: rowID, in: child) {
+                    return found
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: Row decorator read/write (path-based, independent of the public API)
+
+    /// Reads row decorators directly from the field model.
+    /// - nil schemaKey → table field, reads `field.rowDecorators`
+    /// - non-nil schemaKey → collection field, reads `field.schema[schemaKey].rowDecorators`
+    func rowDecoratorsForPath(fieldID: String, schemaKey: String?) -> [Decorator] {
+        guard let field = fieldMap[fieldID] else { return [] }
+        if field.fieldType == .collection {
+            guard let schemaKey = schemaKey else { return [] }
+            return field.schema?[schemaKey]?.rowDecorators ?? []
+        }
+        return field.rowDecorators ?? []
+    }
+
+    /// Writes row decorators directly to the field model.
+    func setRowDecoratorsForPath(_ decorators: [Decorator], fieldID: String, schemaKey: String?) {
+        guard var field = fieldMap[fieldID] else { return }
+        if field.fieldType == .collection {
+            guard var schema = field.schema,
+                  let schemaKey = schemaKey,
+                  var entry  = schema[schemaKey] else { return }
+            entry.rowDecorators = decorators
+            schema[schemaKey]   = entry
+            field.schema        = schema
+        } else {
+            field.rowDecorators = decorators
+        }
+        updateField(field: field)
+        refreshField(fieldId: fieldID)
+    }
+
+    // MARK: Generic fetch / apply routers
+
+    /// Returns the current decorator list for a resolved target.
+    func fetchDecorators(for target: DecoratorTarget) -> [Decorator] {
+        switch target {
+        case .field(let fieldID):
+            return decorators(forFieldID: fieldID)
+        case .row(let fieldID, let schemaKey):
+            return rowDecoratorsForPath(fieldID: fieldID, schemaKey: schemaKey)
+        case .column(let fieldID, let columnID, let schemaKey):
+            return columnDecoratorsForPath(fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
+        }
+    }
+
+    /// Persists an updated decorator list for a resolved target.
+    func applyDecorators(_ decorators: [Decorator], for target: DecoratorTarget) {
+        switch target {
+        case .field(let fieldID):
+            setDecorators(decorators, forFieldID: fieldID)
+        case .row(let fieldID, let schemaKey):
+            setRowDecoratorsForPath(decorators, fieldID: fieldID, schemaKey: schemaKey)
+        case .column(let fieldID, let columnID, let schemaKey):
+            setColumnDecoratorsForPath(decorators, fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
+        }
+    }
+}

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -128,12 +128,10 @@ private extension DocumentEditor {
     func resolveDecoratorTarget(path: String) -> DecoratorTarget? {
         let parsed = DocumentEditor.parsePath(path)
 
-        guard
-            let pageId          = parsed.pageId,
+        guard let pageId = parsed.pageId,
             let fieldPositionId = parsed.fieldPositionId,
             let fieldIdentifier = getFieldIdentifier(forFieldPositionID: fieldPositionId),
-            fieldIdentifier.pageID == pageId
-        else { return nil }
+            fieldIdentifier.pageID == pageId else { return nil }
 
         let fieldID = fieldIdentifier.fieldID
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Navigation.swift
@@ -205,7 +205,11 @@ extension DocumentEditor {
         }
     }
     
-    func columnExistsInField(_ field: JoyDocField, columnId: String) -> Bool {
+    /// When `schemaKey` is provided the column lookup is scoped to that single
+    /// schema entry, ensuring the column belongs to the same schema as the row.
+    /// When `nil` (the default) all schema entries are scanned, preserving the
+    /// existing behaviour for callers that have no row context.
+    func columnExistsInField(_ field: JoyDocField, columnId: String, schemaKey: String? = nil) -> Bool {
         guard let fieldID = field.id else { return false }
         switch field.fieldType {
         case .table:
@@ -213,8 +217,15 @@ extension DocumentEditor {
             return shouldShowColumn(columnID: columnId, fieldID: fieldID)
         case .collection:
             guard let schema = field.schema else { return false }
-            guard let schemaKey = schema.first(where: { $0.value.tableColumns?.contains(where: { $0.id == columnId }) == true })?.key else { return false }
-            return shouldShowColumn(columnID: columnId, fieldID: fieldID, schemaKey: schemaKey)
+            let resolvedKey: String
+            if let schemaKey = schemaKey {
+                guard schema[schemaKey]?.tableColumns?.contains(where: { $0.id == columnId }) == true else { return false }
+                resolvedKey = schemaKey
+            } else {
+                guard let key = schema.first(where: { $0.value.tableColumns?.contains(where: { $0.id == columnId }) == true })?.key else { return false }
+                resolvedKey = key
+            }
+            return shouldShowColumn(columnID: columnId, fieldID: fieldID, schemaKey: resolvedKey)
         default:
             return false
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -35,6 +35,13 @@ public protocol DocumentEditorDelegate: AnyObject {
     func decoratorsDidChange()
 }
 
+public extension DocumentEditorDelegate {
+    /// Default no-op so external conformers don't break when the SDK adds
+    /// decorator-cache refresh hooks. Internal view models (TableViewModel,
+    /// CollectionViewModel) provide real implementations.
+    func decoratorsDidChange() {}
+}
+
 public class DocumentEditor: ObservableObject {
     private(set) public var document: JoyDoc
     public var schemaError: SchemaValidationError?

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -32,6 +32,7 @@ public protocol DocumentEditorDelegate: AnyObject {
     func insertRow(for change: Change)
     func deleteRow(for change: Change)
     func moveRow(for change: Change)
+    func decoratorsDidChange()
 }
 
 public class DocumentEditor: ObservableObject {
@@ -280,7 +281,7 @@ public class DocumentEditor: ObservableObject {
         return nil
     }
 
-    private func valueDelegate(for fieldID: String, fieldType: FieldTypes) -> DocumentEditorDelegate? {
+    func valueDelegate(for fieldID: String, fieldType: FieldTypes) -> DocumentEditorDelegate? {
         if let delegate = delegateMap[fieldID]?.value {
             return delegate
         }

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -159,7 +159,7 @@ struct TableDataModel {
     var columnIdToColumnMap: [String: CellDataModel] = [:]
     var schemaChainMap: [String: [String]] = [:]
     var rowDecorators: [DecoratorLocal] = []
-    var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
+    private(set) var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
     var selectedRows = [String]()
     var cellModels = [RowDataModel]()
     var filteredcellModels = [RowDataModel]()
@@ -217,7 +217,7 @@ struct TableDataModel {
             buildFullSchemaChainMap()
             self.fieldPositionSchema = fieldPosition.schema ?? [:]
             fieldData.schema?.forEach { key, value in
-                self.rowDecoratorsBySchemaKey[key] = value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+                self.setRowDecorators(value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? [], forSchemaKey: key)
                 if value.root == true {
                     //Only top level columns
                     self.tableColumns = filterTableColumns(key: key)
@@ -377,6 +377,10 @@ struct TableDataModel {
             return rowDecorators
         }
         return rowDecoratorsBySchemaKey[schemaKey] ?? []
+    }
+
+    mutating func setRowDecorators(_ decorators: [DecoratorLocal], forSchemaKey schemaKey: String) {
+        rowDecoratorsBySchemaKey[schemaKey] = decorators
     }
 
     func hasAnyRowDecorators(schemaKey: String) -> Bool {

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -159,7 +159,7 @@ struct TableDataModel {
     var columnIdToColumnMap: [String: CellDataModel] = [:]
     var schemaChainMap: [String: [String]] = [:]
     var rowDecorators: [DecoratorLocal] = []
-    private var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
+    var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
     var selectedRows = [String]()
     var cellModels = [RowDataModel]()
     var filteredcellModels = [RowDataModel]()


### PR DESCRIPTION
## Context

Implements the dynamic decorator public API per the decorator spec. Decorators are visual badges (icon + label + color) attached to fields, rows, or columns. This PR adds path-based CRUD methods so integrators can read, add, update, and remove decorators at runtime — and the UI reflects changes live without re-opening the table/collection modal.

On top of that baseline, the PR also introduces (a) error reporting via `onError`/`JoyfillError.decoratorError`, (b) decorator validation with block-and-return-early semantics, (c) license gating for collection-field writes, and (d) a full unit-test suite (70 tests).

## What Changed

### New file: `Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift`
- Path-based public API: `getDecorators(path:)`, `addDecorators(path:)`, `removeDecorator(path:action:)`, `updateDecorator(path:action:decorator:)`
- Path format: `pageId/fieldPositionId` (field), `/rowId` (row), `/rowId/columnId` (column)
- `resolveDecoratorTarget` — resolves a path string to the correct field, row, or column scope
- `resolvedSchemaKey(forRowID:inFieldID:)` — recursive schema key resolution for collection fields (root vs nested rows)
- `validateDecorator(_:)` — enforces `action` required/non-empty and `color` matches `^#[0-9A-Fa-f]{6}$` when non-nil/non-empty
- `licenseAllowsDecoratorWrite(for:path:)` — blocks collection-field writes when `isCollectionFieldEnabled == false`
- Separate read/write helpers for field, row, and column decorators with full table/collection branching

### Modified: `Sources/JoyfillUI/ViewModels/DocumentEditor.swift`
- Added `decoratorsDidChange()` to `DocumentEditorDelegate` protocol

### Modified: `Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift`
- `decoratorsDidChange()` — refreshes `tableDataModel.rowDecorators` and column decorator arrays from the live field model

### Modified: `Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift`
- `decoratorsDidChange()` — replaces `tableDataModel.schema` from the fresh field, refreshes `rowDecoratorsBySchemaKey` cache, and patches root-level `tableColumns`

### Modified: `Sources/JoyfillUI/View/Fields/Models.swift`
- Changed `rowDecoratorsBySchemaKey` from `private` to `var` so `CollectionViewModel` can update it

### Modified: `Sources/JoyfillUI/View/Types.swift`
- Added `JoyfillError.decoratorError(error: DecoratorError)` case
- Added public `DecoratorError` struct with `message: String`

### Modified: `JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift`
- Exhaustive switch update for the new error case (prints the decorator error message)

### Example project: `DecoratorAPIDemoView.swift`
- `DecoratorManagerView` — full CRUD UI for managing decorators across all field types (field/row/column), with schema picker for collections
- `DecoratorEventHandler` class — handles `onFocus` events from decorator taps and calls `updateDecorator` to visually mark decorators as "Viewed"
- Demonstrates the full integration pattern for consuming the decorator API

## Public API

```swift
public extension DocumentEditor {
    func getDecorators(path: String) -> [Decorator]
    func addDecorators(path: String, decorators: [Decorator])
    func removeDecorator(path: String, action: String)
    func updateDecorator(path: String, action: String, decorator: Decorator)
}

public enum JoyfillError: Error {
    case schemaValidationError(error: SchemaValidationError)
    case schemaVersionError(error: SchemaValidationError)
    case decoratorError(error: DecoratorError)
}

public struct DecoratorError: Error {
    public let message: String
}
```

New method on `DocumentEditorDelegate`:
```swift
func decoratorsDidChange()
```

> **Docs update needed** — The public API docs should be updated to document the path format, the new decorator methods, the error enum case, and license requirements.

## Error reporting

`events?.onError(error: .decoratorError(...))` fires in four cases:

1. **Path cannot be resolved** — bad `pageId` / `fieldPositionId` / `rowId` / `columnId`. Message: `"Failed to resolve path '<path>'"`. Applies to all four public methods. `getDecorators` additionally returns `[]`.
2. **Action not found** on `removeDecorator` or `updateDecorator`. Message: `"Failed to remove/update decorator with action: '<action>'"`.
3. **Decorator validation fails** — nil/empty `action`, or malformed `color` hex (non-`#`, wrong length, non-hex chars). Message: `"Invalid decorator property: ..."`.
4. **License block** — write to a collection-field decorator with `isCollectionFieldEnabled == false`. Message: `"Collection field decorators are not available without a valid license (path '<path>')"`.

**Block-and-return-early** semantics: on validation failure the write is rejected, nothing persists, no delegate callback fires. For `addDecorators`, batches are atomic — if any decorator in the batch is invalid, the entire batch is rejected.

## License gating

Writes to decorators on a `.collection` field are now blocked when the license does not grant collection access (`LicenseValidator.isCollectionEnabled(licenseToken:) == false`). This matches how the rest of the SDK treats unlicensed collection fields (silently skipped in view-model building at `DocumentEditor.swift:814`).

| Method | Behavior on unlicensed collection field |
|---|---|
| `getDecorators` | allowed (reads are not gated) |
| `addDecorators` | blocked, `decoratorError` emitted |
| `removeDecorator` | blocked, `decoratorError` emitted |
| `updateDecorator` | blocked, `decoratorError` emitted |

Table-field decorators are unaffected.

## Design Decisions

1. **Path-based API over direct field access** — Paths (`pageId/fieldPositionId/rowId/columnId`) give integrators a single entry point that works for all decorator scopes without needing to know internal field IDs or schema keys. The SDK resolves the path internally.

2. **Page-scoped field position lookup** — `resolveDecoratorTarget` looks up the field position on the specific page from the path (not `getFieldIdentifier(forFieldPositionID:)` which iterates all pages). This is required because Navigation.json has 22 shared field position IDs across pages that point to different fields.

3. **Delegate pattern for live updates** — Table/collection views cache decorator data in `TableDataModel` at init time. Rather than forcing a full view rebuild, `decoratorsDidChange()` patches the existing `@StateObject` view model's cached decorators. This matches the existing `change(changes:)` delegate pattern.

4. **`valueDelegate(for:fieldType:)` for lazy creation** — If no view model is registered yet (modal not open), a throwaway instance is created. The decorator data is already persisted in `fieldMap`, so when the modal eventually opens it initializes fresh. Same pattern as the change API.

5. **`tableDataModel.schema = field.schema ?? [:]`** — For collections, we replace the entire schema instead of patching individual properties. This keeps `hasAnyRowDecorators` (which gates row decorator visibility by checking `schema.values`) in sync with the `rowDecoratorsBySchemaKey` render cache.

6. **`DecoratorEventHandler` as a class, not struct** — SwiftUI struct views are recreated on every render, but `@StateObject` only initializes once. A class reference stored via `DocumentEditor(events:)` at init time maintains a stable connection. Accessed via `editor.events as? DecoratorEventHandler`.

7. **License gating mirrors the view-model build-time gate** — `DocumentEditor.swift:814` already skips collection fields when the license is invalid (they never get a view model). Mirroring that at the decorator write layer keeps behavior consistent: unlicensed integrators can't accidentally mutate collection-field state that will never render.

8. **Reads are not license-gated** — inspecting existing decorator data is harmless and useful for debugging or UI state derivation. Only mutating APIs (`add`/`remove`/`update`) enforce the license.

## Test Coverage

New unit-test suite under `JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/`:

| File | Tests |
|---|---|
| `DecoratorTestSupport.swift` | shared helpers (`MockDecoratorEvents`, sample IDs, editor factories) |
| `DecoratorPathResolutionTests.swift` | 15 |
| `DecoratorPublicAPITests.swift` | 16 |
| `DecoratorErrorHandlingTests.swift` | 28 |
| `DecoratorLiveUpdateTests.swift` | 11 |
| **Total** | **70** |

Coverage areas:
- **Path resolution** — 2/3/4-segment paths, schema-key resolution for root and nested rows, the shared-`fieldPositionId` regression from the original bug, invalid page/fieldPosition/field IDs, empty path, extra slashes.
- **CRUD happy paths** — `get`/`add`/`remove`/`update` on field, row, column scopes for both table and collection fields; round-trip reads; consecutive operations; `fieldMap` persistence.
- **Error emission + validation** — every public method's path-resolution error; unknown-action errors on `remove`/`update`; validation for nil/empty action, malformed/short/invalid/valid hex colors; atomic batch rejection; error-message shape; `DecoratorError` pattern-matching; `events: nil` crash safety.
- **License gating** — collection add/remove/update blocked + `onError` fired; collection get allowed; table writes unaffected; batch writes blocked wholesale.
- **Live updates** — `TableViewModel` row/column cache refresh; `CollectionViewModel` root/nested row and column refresh; `hasAnyRowDecorators` regression; lazy delegate creation; cross-field isolation.

Collection tests require the `JOYFILL_TEST_LICENSE` env var (same pattern as the existing `ValidationTestCase.collectionDocumentEditor`). Without it, the license gate correctly blocks the writes and those tests will fail by design.

### Modified: `JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj`
- New `DecoratorAPI` group under the `JoyfillTests` target, wiring all 5 test files into the Sources build phase.

## Notes for Reviewers

- The example project files (`DecoratorAPIDemoView.swift`) are intentionally verbose — they serve as integration documentation for the API.
- `refreshField` is still called alongside `decoratorsDidChange()`. It rebuilds the page field model (needed for field-level decorators), while `decoratorsDidChange()` patches the live table/collection view model. Both are needed.
- The recursive `schemaKey(forRowID:in:)` walks the `childrens` tree to find which schema a nested row belongs to. This is O(rows) per call but row counts per field are small in practice.
- Validation uses a simple regex (`^#[0-9A-Fa-f]{6}$`). 3-char shorthand (`#abc`) and 8-char (`#rrggbbaa`) are intentionally rejected — Decorator colors are stored as full 6-char hex strings downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)