### PR TITLE
Wrap Log() with #if DEBUG to skip string construction in release builds

### DIFF
--- a/Sources/JoyfillUI/Extensions/JoyfillLogger.swift
+++ b/Sources/JoyfillUI/Extensions/JoyfillLogger.swift
@@ -67,6 +67,7 @@ public func Log(
     file: String = #file,
     line: Int = #line
 ) {
+    #if DEBUG
     JoyfillLogger.shared.log(
         message,
         type: type,
@@ -74,4 +75,5 @@ public func Log(
         file: file,
         line: line
     )
+    #endif
 } 


### PR DESCRIPTION
## Context

A review suggestion flagged that the public `Log()` function in `JoyfillLogger.swift` was still calling into `JoyfillLogger.shared.log()` in release builds — causing unnecessary string interpolation and `NSString` path extraction on every call, even though the `log()` method body already had `#if DEBUG` around `print`. For high-frequency call sites like `onChange`, this adds small but avoidable overhead in production.

## What Changed

**File:** `Sources/JoyfillUI/Extensions/JoyfillLogger.swift`

Wrapped the body of the public `Log()` global function with `#if DEBUG` so that in release builds, the entire function body is compiled out — no function dispatch to `JoyfillLogger.shared.log()`, no string construction, zero overhead.

## Why This Approach

We chose to wrap at the `Log()` call site rather than inside the `log()` method because `Log()` is the single public entry point used across the codebase. This keeps the guard at the outermost layer and avoids even the cost of calling into the `log()` method in release builds. The existing `#if DEBUG` inside `log()` is now redundant but left in place as a safety net.

## Screenshots / Video

N/A — no visual change. This is a compile-time optimization only.

## Public API Impact

No public API change. `Log()` remains available with the same signature. No documentation update needed.

## Test Coverage

No new tests added — this is a compile-time directive change that doesn't alter runtime behavior in debug builds. Existing logging behavior is unchanged.

## Notes for Reviewer

- The nested `#if DEBUG` inside `log()` method (line 47) is now redundant but harmless — can be cleaned up in a follow-up if desired.
- This was a community/review suggestion to reduce overhead for frequently triggered log calls in release builds.