### PR TITLE
NO-2080: Add typed signature input mode

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -1402,6 +1402,166 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         XCTAssertFalse(editSignatureButton.exists, "Edit button should not exist for a fresh row signature (no carry-over)")
         app.buttons["SaveSignatureIdentifier"].firstMatch.tap()
     }
+
+    func addCollectionRowForSignatureTests() {
+        let addRowButton = app.buttons["TableAddRowIdentifier"].firstMatch
+        XCTAssertTrue(addRowButton.waitForExistence(timeout: 5), "Add row button not found in collection")
+        addRowButton.tap()
+    }
+
+    func goToCollectionDetailFieldForSignatureTests() {
+        returnToRootView()
+        dismissAnyOpenModals()
+        waitForAppToSettle()
+
+        let pageSelectionButton = app.buttons["PageNavigationIdentifier"].firstMatch
+        pageSelectionButton.waitAndTap(message: "Page navigation button not found")
+        app.swipeUp()
+        app.swipeUp()
+
+        let page16InSheet = app.buttons
+            .matching(identifier: "PageSelectionIdentifier")
+            .matching(NSPredicate(format: "label == %@", "Page 16"))
+            .firstMatch
+        XCTAssertTrue(page16InSheet.waitForExistence(timeout: 5), "Page 16 option not found in page selector")
+        page16InSheet.tap()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.7))
+
+        for _ in 0..<24 {
+            let collectionButtons = app.buttons.matching(identifier: "CollectionDetailViewIdentifier")
+            if collectionButtons.count > 0 {
+                for index in 0..<collectionButtons.count {
+                    let target = collectionButtons.element(boundBy: index)
+                    if target.exists && target.isHittable {
+                        target.tap()
+                        return
+                    }
+                }
+            }
+            app.swipeUp()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        }
+
+        XCTFail("CollectionDetailViewIdentifier not found for signature tests after selecting Page 16")
+    }
+
+    func swipeLeftOnCollectionGridForSignatureDiscovery() {
+        let table = app.tables.firstMatch
+        if table.waitForExistence(timeout: 1) {
+            table.swipeLeft()
+            return
+        }
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "App window not available for collection swipe")
+        let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.55))
+        let end = window.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.55))
+        start.press(forDuration: 0.05, thenDragTo: end)
+    }
+
+    @discardableResult
+    func openLastCollectionSignatureCell() -> XCUIElement {
+        for _ in 0..<10 {
+            let signatureButtons = app.buttons.matching(identifier: "TableSignatureOpenSheetButton")
+            if signatureButtons.count > 0 {
+                let target = signatureButtons.element(boundBy: signatureButtons.count - 1)
+                if target.exists && target.isHittable {
+                    target.tap()
+                    return target
+                }
+            }
+            swipeLeftOnCollectionGridForSignatureDiscovery()
+        }
+
+        let signatureButtons = app.buttons.matching(identifier: "TableSignatureOpenSheetButton")
+        XCTAssertGreaterThan(signatureButtons.count, 0, "Collection signature button not found after swiping to last columns")
+        let fallbackTarget = signatureButtons.element(boundBy: max(signatureButtons.count - 1, 0))
+        fallbackTarget.waitAndTap(message: "Collection signature button not hittable")
+        return fallbackTarget
+    }
+
+    func switchToTypeModeInCollectionSignature() {
+        app.buttons["Type"].firstMatch.waitAndTap(message: "Type mode button not found")
+    }
+
+    func enterCollectionTypedSignature(_ text: String) {
+        let textField = app.textFields["Type Signature"].firstMatch
+        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Type Signature text field not found")
+        textField.tap()
+
+        if let existingValue = textField.value as? String, !existingValue.isEmpty, existingValue != "Type Signature" {
+            textField.clearText()
+        }
+
+        textField.typeText(text)
+    }
+
+    func testCollectionExistingSignatureOpensReadonlyPreviewFirst() throws {
+        goToCollectionDetailFieldForSignatureTests()
+        addCollectionRowForSignatureTests()
+
+        _ = openLastCollectionSignatureCell()
+        drawSignatureLine()
+        app.buttons["SaveSignatureIdentifier"].firstMatch.waitAndTap(message: "Save signature button not found")
+
+        _ = openLastCollectionSignatureCell()
+        XCTAssertTrue(app.buttons["TableSignatureEditButton"].firstMatch.waitForExistence(timeout: 5),
+                      "Existing collection signature should open in preview mode with Edit button")
+    }
+
+    func testCollectionSignatureModeResetsToDrawOnOpen() throws {
+        goToCollectionDetailFieldForSignatureTests()
+        addCollectionRowForSignatureTests()
+
+        _ = openLastCollectionSignatureCell()
+        let drawCanvas = app.otherElements["CanvasIdentifier"].firstMatch
+        XCTAssertTrue(drawCanvas.waitForExistence(timeout: 5), "New collection signature should open in Draw mode")
+
+        switchToTypeModeInCollectionSignature()
+        XCTAssertTrue(app.textFields["Type Signature"].firstMatch.waitForExistence(timeout: 5),
+                      "Type field should appear after switching to Type mode")
+
+        dismissSheet()
+        _ = openLastCollectionSignatureCell()
+        XCTAssertTrue(app.otherElements["CanvasIdentifier"].firstMatch.waitForExistence(timeout: 5),
+                      "Collection signature should reset to Draw mode when reopened")
+    }
+
+    func testCollectionRestoreTypedTextOnEdit() throws {
+        goToCollectionDetailFieldForSignatureTests()
+        addCollectionRowForSignatureTests()
+
+        _ = openLastCollectionSignatureCell()
+        switchToTypeModeInCollectionSignature()
+        enterCollectionTypedSignature("Collection Typed")
+        app.buttons["SaveSignatureIdentifier"].firstMatch.waitAndTap(message: "Save signature button not found")
+
+        _ = openLastCollectionSignatureCell()
+        app.buttons["TableSignatureEditButton"].firstMatch.waitAndTap(message: "Edit signature button not found")
+        switchToTypeModeInCollectionSignature()
+
+        XCTAssertEqual("Collection Typed", app.textFields["Type Signature"].firstMatch.value as? String ?? "",
+                       "Previously typed collection signature text should be restored on edit")
+    }
+
+    func testCollectionTypedSignatureIsRowScoped() throws {
+        goToCollectionDetailFieldForSignatureTests()
+        addCollectionRowForSignatureTests()
+
+        _ = openLastCollectionSignatureCell()
+        switchToTypeModeInCollectionSignature()
+        enterCollectionTypedSignature("Row One Typed")
+        app.buttons["SaveSignatureIdentifier"].firstMatch.waitAndTap(message: "Save signature button not found")
+
+        addCollectionRowForSignatureTests()
+
+        _ = openLastCollectionSignatureCell()
+        switchToTypeModeInCollectionSignature()
+
+        let typedValue = app.textFields["Type Signature"].firstMatch.value as? String ?? ""
+        XCTAssertTrue(typedValue.isEmpty || typedValue == "Type Signature",
+                      "Typed signature should be row-scoped and not carry to new row")
+    }
     
 }
 

