### PR TITLE
NO-2083: fix crash in CollectionEditMultipleRowsSheetView when selectedRows is empty during bulk edit dismiss

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -1192,6 +1192,50 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
             // No change event received, which is the expected behavior for this test.
         }
     }
+
+    func testBulkEditApplyAllKeepsRowsSelected() throws {
+        goToCollectionDetailField()
+
+        selectAllParentRows()
+        let moreButton = app.buttons["TableMoreButtonIdentifier"]
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "More button should appear after selecting rows")
+
+        tapOnMoreButton()
+        let editRowsMenuBefore = editRowsButton()
+        let deleteRowsMenuBefore = deleteRowButton()
+        XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 1), "Edit rows option should be visible in More menu")
+        XCTAssertTrue(deleteRowsMenuBefore.waitForExistence(timeout: 1), "Delete rows option should be visible in More menu")
+
+        let editLabelBefore = editRowsMenuBefore.label
+        let deleteLabelBefore = deleteRowsMenuBefore.label
+        XCTAssertTrue(editLabelBefore.contains("rows"), "This should be a bulk edit flow, but got: \(editLabelBefore)")
+        XCTAssertTrue(deleteLabelBefore.contains("rows"), "This should be a bulk delete flow, but got: \(deleteLabelBefore)")
+
+        editRowsMenuBefore.tap()
+
+        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        XCTAssertTrue(textField.waitForExistence(timeout: 1), "Bulk edit text field should be visible")
+        textField.tap()
+        textField.typeText("BulkSelectionPersistence")
+
+        let applyAllButton = app.buttons["ApplyAllButtonIdentifier"]
+        XCTAssertTrue(applyAllButton.waitForExistence(timeout: 1), "Apply All button should be visible in bulk edit")
+        applyAllButton.tap()
+
+        waitForAppToSettle()
+
+        XCTAssertFalse(applyAllButton.exists, "Bulk edit sheet should be dismissed after applying")
+        XCTAssertNotNil(onChangeOptionalResult(), "Bulk edit should produce a change event after editing data")
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "Rows should remain selected after Apply All")
+
+        tapOnMoreButton()
+        let editRowsMenuAfter = editRowsButton()
+        let deleteRowsMenuAfter = deleteRowButton()
+        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 1), "Edit rows option should still be visible after Apply All")
+        XCTAssertTrue(deleteRowsMenuAfter.waitForExistence(timeout: 1), "Delete rows option should still be visible after Apply All")
+        XCTAssertEqual(editRowsMenuAfter.label, editLabelBefore, "Edit rows label/count should remain unchanged after bulk apply")
+        XCTAssertEqual(deleteRowsMenuAfter.label, deleteLabelBefore, "Delete rows label/count should remain unchanged after bulk apply")
+    }
     
     // Edit all Nested rows
     func testBulkEditNestedRows() throws {
@@ -1404,4 +1448,3 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
     }
     
 }
-

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -75,6 +75,12 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         }
         usleep(500000) // 0.5 second to allow UI to settle
     }
+
+    private func rowCountFromBulkMenuLabel(_ label: String) -> Int? {
+        let numberToken = label.split(whereSeparator: { !$0.isNumber }).first
+        guard let numberToken else { return nil }
+        return Int(numberToken)
+    }
     
     func ensureCleanCollectionState() {
         returnToRootView()
@@ -1202,14 +1208,15 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
 
         tapOnMoreButton()
         let editRowsMenuBefore = editRowsButton()
-        let deleteRowsMenuBefore = deleteRowButton()
         XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 1), "Edit rows option should be visible in More menu")
-        XCTAssertTrue(deleteRowsMenuBefore.waitForExistence(timeout: 1), "Delete rows option should be visible in More menu")
+        XCTAssertTrue(deleteRowButton().waitForExistence(timeout: 1), "Delete rows option should be visible in More menu")
 
         let editLabelBefore = editRowsMenuBefore.label
-        let deleteLabelBefore = deleteRowsMenuBefore.label
         XCTAssertTrue(editLabelBefore.contains("rows"), "This should be a bulk edit flow, but got: \(editLabelBefore)")