--- a/JoyfillSwiftUIExample/JoyfillUITests/SignatureField/SignatureFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/SignatureField/SignatureFieldUITestCases.swift
@@ -22,6 +22,38 @@ final class SignatureFieldUITestCases: JoyfillUITestsBaseClass {
         startPoint.press(forDuration: 0.1, thenDragTo: endPoint)
     }
     
+    @discardableResult
+    private func openPrimarySignatureField() -> XCUIElement {
+        let signatureButton = app.buttons.matching(identifier: "SignatureIdentifier").element(boundBy: 0)
+        signatureButton.waitAndTap(message: "Primary signature button not found")
+        return signatureButton
+    }
+
+    private func switchToTypeMode() {
+        app.buttons["Type"].firstMatch.waitAndTap(message: "Type mode button not found")
+    }
+
+    private func signatureTypedTextField() -> XCUIElement {
+        app.textFields["Type Signature"].firstMatch
+    }
+
+    private func enterTypedSignature(_ text: String) {
+        let textField = signatureTypedTextField()
+        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Type signature text field not found")
+        textField.tap()
+
+        if let currentValue = textField.value as? String, !currentValue.isEmpty, currentValue != "Type Signature" {
+            textField.clearText()
+        }
+
+        textField.typeText(text)
+    }
+
+    private func typedSignatureValue() -> String {
+        let value = signatureTypedTextField().value as? String ?? ""
+        return value
+    }
+
     func testSaveSignature() throws {
         let signatureDetailButton = app.buttons.matching(identifier: "SignatureIdentifier").element(boundBy: 0)
         
@@ -35,7 +67,78 @@ final class SignatureFieldUITestCases: JoyfillUITestsBaseClass {
         XCTAssertEqual("Edit Signature", signatureDetailButton.label)
         XCTAssertNotNil(onChangeResultValue().signatureURL?.isEmpty)
     }
-    
+
+    func testTypeTabVisibleAndInputShown() throws {
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+
+        let textField = signatureTypedTextField()
+        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Type signature text field should be visible in Type mode")
+    }
+
+    func testSaveTypedSignature() throws {
+        let signatureDetailButton = openPrimarySignatureField()
+        switchToTypeMode()
+        enterTypedSignature("John Doe")
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+
+        XCTAssertEqual("Edit Signature", signatureDetailButton.label)
+        let signatureURL = onChangeResultValue().signatureURL ?? ""
+        XCTAssertTrue(signatureURL.hasPrefix("data:image/png;base64"), "Typed signature should be saved as base64 PNG")
+    }
+
+    func testWhitespaceOnlyTypedSignatureClearsValue() throws {
+        let signatureDetailButton = openPrimarySignatureField()
+        switchToTypeMode()
+        enterTypedSignature("   ")
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+
+        XCTAssertEqual("Add Signature", signatureDetailButton.label)
+        XCTAssertEqual("", onChangeResultValue().signatureURL ?? "")
+    }
+
+    func testTypedSignatureTrimmedAndRestoredOnReopen() throws {
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+        enterTypedSignature("  John Doe  ")
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+        XCTAssertEqual("John Doe", typedSignatureValue(), "Typed signature should be trimmed and restored when reopening")
+    }
+
+    func testClearButtonInTypeModeClearsText() throws {
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+        enterTypedSignature("Clear Me")
+        app.buttons["ClearSignatureIdentifier"].waitAndTap()
+
+        let valueAfterClear = typedSignatureValue()
+        XCTAssertTrue(valueAfterClear.isEmpty || valueAfterClear == "Type Signature", "Clear should empty the typed signature text field")
+
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+        let signatureButton = app.buttons.matching(identifier: "SignatureIdentifier").element(boundBy: 0)
+        XCTAssertEqual("Add Signature", signatureButton.label)
+    }
+
+    func testSwitchTypeToDrawThenSaveResetsTypedCache() throws {
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+        enterTypedSignature("Reset Me")
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+
+        _ = openPrimarySignatureField()
+        app.buttons["Draw"].firstMatch.waitAndTap(message: "Draw mode button not found")
+        drawSignatureLine()
+        app.buttons["SaveSignatureIdentifier"].waitAndTap()
+
+        _ = openPrimarySignatureField()
+        switchToTypeMode()
+        let restoredValue = typedSignatureValue()
+        XCTAssertTrue(restoredValue.isEmpty || restoredValue == "Type Signature", "Typed signature cache should be reset after saving in Draw mode")
+    }
+
     func testClearSignature() throws {
         let signatureDetailButton = app.buttons.matching(identifier: "SignatureIdentifier").element(boundBy: 0)
         XCTAssertTrue(signatureDetailButton.waitForExistence(timeout: 5), "Signature button not found")

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableNumber_Block_DateFieldTest.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableNumber_Block_DateFieldTest.swift
@@ -1238,6 +1238,101 @@ final class TableNumber_Block_DateFieldTest: JoyfillUITestsBaseClass {
         element.swipeLeft()
     }
     
+    @discardableResult
+    func openTableSignature(at index: Int) -> XCUIElement {
+        for _ in 0..<10 {
+            let signatureButtons = app.buttons.matching(identifier: "TableSignatureOpenSheetButton")
+            if signatureButtons.count > index {
+                let target = signatureButtons.element(boundBy: index)
+                if target.exists && target.isHittable {
+                    target.tap()
+                    return target
+                }
+            }
+            swipeLeftOnTableGridForSignatureDiscovery()
+        }
+        
+        let signatureButtons = app.buttons.matching(identifier: "TableSignatureOpenSheetButton")
+        XCTAssertTrue(signatureButtons.count > index, "Table signature button at index \(index) not found after swiping to last columns")
+        let fallbackTarget = signatureButtons.element(boundBy: index)
+        fallbackTarget.waitAndTap(message: "Table signature button at index \(index) not hittable")
+        return fallbackTarget
+    }
+
+    func swipeLeftOnTableGridForSignatureDiscovery() {
+        let table = app.tables.firstMatch
+        if table.waitForExistence(timeout: 1) {
+            table.swipeLeft()
+            return
+        }
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "App window not available for table swipe")
+        let start = window.coordinate(withNormalizedOffset: CGVector(dx: 0.85, dy: 0.55))
+        let end = window.coordinate(withNormalizedOffset: CGVector(dx: 0.15, dy: 0.55))
+        start.press(forDuration: 0.05, thenDragTo: end)
+    }
+    
+    func switchToTypeModeInTableSignature() {
+        app.buttons["Type"].firstMatch.waitAndTap(message: "Type mode button not found")
+    }
+    
+    func tableSignatureTypedTextField() -> XCUIElement {
+        app.textFields["Type Signature"].firstMatch
+    }
+    
+    func enterTableTypedSignature(_ text: String) {
+        let textField = tableSignatureTypedTextField()
+        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Type Signature text field not found")
+        textField.tap()
+        if let existingValue = textField.value as? String, !existingValue.isEmpty, existingValue != "Type Signature" {
+            textField.clearText()
+        }
+        textField.typeText(text)
+    }
+    
+    func tableTypedSignatureValue() -> String {
+        tableSignatureTypedTextField().value as? String ?? ""
+    }
+    
+    func testTableExistingSignatureOpensReadonlyPreviewFirst() throws {
+        goToTableDetailPage()
+        _ = openTableSignature(at: 0)
+        XCTAssertTrue(app.buttons["TableSignatureEditButton"].firstMatch.waitForExistence(timeout: 5),
+                      "Existing table signature should open in preview mode with Edit button")
+    }
+    
+    func testTableSignatureModeResetsToDrawOnOpen() throws {
+        goToTableDetailPage()
+        _ = openTableSignature(at: 1)
+        
+        let drawCanvas = app.otherElements["CanvasIdentifier"].firstMatch
+        XCTAssertTrue(drawCanvas.waitForExistence(timeout: 5), "New table signature should open in Draw mode")
+        
+        switchToTypeModeInTableSignature()
+        XCTAssertTrue(tableSignatureTypedTextField().waitForExistence(timeout: 5), "Type field should appear after switching to Type mode")
+        
+        dismissSheet()
+        _ = openTableSignature(at: 1)
+        XCTAssertTrue(app.otherElements["CanvasIdentifier"].firstMatch.waitForExistence(timeout: 5),
+                      "Table signature should reset to Draw mode when reopened")
+    }
+    
+    func testTableRestoreTypedTextOnEdit() throws {
+        goToTableDetailPage()
+        _ = openTableSignature(at: 1)
+        
+        switchToTypeModeInTableSignature()
+        enterTableTypedSignature("Table Typed")
+        app.buttons["SaveSignatureIdentifier"].firstMatch.waitAndTap()
+        
+        _ = openTableSignature(at: 1)
+        app.buttons["TableSignatureEditButton"].firstMatch.waitAndTap()
+        switchToTypeModeInTableSignature()
+        
+        XCTAssertEqual("Table Typed", tableTypedSignatureValue(), "Previously typed table signature text should be restored on edit")
+    }
+    
     func testClearExistingSignature() throws {
         goToTableDetailPage()
         //swipeLeftForSignatureColumn()

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -153,10 +153,8 @@ struct TypeToSign: View {
     let fontName: String
     
     var body: some View {
-        
         TextField("Type Signature", text: $typeSign)
             .font(.custom(fontName, size: 60))
-            .foregroundColor(typeSign.isEmpty ? .gray.opacity(0.7) : .black.opacity(0.92))
             .lineLimit(1)
             .minimumScaleFactor(0.3)
             .padding(.horizontal, 20)
@@ -230,7 +228,7 @@ struct CanvasSignatureView: View {
     var fieldID: String?
     @Environment(\.presentationMode) private var presentationMode
     let screenWidth = UIScreen.main.bounds.width
-    private let typedSignatureFontName = "SignPainter-HouseScript Semibold"
+    private let typedSignatureFontName = "SnellRoundhand-Black"
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -474,7 +472,6 @@ private struct TypedSignatureSnapshotView: View {
             Color.clear
             Text(text)
                 .font(.custom(fontName, size: 72))
-                .foregroundColor(.black.opacity(0.92))
                 .lineLimit(1)
                 .minimumScaleFactor(0.2)
                 .padding(.horizontal, 20)

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -381,7 +381,7 @@ struct CanvasSignatureView: View {
                     .accessibilityIdentifier("ClearSignatureIdentifier")
                     
                     Button(action: {
-                        if signatureInputMode == .draw{
+                        if signatureInputMode == .draw {
                             if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
                                 savedLines = []
                                 savedTypedSignature = ""

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -236,7 +236,7 @@ struct CanvasSignatureView: View {
                 .fontWeight(.bold)
                 .padding(.top, 12)
                 .padding(.bottom, 8)
-            HStack {
+            HStack(spacing: 8) {
                 if isEditable || signatureImage == nil {
                     Button(action: {
                         signatureInputMode = .draw
@@ -258,7 +258,6 @@ struct CanvasSignatureView: View {
                                 .stroke(Color.allFieldBorderColor, lineWidth: 1)
                         )
                     })
-                    Spacer().frame(width: 8)
                     Button(action: {
                         signatureInputMode = .type
                     }, label: {

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -232,10 +232,10 @@ struct CanvasSignatureView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-                Text("\(signatureImage != nil ? "Edit Signature" : "Add Signature")")
-                    .fontWeight(.bold)
-                    .padding(.top, 12)
-                    .padding(.bottom, 8)
+            Text("\(signatureImage != nil ? "Edit Signature" : "Add Signature")")
+                .fontWeight(.bold)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
             HStack {
                 if isEditable || signatureImage == nil {
                     Button(action: {

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -147,6 +147,22 @@ struct Line: Equatable {
     var lineWidth: Double = 2.0
 }
 
+struct TypeToSign: View {
+    @Binding var typeSign: String
+    let fontName: String
+    
+    var body: some View {
+        
+        TextField("Type Signature", text: $typeSign)
+            .font(.custom(fontName, size: 60))
+            .foregroundColor(typeSign.isEmpty ? .gray.opacity(0.7) : .black.opacity(0.92))
+            .lineLimit(1)
+            .minimumScaleFactor(0.3)
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+}
+
 struct CanvasView: View {
     @State var currentLine = Line()
     @Binding var lines: [Line]
@@ -203,6 +219,8 @@ struct CanvasSignatureView: View {
     @Binding var signatureImage: UIImage?
     @State var signatureCanvasImage: UIImage?
     @State var showCanvasError: Bool = false
+    @State var signatureInputMode: SignatureInputMode = .draw
+    @State private var typedSignatureText: String = ""
     @Binding var signatureURL: String
     @Binding var showError: Bool
     @Binding var isEditable: Bool
@@ -210,25 +228,85 @@ struct CanvasSignatureView: View {
     var fieldID: String?
     @Environment(\.presentationMode) private var presentationMode
     let screenWidth = UIScreen.main.bounds.width
+    private let typedSignatureFontName = "SignPainter-HouseScript Semibold"
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text("\(signatureImage != nil ? "Edit Signature" : "Add Signature")")
-                .fontWeight(.bold)
-                .padding(.top, 12)
-            
+                Text("\(signatureImage != nil ? "Edit Signature" : "Add Signature")")
+                    .fontWeight(.bold)
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
+            HStack {
+                if isEditable || signatureImage == nil {
+                    Button(action: {
+                        signatureInputMode = .draw
+                    }, label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "pencil.tip")
+                            Text("Draw")
+                        }
+                        .font(.system(size: 14, weight: .medium))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .foregroundColor(signatureInputMode == .draw ? .white : .primary)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(signatureInputMode == .draw ? Color.accentColor : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.allFieldBorderColor, lineWidth: 1)
+                        )
+                    })
+                    Spacer().frame(width: 8)
+                    Button(action: {
+                        signatureInputMode = .type
+                    }, label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "keyboard")
+                            Text("Type")
+                        }
+                        .font(.system(size: 14, weight: .medium))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .foregroundColor(signatureInputMode == .type ? .white : .primary)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(signatureInputMode == .type ? Color.accentColor : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.allFieldBorderColor, lineWidth: 1)
+                        )
+                    })
+                }
+            }
             if isEditable {
-                CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
-                    .frame(height: 150)
-                    .cornerRadius(10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color(UIColor.systemGray5))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.allFieldBorderColor, lineWidth: 1)
-                    )
+                if signatureInputMode == .draw {
+                    CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
+                        .frame(height: 150)
+                        .cornerRadius(10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(UIColor.systemGray5))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.allFieldBorderColor, lineWidth: 1)
+                        )
+                } else {
+                    TypeToSign(typeSign: $typedSignatureText, fontName: typedSignatureFontName)
+                        .frame(height: 150)
+                        .cornerRadius(10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(UIColor.systemGray5))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color.allFieldBorderColor, lineWidth: 1)
+                        )
+                }
             } else {
                 if let signatureImage = signatureImage {
                     ZStack(alignment: .bottomTrailing) {
@@ -288,6 +366,7 @@ struct CanvasSignatureView: View {
                     Button(action: {
                         lines.removeAll()
                         signatureCanvasImage = nil
+                        typedSignatureText = ""
                         showCanvasError = false
                     }, label: {
                         Text("Clear")
@@ -302,22 +381,41 @@ struct CanvasSignatureView: View {
                     .accessibilityIdentifier("ClearSignatureIdentifier")
                     
                     Button(action: {
-                        if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
-                            savedLines = []
-                            signatureImage = nil
-                            signatureURL = ""
-                            showError = false
+                        if signatureInputMode == .draw{
+                            if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
+                                savedLines = []
+                                signatureImage = nil
+                                signatureURL = ""
+                                showError = false
+                                presentationMode.wrappedValue.dismiss()
+                                return
+                            }
+                            if !showCanvasError {
+                                signatureImage = CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
+                                    .frame(width: screenWidth, height: 220)
+                                    .snapshot()
+                                showError = false
+                            }
+                            savedLines = lines
                             presentationMode.wrappedValue.dismiss()
-                            return
+                        } else {
+                            let trimmedTypedSignatureText = typedSignatureText.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if trimmedTypedSignatureText.isEmpty {
+                                    savedLines = []
+                                    signatureImage = nil
+                                    signatureURL = ""
+                                    showError = false
+                                    presentationMode.wrappedValue.dismiss()
+                                    return
+                                }
+                                signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
+                                signatureCanvasImage = signatureImage
+                                lines.removeAll()
+                                savedLines = []
+                                showCanvasError = false
+                                showError = false
+                                presentationMode.wrappedValue.dismiss()
                         }
-                        if !showCanvasError {
-                            signatureImage = CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
-                                .frame(width: screenWidth, height: 220)
-                                .snapshot()
-                            showError = false
-                        }
-                        savedLines = lines
-                        presentationMode.wrappedValue.dismiss()
                     }, label: {
                         Text("Save")
                             .foregroundColor(.white)
@@ -352,7 +450,32 @@ struct CanvasSignatureView: View {
             FormFooterView()
         }
     }
+
+    private func typedSignatureSnapshot(text: String) -> UIImage {
+        TypedSignatureSnapshotView(text: text, fontName: typedSignatureFontName)
+                .frame(width: screenWidth, height: 220)
+                .snapshot()
+    }
 }
+
+private struct TypedSignatureSnapshotView: View {
+    let text: String
+    let fontName: String
+
+    var body: some View {
+        ZStack {
+            Color.clear
+            Text(text)
+                .font(.custom(fontName, size: 72))
+                .foregroundColor(.black.opacity(0.92))
+                .lineLimit(1)
+                .minimumScaleFactor(0.2)
+                .padding(.horizontal, 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        }
+    }
+}
+
 extension View {
     func snapshot() -> UIImage {
         let controller = UIHostingController(rootView: self)
@@ -370,3 +493,7 @@ extension View {
     }
 }
 
+enum SignatureInputMode {
+    case draw
+    case type
+}

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -381,44 +381,7 @@ struct CanvasSignatureView: View {
                     .accessibilityIdentifier("ClearSignatureIdentifier")
                     
                     Button(action: {
-                        if signatureInputMode == .draw {
-                            if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
-                                savedLines = []
-                                savedTypedSignature = ""
-                                signatureImage = nil
-                                signatureURL = ""
-                                showError = false
-                                presentationMode.wrappedValue.dismiss()
-                                return
-                            }
-                            if !showCanvasError {
-                                signatureImage = CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
-                                    .frame(width: screenWidth, height: 220)
-                                    .snapshot()
-                                showError = false
-                            }
-                            savedLines = lines
-                            savedTypedSignature = ""
-                            presentationMode.wrappedValue.dismiss()
-                        } else {
-                            let trimmedTypedSignatureText = typedSignatureText.trimmingCharacters(in: .whitespacesAndNewlines)
-                                if trimmedTypedSignatureText.isEmpty {
-                                    savedLines = []
-                                    savedTypedSignature = ""
-                                    signatureImage = nil
-                                    signatureURL = ""
-                                    showError = false
-                                    presentationMode.wrappedValue.dismiss()
-                                    return
-                                }
-                                savedTypedSignature = trimmedTypedSignatureText
-                                signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
-                                lines.removeAll()
-                                savedLines = []
-                                showCanvasError = false
-                                showError = false
-                                presentationMode.wrappedValue.dismiss()
-                        }
+                        saveSignature()
                     }, label: {
                         Text("Save")
                             .foregroundColor(.white)
@@ -459,6 +422,54 @@ struct CanvasSignatureView: View {
         TypedSignatureSnapshotView(text: text, fontName: typedSignatureFontName)
                 .frame(width: screenWidth, height: 220)
                 .snapshot()
+    }
+    
+    private func saveSignature() {
+        switch signatureInputMode {
+        case .draw:
+            saveDrawSignature()
+        case .type:
+            saveTypedSignature()
+        }
+    }
+    private func saveDrawSignature() {
+        if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
+            clearSignatureAndDismiss()
+            return
+        }
+        if !showCanvasError {
+            signatureImage = CanvasView(lines: $lines, signatureCanvasImage: $signatureCanvasImage, showCanvasError: $showCanvasError)
+                .frame(width: screenWidth, height: 220)
+                .snapshot()
+            showError = false
+        }
+        savedLines = lines
+        savedTypedSignature = ""
+        presentationMode.wrappedValue.dismiss()
+    }
+    
+    private func saveTypedSignature() {
+        let trimmedTypedSignatureText = typedSignatureText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedTypedSignatureText.isEmpty {
+                clearSignatureAndDismiss()
+                return
+            }
+            savedTypedSignature = trimmedTypedSignatureText
+            signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
+            lines.removeAll()
+            savedLines = []
+            showCanvasError = false
+            showError = false
+            presentationMode.wrappedValue.dismiss()
+    }
+    
+    private func clearSignatureAndDismiss() {
+        savedLines = []
+        savedTypedSignature = ""
+        signatureImage = nil
+        signatureURL = ""
+        showError = false
+        presentationMode.wrappedValue.dismiss()
     }
 }
 

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -449,17 +449,17 @@ struct CanvasSignatureView: View {
     
     private func saveTypedSignature() {
         let trimmedTypedSignatureText = typedSignatureText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedTypedSignatureText.isEmpty {
-                clearSignatureAndDismiss()
-                return
-            }
-            savedTypedSignature = trimmedTypedSignatureText
-            signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
-            lines.removeAll()
-            savedLines = []
-            showCanvasError = false
-            showError = false
-            presentationMode.wrappedValue.dismiss()
+        if trimmedTypedSignatureText.isEmpty {
+            clearSignatureAndDismiss()
+            return
+        }
+        savedTypedSignature = trimmedTypedSignatureText
+        signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
+        lines.removeAll()
+        savedLines = []
+        showCanvasError = false
+        showError = false
+        presentationMode.wrappedValue.dismiss()
     }
     
     private func clearSignatureAndDismiss() {

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -413,7 +413,6 @@ struct CanvasSignatureView: View {
                                 }
                                 savedTypedSignature = trimmedTypedSignatureText
                                 signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
-                                signatureCanvasImage = signatureImage
                                 lines.removeAll()
                                 savedLines = []
                                 showCanvasError = false

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -219,7 +219,7 @@ struct CanvasSignatureView: View {
     @Binding var signatureImage: UIImage?
     @State var signatureCanvasImage: UIImage?
     @State var showCanvasError: Bool = false
-    @State var signatureInputMode: SignatureInputMode = .draw
+    @State private var signatureInputMode: SignatureInputMode = .draw
     @State private var typedSignatureText: String = ""
     @Binding var signatureURL: String
     @Binding var showError: Bool

--- a/Sources/JoyfillUI/View/Fields/SignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/SignatureView.swift
@@ -6,6 +6,7 @@ struct SignatureView: View {
     @State private var lines: [Line] = []
     @State var signatureImage: UIImage?
     @State private var savedLines: [Line] = []
+    @State private var savedTypedSignature: String = ""
     @State var signatureURL: String = ""
     @State private var showCanvasSignatureView: Bool = false
     @State var isEditable: Bool = true
@@ -74,7 +75,7 @@ struct SignatureView: View {
             .accessibilityIdentifier("SignatureIdentifier")
             .padding(.top, 6)
             
-            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable, documentEditor: signatureDataModel.documentEditor, fieldID: signatureDataModel.fieldIdentifier.fieldID).environment(\.footerContainer, footerContainer), isActive: $showCanvasSignatureView) {
+            NavigationLink(destination: CanvasSignatureView(lines: $lines, savedLines: $savedLines, savedTypedSignature: $savedTypedSignature, signatureImage: $signatureImage, signatureURL: $signatureURL, showError: $showError, isEditable: $isEditable, documentEditor: signatureDataModel.documentEditor, fieldID: signatureDataModel.fieldIdentifier.fieldID).environment(\.footerContainer, footerContainer), isActive: $showCanvasSignatureView) {
                 EmptyView()
             }
             .frame(width: 0, height: 0)
@@ -216,6 +217,7 @@ struct CanvasView: View {
 struct CanvasSignatureView: View {
     @Binding var lines: [Line]
     @Binding var savedLines: [Line]
+    @Binding var savedTypedSignature: String
     @Binding var signatureImage: UIImage?
     @State var signatureCanvasImage: UIImage?
     @State var showCanvasError: Bool = false
@@ -384,6 +386,7 @@ struct CanvasSignatureView: View {
                         if signatureInputMode == .draw{
                             if lines.isEmpty && signatureCanvasImage == nil && showCanvasError == false {
                                 savedLines = []
+                                savedTypedSignature = ""
                                 signatureImage = nil
                                 signatureURL = ""
                                 showError = false
@@ -397,17 +400,20 @@ struct CanvasSignatureView: View {
                                 showError = false
                             }
                             savedLines = lines
+                            savedTypedSignature = ""
                             presentationMode.wrappedValue.dismiss()
                         } else {
                             let trimmedTypedSignatureText = typedSignatureText.trimmingCharacters(in: .whitespacesAndNewlines)
                                 if trimmedTypedSignatureText.isEmpty {
                                     savedLines = []
+                                    savedTypedSignature = ""
                                     signatureImage = nil
                                     signatureURL = ""
                                     showError = false
                                     presentationMode.wrappedValue.dismiss()
                                     return
                                 }
+                                savedTypedSignature = trimmedTypedSignatureText
                                 signatureImage = typedSignatureSnapshot(text: trimmedTypedSignatureText)
                                 signatureCanvasImage = signatureImage
                                 lines.removeAll()
@@ -437,6 +443,7 @@ struct CanvasSignatureView: View {
         .onAppear {
             signatureCanvasImage = signatureImage
             showCanvasError = showError
+            typedSignatureText = savedTypedSignature
         }
         .onDisappear {
             documentEditor?.setOpenNavigationFieldID(nil)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
@@ -8,6 +8,7 @@ struct TableSignatureView: View {
     @State private var savedLines: [Line] = []
     @State private var signatureImage: UIImage?
     @State private var showCanvasSignatureView: Bool = false
+    @State var signatureInputMode: SignatureInputMode = .draw
     @State var title: String = ""
     @State var showError: Bool = false
     
@@ -21,6 +22,8 @@ struct TableSignatureView: View {
     var body: some View {
         Button(action: {
             cellModel.didFocusBlur?(.focus, cellModel.data)
+            isEditable = title.isEmpty
+            signatureInputMode = .draw
             loadImageFromURL()
             showCanvasSignatureView = true
         }, label: {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
@@ -9,7 +9,6 @@ struct TableSignatureView: View {
     @State private var savedTypedSignature: String = ""
     @State private var signatureImage: UIImage?
     @State private var showCanvasSignatureView: Bool = false
-    @State var signatureInputMode: SignatureInputMode = .draw
     @State var title: String = ""
     @State var showError: Bool = false
     
@@ -24,7 +23,6 @@ struct TableSignatureView: View {
         Button(action: {
             cellModel.didFocusBlur?(.focus, cellModel.data)
             isEditable = title.isEmpty
-            signatureInputMode = .draw
             loadImageFromURL()
             showCanvasSignatureView = true
         }, label: {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift
@@ -6,6 +6,7 @@ struct TableSignatureView: View {
     @State var isEditable: Bool = false
     @State private var lines: [Line] = []
     @State private var savedLines: [Line] = []
+    @State private var savedTypedSignature: String = ""
     @State private var signatureImage: UIImage?
     @State private var showCanvasSignatureView: Bool = false
     @State var signatureInputMode: SignatureInputMode = .draw
@@ -37,7 +38,7 @@ struct TableSignatureView: View {
             isEditable = false
             cellModel.didFocusBlur?(.blur, cellModel.data)
         }) {
-            CanvasSignatureView(lines: $lines, savedLines: $savedLines, signatureImage: $signatureImage, signatureURL: $title, showError: $showError, isEditable: $isEditable)
+            CanvasSignatureView(lines: $lines, savedLines: $savedLines, savedTypedSignature: $savedTypedSignature, signatureImage: $signatureImage, signatureURL: $title, showError: $showError, isEditable: $isEditable)
                 .environment(\.footerContainer, FooterContainer())
         }
         .onChange(of: signatureImage) { newImage in


### PR DESCRIPTION
## 1) Spec Context
This PR implements **NO-2080** by adding typed-signature support alongside draw mode, and by tightening signature behavior for edit/reopen flows across standard, table, and collection signature fields.

## 2) What Changed (Code + Files)
### Core implementation
- `Sources/JoyfillUI/View/Fields/SignatureView.swift`
- `Sources/JoyfillUI/View/Fields/TableView/TableSignatureView.swift`

### Key updates
- Added draw/type toggle support in signature input.
- Added typed-signature rendering flow (`TypeToSign` + typed snapshot generation).
- Added mode-specific save behavior:
  - Draw mode preserves existing canvas snapshot behavior.
  - Type mode trims input, treats empty value as clear, snapshots typed text, and clears stale draw line data.
- Restored previously typed signature text when reopening an existing typed signature for edit.
- Updated typed-signature font styling and removed opacity-based text styling.
- Updated table signature entry behavior to reset mode/editability before presenting the sheet.

## 3) UI Test Coverage Added
### Files changed
- `JoyfillSwiftUIExample/JoyfillUITests/SignatureField/SignatureFieldUITestCases.swift`
- `JoyfillSwiftUIExample/JoyfillUITests/TableField/TableNumber_Block_DateFieldTest.swift`
- `JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift`

### New test scenarios
- Existing saved signature opens read-only preview first (with Edit action).
- Signature mode resets to Draw when reopening a fresh signature sheet.
- Previously typed text is restored on edit.
- Typed signatures are row-scoped in table/collection flows (no carry-over to new rows).

## 4) Public API / Docs
- **No public API changes**.
- **No docs update required**.

## 5) Reviewer Notes
- Primary focus areas:
  - mode-specific save logic and state cleanup
  - typed-text restore path on edit
  - row-scoped behavior in table/collection signature flows