-        XCTAssertTrue(deleteLabelBefore.contains("rows"), "This should be a bulk delete flow, but got: \(deleteLabelBefore)")
+        guard let beforeBulkEditCount = rowCountFromBulkMenuLabel(editLabelBefore) else {
+            XCTFail("Could not parse bulk edit row count from label: \(editLabelBefore)")
+            return
+        }
 
         editRowsMenuBefore.tap()
 
@@ -1222,19 +1229,19 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         XCTAssertTrue(applyAllButton.waitForExistence(timeout: 1), "Apply All button should be visible in bulk edit")
         applyAllButton.tap()
 
-        waitForAppToSettle()
-
-        XCTAssertFalse(applyAllButton.exists, "Bulk edit sheet should be dismissed after applying")
+        XCTAssertTrue(waitUntil(2) { !applyAllButton.exists }, "Bulk edit sheet should be dismissed after applying")
         XCTAssertNotNil(onChangeOptionalResult(), "Bulk edit should produce a change event after editing data")
         XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "Rows should remain selected after Apply All")
 
         tapOnMoreButton()
         let editRowsMenuAfter = editRowsButton()
-        let deleteRowsMenuAfter = deleteRowButton()
         XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 1), "Edit rows option should still be visible after Apply All")
-        XCTAssertTrue(deleteRowsMenuAfter.waitForExistence(timeout: 1), "Delete rows option should still be visible after Apply All")
-        XCTAssertEqual(editRowsMenuAfter.label, editLabelBefore, "Edit rows label/count should remain unchanged after bulk apply")
-        XCTAssertEqual(deleteRowsMenuAfter.label, deleteLabelBefore, "Delete rows label/count should remain unchanged after bulk apply")
+        let editLabelAfter = editRowsMenuAfter.label
+        guard let afterBulkEditCount = rowCountFromBulkMenuLabel(editLabelAfter) else {
+            XCTFail("Could not parse bulk edit row count after apply from label: \(editLabelAfter)")
+            return
+        }
+        XCTAssertEqual(afterBulkEditCount, beforeBulkEditCount, "Edit rows count should remain unchanged after bulk apply")
     }
     
     // Edit all Nested rows

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -76,12 +76,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         usleep(500000) // 0.5 second to allow UI to settle
     }
 
-    private func rowCountFromBulkMenuLabel(_ label: String) -> Int? {
-        let numberToken = label.split(whereSeparator: { !$0.isNumber }).first
-        guard let numberToken else { return nil }
-        return Int(numberToken)
-    }
-    
+
     func ensureCleanCollectionState() {
         returnToRootView()
         dismissAnyOpenModals()
@@ -1199,7 +1194,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         }
     }
 
-    func testBulkEditApplyAllKeepsRowsSelected() throws {
+    func testBulkEditApplyAllClearsSelection() throws {
         goToCollectionDetailField()
 
         selectAllParentRows()
@@ -1209,14 +1204,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         tapOnMoreButton()
         let editRowsMenuBefore = editRowsButton()
         XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 1), "Edit rows option should be visible in More menu")
-        XCTAssertTrue(deleteRowButton().waitForExistence(timeout: 1), "Delete rows option should be visible in More menu")
-
-        let editLabelBefore = editRowsMenuBefore.label
-        XCTAssertTrue(editLabelBefore.contains("rows"), "This should be a bulk edit flow, but got: \(editLabelBefore)")
-        guard let beforeBulkEditCount = rowCountFromBulkMenuLabel(editLabelBefore) else {
-            XCTFail("Could not parse bulk edit row count from label: \(editLabelBefore)")
-            return
-        }
+        XCTAssertTrue(editRowsMenuBefore.label.contains("rows"), "This should be a bulk edit flow, but got: \(editRowsMenuBefore.label)")
 
         editRowsMenuBefore.tap()
 
@@ -1231,17 +1219,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
 
         XCTAssertTrue(waitUntil(2) { !applyAllButton.exists }, "Bulk edit sheet should be dismissed after applying")
         XCTAssertNotNil(onChangeOptionalResult(), "Bulk edit should produce a change event after editing data")
-        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "Rows should remain selected after Apply All")
-
-        tapOnMoreButton()
-        let editRowsMenuAfter = editRowsButton()
-        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 1), "Edit rows option should still be visible after Apply All")
-        let editLabelAfter = editRowsMenuAfter.label
-        guard let afterBulkEditCount = rowCountFromBulkMenuLabel(editLabelAfter) else {
-            XCTFail("Could not parse bulk edit row count after apply from label: \(editLabelAfter)")
-            return
-        }
-        XCTAssertEqual(afterBulkEditCount, beforeBulkEditCount, "Edit rows count should remain unchanged after bulk apply")
+        XCTAssertFalse(moreButton.exists, "Selection should be cleared after Apply All")
     }
     
     // Edit all Nested rows

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
@@ -6,6 +6,12 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
     override func getJSONFileNameForTest() -> String {
         return "Joydocjson"
     }
+
+    private func rowCountFromBulkMenuLabel(_ label: String) -> Int? {
+        let numberToken = label.split(whereSeparator: { !$0.isNumber }).first
+        guard let numberToken else { return nil }
+        return Int(numberToken)
+    }
     
     func goToTableDetailPage() {
         app.swipeUp()
@@ -390,46 +396,47 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
         navigateToTableViewOnSecondPage()
 
         let selectAllButton = app.images["SelectAllRowSelectorButton"]
-        XCTAssertTrue(selectAllButton.waitForExistence(timeout: 5), "Select all row button should be visible")
+        XCTAssertTrue(selectAllButton.waitForExistence(timeout: 1), "Select all row button should be visible")
         selectAllButton.tap()
 
         let moreButton = app.buttons["TableMoreButtonIdentifier"]
-        XCTAssertTrue(moreButton.waitForExistence(timeout: 5), "More button should be visible after selecting rows")
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "More button should be visible after selecting rows")
         moreButton.tap()
 
         let editRowsMenuBefore = app.buttons["TableEditRowsIdentifier"]
-        let deleteRowsMenuBefore = app.buttons["TableDeleteRowIdentifier"]
-        XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 5), "Edit rows option should be visible in More menu")
-        XCTAssertTrue(deleteRowsMenuBefore.waitForExistence(timeout: 5), "Delete rows option should be visible in More menu")
+        XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 1), "Edit rows option should be visible in More menu")
 
         let editLabelBefore = editRowsMenuBefore.label
-        let deleteLabelBefore = deleteRowsMenuBefore.label
         XCTAssertTrue(editLabelBefore.contains("rows"), "Expected bulk edit menu label, got: \(editLabelBefore)")
-        XCTAssertTrue(deleteLabelBefore.contains("rows"), "Expected bulk delete menu label, got: \(deleteLabelBefore)")
+        guard let beforeBulkEditCount = rowCountFromBulkMenuLabel(editLabelBefore) else {
+            XCTFail("Could not parse bulk edit row count from label: \(editLabelBefore)")
+            return
+        }
 
         editRowsMenuBefore.tap()
 
         let textField = app.textFields["EditRowsTextFieldIdentifier"]
-        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Bulk edit text field should be visible")
+        XCTAssertTrue(textField.waitForExistence(timeout: 1), "Bulk edit text field should be visible")
         textField.tap()
         textField.typeText("KeepSelection")
 
         let applyAllButton = app.buttons["ApplyAllButtonIdentifier"]
-        XCTAssertTrue(applyAllButton.waitForExistence(timeout: 5), "Apply All button should be visible in bulk edit")
+        XCTAssertTrue(applyAllButton.waitForExistence(timeout: 1), "Apply All button should be visible in bulk edit")
         applyAllButton.tap()
 
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
-
-        XCTAssertFalse(applyAllButton.exists, "Bulk edit sheet should be dismissed after applying")
-        XCTAssertTrue(moreButton.waitForExistence(timeout: 5), "Rows should remain selected after Apply All")
+        XCTAssertTrue(waitUntil(2) { !applyAllButton.exists }, "Bulk edit sheet should be dismissed after applying")
+        XCTAssertNotNil(onChangeOptionalResult(), "Bulk edit should produce a change event after editing data")
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "Rows should remain selected after Apply All")
 
         moreButton.tap()
         let editRowsMenuAfter = app.buttons["TableEditRowsIdentifier"]
-        let deleteRowsMenuAfter = app.buttons["TableDeleteRowIdentifier"]
-        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 5), "Edit rows option should still be visible after Apply All")
-        XCTAssertTrue(deleteRowsMenuAfter.waitForExistence(timeout: 5), "Delete rows option should still be visible after Apply All")
-        XCTAssertEqual(editRowsMenuAfter.label, editLabelBefore, "Edit rows label/count should remain unchanged after bulk apply")
-        XCTAssertEqual(deleteRowsMenuAfter.label, deleteLabelBefore, "Delete rows label/count should remain unchanged after bulk apply")
+        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 1), "Edit rows option should still be visible after Apply All")
+        let editLabelAfter = editRowsMenuAfter.label
+        guard let afterBulkEditCount = rowCountFromBulkMenuLabel(editLabelAfter) else {
+            XCTFail("Could not parse bulk edit row count after apply from label: \(editLabelAfter)")
+            return
+        }
+        XCTAssertEqual(afterBulkEditCount, beforeBulkEditCount, "Edit rows count should remain unchanged after bulk apply")
     }
     
     func testEditSingleRow() throws {

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
@@ -385,6 +385,52 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
             XCTAssertEqual(button.label, dropdownValueLabel, "The label on button \(index + 1) is incorrect")
         }
     }
+
+    func testBulkEditApplyAllKeepsRowsSelected() throws {
+        navigateToTableViewOnSecondPage()
+
+        let selectAllButton = app.images["SelectAllRowSelectorButton"]
+        XCTAssertTrue(selectAllButton.waitForExistence(timeout: 5), "Select all row button should be visible")
+        selectAllButton.tap()
+
+        let moreButton = app.buttons["TableMoreButtonIdentifier"]
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 5), "More button should be visible after selecting rows")
+        moreButton.tap()
+
+        let editRowsMenuBefore = app.buttons["TableEditRowsIdentifier"]
+        let deleteRowsMenuBefore = app.buttons["TableDeleteRowIdentifier"]
+        XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 5), "Edit rows option should be visible in More menu")
+        XCTAssertTrue(deleteRowsMenuBefore.waitForExistence(timeout: 5), "Delete rows option should be visible in More menu")
+
+        let editLabelBefore = editRowsMenuBefore.label
+        let deleteLabelBefore = deleteRowsMenuBefore.label
+        XCTAssertTrue(editLabelBefore.contains("rows"), "Expected bulk edit menu label, got: \(editLabelBefore)")
+        XCTAssertTrue(deleteLabelBefore.contains("rows"), "Expected bulk delete menu label, got: \(deleteLabelBefore)")
+
+        editRowsMenuBefore.tap()
+
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
+        XCTAssertTrue(textField.waitForExistence(timeout: 5), "Bulk edit text field should be visible")
+        textField.tap()
+        textField.typeText("KeepSelection")
+
+        let applyAllButton = app.buttons["ApplyAllButtonIdentifier"]
+        XCTAssertTrue(applyAllButton.waitForExistence(timeout: 5), "Apply All button should be visible in bulk edit")
+        applyAllButton.tap()
+
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
+
+        XCTAssertFalse(applyAllButton.exists, "Bulk edit sheet should be dismissed after applying")
+        XCTAssertTrue(moreButton.waitForExistence(timeout: 5), "Rows should remain selected after Apply All")
+
+        moreButton.tap()
+        let editRowsMenuAfter = app.buttons["TableEditRowsIdentifier"]
+        let deleteRowsMenuAfter = app.buttons["TableDeleteRowIdentifier"]
+        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 5), "Edit rows option should still be visible after Apply All")
+        XCTAssertTrue(deleteRowsMenuAfter.waitForExistence(timeout: 5), "Delete rows option should still be visible after Apply All")
+        XCTAssertEqual(editRowsMenuAfter.label, editLabelBefore, "Edit rows label/count should remain unchanged after bulk apply")
+        XCTAssertEqual(deleteRowsMenuAfter.label, deleteLabelBefore, "Delete rows label/count should remain unchanged after bulk apply")
+    }
     
     func testEditSingleRow() throws {
         navigateToTableViewOnSecondPage()

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
@@ -7,12 +7,7 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
         return "Joydocjson"
     }
 
-    private func rowCountFromBulkMenuLabel(_ label: String) -> Int? {
-        let numberToken = label.split(whereSeparator: { !$0.isNumber }).first
-        guard let numberToken else { return nil }
-        return Int(numberToken)
-    }
-    
+
     func goToTableDetailPage() {
         app.swipeUp()
         app.swipeUp()
@@ -392,7 +387,7 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
         }
     }
 
-    func testBulkEditApplyAllKeepsRowsSelected() throws {
+    func testBulkEditApplyAllClearsSelection() throws {
         navigateToTableViewOnSecondPage()
 
         let selectAllButton = app.images["SelectAllRowSelectorButton"]
@@ -405,13 +400,7 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
 
         let editRowsMenuBefore = app.buttons["TableEditRowsIdentifier"]
         XCTAssertTrue(editRowsMenuBefore.waitForExistence(timeout: 1), "Edit rows option should be visible in More menu")
-
-        let editLabelBefore = editRowsMenuBefore.label
-        XCTAssertTrue(editLabelBefore.contains("rows"), "Expected bulk edit menu label, got: \(editLabelBefore)")
-        guard let beforeBulkEditCount = rowCountFromBulkMenuLabel(editLabelBefore) else {
-            XCTFail("Could not parse bulk edit row count from label: \(editLabelBefore)")
-            return
-        }
+        XCTAssertTrue(editRowsMenuBefore.label.contains("rows"), "Expected bulk edit menu label, got: \(editRowsMenuBefore.label)")
 
         editRowsMenuBefore.tap()
 
@@ -426,17 +415,7 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
 
         XCTAssertTrue(waitUntil(2) { !applyAllButton.exists }, "Bulk edit sheet should be dismissed after applying")
         XCTAssertNotNil(onChangeOptionalResult(), "Bulk edit should produce a change event after editing data")
-        XCTAssertTrue(moreButton.waitForExistence(timeout: 1), "Rows should remain selected after Apply All")
-
-        moreButton.tap()
-        let editRowsMenuAfter = app.buttons["TableEditRowsIdentifier"]
-        XCTAssertTrue(editRowsMenuAfter.waitForExistence(timeout: 1), "Edit rows option should still be visible after Apply All")
-        let editLabelAfter = editRowsMenuAfter.label
-        guard let afterBulkEditCount = rowCountFromBulkMenuLabel(editLabelAfter) else {
-            XCTFail("Could not parse bulk edit row count after apply from label: \(editLabelAfter)")
-            return
-        }
-        XCTAssertEqual(afterBulkEditCount, beforeBulkEditCount, "Edit rows count should remain unchanged after bulk apply")
+        XCTAssertFalse(moreButton.exists, "Selection should be cleared after Apply All")
     }
     
     func testEditSingleRow() throws {

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -461,23 +461,54 @@ struct CollectionEditMultipleRowsSheetView: View {
                 }
 
                 if !viewModel.tableDataModel.selectedRows.isEmpty {
-                let header = viewModel.getHeaderForSelectedRows()
-                ForEach(Array(header.columns.enumerated()), id: \.offset) { colIndex, col in
-                    let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
-                    VStack(alignment: .leading, spacing: 16) {
-                    if let row = viewModel.tableDataModel.selectedRows.first {
-                        let selectedRow = viewModel.tableDataModel.getRowByID(rowID: row)
-                        let isUsedForBulkEdit = !(viewModel.tableDataModel.selectedRows.count == 1)
-                        if let cell = viewModel.tableDataModel.getDummyNestedCell(col: colIndex, isBulkEdit: isUsedForBulkEdit, rowID: row) {
-                            var cellModel = TableCellModel(rowID: row,
-                                                           timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells[colIndex].timezoneId,
-                                                           data: cell,
-                                                           documentEditor: viewModel.tableDataModel.documentEditor,
-                                                           fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
-                                                           viewMode: .modalView,
-                                                           editMode: viewModel.tableDataModel.mode,
-                                                           didFocusBlur: { action, cellDataModel in
-                                viewModel.emitCellFocusBlur(action: action, rowID: row, columnID: cellDataModel.id) })
+                    selectedRowsHeaderColumns
+                }
+                Spacer()
+            }
+            .padding(.all, 16)
+            .environment(\.navigationFocusColumnId, viewModel.tableDataModel.navigationIntent.focusColumnId)
+        }
+        .id(viewID)
+        .onAppear {
+            if let columnId = viewModel.tableDataModel.navigationIntent.scrollToColumnId {
+                scrollProxy.scrollTo(columnId, anchor: .top)
+            }
+        }
+        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ newValue in
+            viewID = UUID()
+        }
+        .simultaneousGesture(DragGesture().onChanged({ _ in
+            dismissKeyboard()
+            viewModel.tableDataModel.navigationIntent.focusColumnId = nil
+        }))
+        .onTapGesture {
+            viewModel.tableDataModel.navigationIntent.focusColumnId = nil
+        }
+        }
+        .safeAreaInset(edge: .bottom) {
+            FormFooterView()
+        }
+    }
+
+    @ViewBuilder
+    private var selectedRowsHeaderColumns: some View {
+        let header = viewModel.getHeaderForSelectedRows()
+        ForEach(Array(header.columns.enumerated()), id: \.offset) { colIndex, col in
+            let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
+            VStack(alignment: .leading, spacing: 16) {
+                if let row = viewModel.tableDataModel.selectedRows.first {
+                    let selectedRow = viewModel.tableDataModel.getRowByID(rowID: row)
+                    let isUsedForBulkEdit = !(viewModel.tableDataModel.selectedRows.count == 1)
+                    if let cell = viewModel.tableDataModel.getDummyNestedCell(col: colIndex, isBulkEdit: isUsedForBulkEdit, rowID: row) {
+                        var cellModel = TableCellModel(rowID: row,
+                                                       timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells[colIndex].timezoneId,
+                                                       data: cell,
+                                                       documentEditor: viewModel.tableDataModel.documentEditor,
+                                                       fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
+                                                       viewMode: .modalView,
+                                                       editMode: viewModel.tableDataModel.mode,
+                                                       didFocusBlur: { action, cellDataModel in
+                            viewModel.emitCellFocusBlur(action: action, rowID: row, columnID: cellDataModel.id) })
                         { cellDataModel in
                             switch cell.type {
                             case .text:
@@ -561,7 +592,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                                 } else {
                                     self.changes[colIndex] = ValueUnion.string(cellDataModel.title ?? "")
                                 }
- 
+                                
                             default:
                                 break
                             }
@@ -571,12 +602,12 @@ struct CollectionEditMultipleRowsSheetView: View {
                                 }
                             }
                         }
-
+                        
                         var isFilledBasedOnChange: Bool {
                             guard isUsedForBulkEdit, let changeValue = changes[colIndex] else {
                                 return false
                             }
-
+                            
                             switch changeValue {
                             case .string(let str):
                                 return !str.isEmpty
@@ -596,9 +627,9 @@ struct CollectionEditMultipleRowsSheetView: View {
                                 return false
                             }
                         }
-
+                        
                         let isEffectivelyFilled = isUsedForBulkEdit ? isFilledBasedOnChange : cellModel.data.isCellFilled
-
+                        
                         switch col.type {
                         case .text:
                             fieldTitle(col, isCellFilled: isEffectivelyFilled, schemaKey: header.schemaKey)
@@ -685,34 +716,8 @@ struct CollectionEditMultipleRowsSheetView: View {
                         }
                     }
                 }
-                    }
-                    .id(col.id)
-                }
-                } // selectedRows non-empty guard
-                Spacer()
             }
-            .padding(.all, 16)
-            .environment(\.navigationFocusColumnId, viewModel.tableDataModel.navigationIntent.focusColumnId)
-        }
-        .id(viewID)
-        .onAppear {
-            if let columnId = viewModel.tableDataModel.navigationIntent.scrollToColumnId {
-                scrollProxy.scrollTo(columnId, anchor: .top)
-            }
-        }
-        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ newValue in
-            viewID = UUID()
-        }
-        .simultaneousGesture(DragGesture().onChanged({ _ in
-            dismissKeyboard()
-            viewModel.tableDataModel.navigationIntent.focusColumnId = nil
-        }))
-        .onTapGesture {
-            viewModel.tableDataModel.navigationIntent.focusColumnId = nil
-        }
-        }
-        .safeAreaInset(edge: .bottom) {
-            FormFooterView()
+            .id(col.id)
         }
     }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -417,7 +417,6 @@ struct CollectionEditMultipleRowsSheetView: View {
                         Button(action: {
                             Task { @MainActor in
                                 await viewModel.bulkEdit(changes: changes)
-                                viewModel.tableDataModel.emptySelection()
                                 presentationMode.wrappedValue.dismiss()
                             }
                             

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -417,6 +417,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                         Button(action: {
                             Task { @MainActor in
                                 await viewModel.bulkEdit(changes: changes)
+                                viewModel.tableDataModel.emptySelection()
                                 presentationMode.wrappedValue.dismiss()
                             }
                             
@@ -459,6 +460,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                     }
                 }
 
+                if !viewModel.tableDataModel.selectedRows.isEmpty {
                 let header = viewModel.getHeaderForSelectedRows()
                 ForEach(Array(header.columns.enumerated()), id: \.offset) { colIndex, col in
                     let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
@@ -686,6 +688,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                     }
                     .id(col.id)
                 }
+                } // selectedRows non-empty guard
                 Spacer()
             }
             .padding(.all, 16)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -343,6 +343,7 @@ struct EditMultipleRowsSheetView: View {
                         Button(action: {
                             Task { @MainActor in
                                 await viewModel.bulkEdit(changes: changes)
+                                viewModel.tableDataModel.emptySelection()
                                 presentationMode.wrappedValue.dismiss()
                             }
                         }, label: {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -343,7 +343,6 @@ struct EditMultipleRowsSheetView: View {
                         Button(action: {
                             Task { @MainActor in
                                 await viewModel.bulkEdit(changes: changes)
-                                viewModel.tableDataModel.emptySelection()
                                 presentationMode.wrappedValue.dismiss()
                             }
                         }, label: {


### PR DESCRIPTION
## 1) Spec Context
`NO-2083` — During bulk edit, tapping **Apply All** triggers \`emptySelection()\` after \`bulkEdit\` completes. This clears \`selectedRows\`, which causes SwiftUI to re-evaluate the sheet's body mid-dismissal. The body called \`getHeaderForSelectedRows()\` unconditionally, hitting a \`fatalError\` via \`Log(type: .error)\` when \`selectedRows\` is empty.

## 2) What Changed (Files/Code)
- **Crash fix** — \`CollectionEditMultipleRowsSheetView\` body now guards against empty \`selectedRows\` before calling \`getHeaderForSelectedRows()\`:
  - \`Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift\`
- **UI regression tests** added for bulk edit Apply All flow:
  - \`JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift\` → \`testBulkEditApplyAllClearsSelection()\`
  - \`JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift\` → \`testBulkEditApplyAllClearsSelection()\`

## 3) Decision Notes (Why)
After \`Apply All\`, \`emptySelection()\` clears \`selectedRows\` (a \`@Published\` property). This triggers a SwiftUI body re-render before the sheet finishes dismissing. The guard \`if !viewModel.tableDataModel.selectedRows.isEmpty\` prevents \`getHeaderForSelectedRows()\` from being called in that transient empty state, avoiding the fatal crash.

## 4) Screenshot / Video
Crash fix — no visual change. Behaviour is unchanged: selection is cleared and sheet dismisses after Apply All.

## 5) Public API / Docs Impact
- Public API change: **No**
- Docs update needed: **No**

## 6) Test Coverage
Both Collection and Table bulk edit flows are covered. Tests verify:
- Bulk edit sheet dismisses after Apply All
- A change event is emitted
- Selection is cleared after apply (More button no longer visible)

## 7) Reviewer Notes
The crash only manifests in DEBUG builds (the \`Log(type: .error)\` calls \`fatalError\` in debug). The guard is the correct long-term fix — \`getHeaderForSelectedRows()\` should never be called without a selected row.