### PR TITLE
NO-2075: Decorator API — row/cell scopes, decorate flag auto-toggle, collection support

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		9EAAC7E02EAB3EF4000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
 		9EAAC7E12EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */; };
 		9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
+		BA2352F22F99E9FE002D9345 /* Decorator.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2352F12F99E9F4002D9345 /* Decorator.json */; };
 		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
 		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
 		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
@@ -578,6 +579,7 @@
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
 		9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyModeUITestCases.swift; sourceTree = "<group>"; };
+		BA2352F12F99E9F4002D9345 /* Decorator.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Decorator.json; sourceTree = "<group>"; };
 		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
 		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
 		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
@@ -829,6 +831,7 @@
 		1307CF1A2BE36ECE00B19FBA /* JoyfillUITests */ = {
 			isa = PBXGroup;
 			children = (
+				BA2352F02F99E9DB002D9345 /* DecoratorUITests */,
 				E24089FE2F7CEFA1005C4885 /* Navigation Goto tests */,
 				1307CF1B2BE36ECE00B19FBA /* JoyfillUITests.swift */,
 				9EAAC7DF2EAB3EF4000B6F3C /* ReadonlyMode */,
@@ -998,6 +1001,14 @@
 				9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */,
 			);
 			path = ReadonlyMode;
+			sourceTree = "<group>";
+		};
+		BA2352F02F99E9DB002D9345 /* DecoratorUITests */ = {
+			isa = PBXGroup;
+			children = (
+				BA2352F12F99E9F4002D9345 /* Decorator.json */,
+			);
+			path = DecoratorUITests;
 			sourceTree = "<group>";
 		};
 		DEC000A000000000000000A0 /* DecoratorAPI */ = {
@@ -1632,6 +1643,7 @@
 			files = (
 				3682A4C92E158AA4005B73C3 /* FormulaTemplate_Write_ChartField.json in Resources */,
 				369D45672E0E52CA00677280 /* JoyfillResolver_LongChainIndirectCircularDependency.json in Resources */,
+				BA2352F22F99E9FE002D9345 /* Decorator.json in Resources */,
 				E2B8E3B92E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json in Resources */,
 				369D45682E0E52CA00677280 /* JoyfillResolverTemplate_ComplexWorking.json in Resources */,
 				E2E3E77B2E85611E002A10C2 /* first-form.json in Resources */,

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -175,6 +175,11 @@
 		9EAAC7E02EAB3EF4000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
 		9EAAC7E12EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */; };
 		9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
+		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
+		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
+		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
+		DEC000B400000000000000A4 /* DecoratorErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */; };
+		DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */; };
 		E20E53022F876E500088A4E4 /* DecoratorAPIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */; };
 		E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */; };
 		E22516882E8BA4C60089E2D2 /* UserJsonTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */; };
@@ -365,6 +370,8 @@
 		E2A6843B2DCA413B00385FE1 /* ImageReplacementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6843A2DCA413B00385FE1 /* ImageReplacementTest.swift */; };
 		E2A6843D2DCA41F000385FE1 /* JoyDoc+helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6843C2DCA41F000385FE1 /* JoyDoc+helper.swift */; };
 		E2ABC23F2DF06C7800A33038 /* ChangelogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ABC23E2DF06C7800A33038 /* ChangelogView.swift */; };
+		E2B4CFBD2F97AF2300F2128D /* DecoratorCOWTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFBC2F97AF2300F2128D /* DecoratorCOWTests.swift */; };
+		E2B4CFBF2F97AF3700F2128D /* DecoratorDeepPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFBE2F97AF3700F2128D /* DecoratorDeepPathTests.swift */; };
 		E2B5F75F2D75E5F30057FD85 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = E2B5F75E2D75E5F30057FD85 /* JoyfillAPIService */; };
 		E2B5F7612D75E67C0057FD85 /* TemplateSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B5F7602D75E67C0057FD85 /* TemplateSearchView.swift */; };
 		E2B8E3B92E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json in Resources */ = {isa = PBXBuildFile; fileRef = E2B8E3B82E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json */; };
@@ -401,11 +408,6 @@
 		E2C8BD2E2E462A8F00B93B9E /* FieldTitleNotDisplayed.json in Resources */ = {isa = PBXBuildFile; fileRef = E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */; };
 		E2C8BD2F2E462A8F00B93B9E /* FieldTitleNotDisplayed.json in Resources */ = {isa = PBXBuildFile; fileRef = E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */; };
 		E2CC9FEE2E375E0400797331 /* SchemaValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */; };
-		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
-		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
-		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
-		DEC000B400000000000000A4 /* DecoratorErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */; };
-		DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */; };
 		E2CC9FF02E377AA800797331 /* JSONSchema in Frameworks */ = {isa = PBXBuildFile; productRef = E2CC9FEF2E377AA800797331 /* JSONSchema */; };
 		E2E27C882E7AF4E60041FF1F /* CreateRowUISample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E27C872E7AF4E60041FF1F /* CreateRowUISample.swift */; };
 		E2E27D022E8C10000041FF1F /* MetadataChangeAPIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E27D012E8C10000041FF1F /* MetadataChangeAPIDemoView.swift */; };
@@ -576,6 +578,11 @@
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
 		9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyModeUITestCases.swift; sourceTree = "<group>"; };
+		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
+		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
+		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
+		DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorErrorHandlingTests.swift; sourceTree = "<group>"; };
+		DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorLiveUpdateTests.swift; sourceTree = "<group>"; };
 		E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorAPIDemoView.swift; sourceTree = "<group>"; };
 		E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableValidationTests.swift; sourceTree = "<group>"; };
 		E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJsonTextFieldView.swift; sourceTree = "<group>"; };
@@ -656,6 +663,8 @@
 		E2A6843A2DCA413B00385FE1 /* ImageReplacementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageReplacementTest.swift; sourceTree = "<group>"; };
 		E2A6843C2DCA41F000385FE1 /* JoyDoc+helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JoyDoc+helper.swift"; sourceTree = "<group>"; };
 		E2ABC23E2DF06C7800A33038 /* ChangelogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogView.swift; sourceTree = "<group>"; };
+		E2B4CFBC2F97AF2300F2128D /* DecoratorCOWTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorCOWTests.swift; sourceTree = "<group>"; };
+		E2B4CFBE2F97AF3700F2128D /* DecoratorDeepPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorDeepPathTests.swift; sourceTree = "<group>"; };
 		E2B5F7602D75E67C0057FD85 /* TemplateSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSearchView.swift; sourceTree = "<group>"; };
 		E2B8E3B82E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FSMIndustry_FormulaTemplate.json; sourceTree = "<group>"; };
 		E2B8E3BD2E43652E00AC6018 /* FormulaTemplate_FSMIndustryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_FSMIndustryTests.swift; sourceTree = "<group>"; };
@@ -685,11 +694,6 @@
 		E2C8BD282E462A8800B93B9E /* AllFieldTitleDispalayed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = AllFieldTitleDispalayed.json; sourceTree = "<group>"; };
 		E2C8BD2C2E462A8F00B93B9E /* FieldTitleNotDisplayed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FieldTitleNotDisplayed.json; sourceTree = "<group>"; };
 		E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationTests.swift; sourceTree = "<group>"; };
-		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
-		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
-		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
-		DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorErrorHandlingTests.swift; sourceTree = "<group>"; };
-		DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorLiveUpdateTests.swift; sourceTree = "<group>"; };
 		E2E27C872E7AF4E60041FF1F /* CreateRowUISample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRowUISample.swift; sourceTree = "<group>"; };
 		E2E27D012E8C10000041FF1F /* MetadataChangeAPIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataChangeAPIDemoView.swift; sourceTree = "<group>"; };
 		E2E3E7622E8450A3002A10C2 /* OnChangeHandler.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = OnChangeHandler.json; sourceTree = "<group>"; };
@@ -996,6 +1000,20 @@
 			path = ReadonlyMode;
 			sourceTree = "<group>";
 		};
+		DEC000A000000000000000A0 /* DecoratorAPI */ = {
+			isa = PBXGroup;
+			children = (
+				DEC000F100000000000000A1 /* DecoratorTestSupport.swift */,
+				E2B4CFBE2F97AF3700F2128D /* DecoratorDeepPathTests.swift */,
+				E2B4CFBC2F97AF2300F2128D /* DecoratorCOWTests.swift */,
+				DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */,
+				DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */,
+				DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */,
+				DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */,
+			);
+			path = DecoratorAPI;
+			sourceTree = "<group>";
+		};
 		E20E53012F876E500088A4E4 /* Decorator Example */ = {
 			isa = PBXGroup;
 			children = (
@@ -1223,18 +1241,6 @@
 				E2CC9FED2E375DF100797331 /* SchemaValidationTests.swift */,
 			);
 			path = SchemaValidation;
-			sourceTree = "<group>";
-		};
-		DEC000A000000000000000A0 /* DecoratorAPI */ = {
-			isa = PBXGroup;
-			children = (
-				DEC000F100000000000000A1 /* DecoratorTestSupport.swift */,
-				DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */,
-				DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */,
-				DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */,
-				DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */,
-			);
-			path = DecoratorAPI;
 			sourceTree = "<group>";
 		};
 		E2E3E7772E856105002A10C2 /* Simple Form Example */ = {
@@ -1998,6 +2004,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2B4CFBF2F97AF3700F2128D /* DecoratorDeepPathTests.swift in Sources */,
 				E2B8E3C02E43652E00AC6018 /* FormulaTemplate_FSMIndustryTests.swift in Sources */,
 				3682A4C42E153DA0005B73C3 /* FormulaTemplate_Read_ChartField.swift in Sources */,
 				1307CF142BE1292900B19FBA /* JoyDoc+Assert.swift in Sources */,
@@ -2029,6 +2036,7 @@
 				E2B8E3EF2E43806700AC6018 /* FormulaTemplate_BlockFieldTests.swift in Sources */,
 				36BCD3732E0BFA0600F5DA4B /* FormulaTemplate_TableField.swift in Sources */,
 				E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */,
+				E2B4CFBD2F97AF2300F2128D /* DecoratorCOWTests.swift in Sources */,
 				369D45772E0E586300677280 /* FormulaTemplate_CollectionField.swift in Sources */,
 				369025652E06E8EC00DCFF5B /* SimpleTableTest.swift in Sources */,
 				E2B8E3C22E436F2D00AC6018 /* FormulaTemplate_TextareaFieldTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		9EAAC7E12EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DE2EAB3EF4000B6F3C /* ReadonlyModeUITestCases.swift */; };
 		9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */; };
 		BA2352F22F99E9FE002D9345 /* Decorator.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2352F12F99E9F4002D9345 /* Decorator.json */; };
+		BA2352F32F99E9FE002D9346 /* Decorator.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2352F12F99E9F4002D9345 /* Decorator.json */; };
 		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
 		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
 		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
@@ -373,6 +374,8 @@
 		E2ABC23F2DF06C7800A33038 /* ChangelogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2ABC23E2DF06C7800A33038 /* ChangelogView.swift */; };
 		E2B4CFBD2F97AF2300F2128D /* DecoratorCOWTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFBC2F97AF2300F2128D /* DecoratorCOWTests.swift */; };
 		E2B4CFBF2F97AF3700F2128D /* DecoratorDeepPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFBE2F97AF3700F2128D /* DecoratorDeepPathTests.swift */; };
+		E2B4CFD32F99F54500F2128D /* DecoratorAPIUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFD22F99F54500F2128D /* DecoratorAPIUITests.swift */; };
+		E2B4CFD92F9A060700F2128D /* DecoratorUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B4CFD82F9A060700F2128D /* DecoratorUITestSupport.swift */; };
 		E2B5F75F2D75E5F30057FD85 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = E2B5F75E2D75E5F30057FD85 /* JoyfillAPIService */; };
 		E2B5F7612D75E67C0057FD85 /* TemplateSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B5F7602D75E67C0057FD85 /* TemplateSearchView.swift */; };
 		E2B8E3B92E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json in Resources */ = {isa = PBXBuildFile; fileRef = E2B8E3B82E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json */; };
@@ -667,6 +670,8 @@
 		E2ABC23E2DF06C7800A33038 /* ChangelogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogView.swift; sourceTree = "<group>"; };
 		E2B4CFBC2F97AF2300F2128D /* DecoratorCOWTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorCOWTests.swift; sourceTree = "<group>"; };
 		E2B4CFBE2F97AF3700F2128D /* DecoratorDeepPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorDeepPathTests.swift; sourceTree = "<group>"; };
+		E2B4CFD22F99F54500F2128D /* DecoratorAPIUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorAPIUITests.swift; sourceTree = "<group>"; };
+		E2B4CFD82F9A060700F2128D /* DecoratorUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorUITestSupport.swift; sourceTree = "<group>"; };
 		E2B5F7602D75E67C0057FD85 /* TemplateSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSearchView.swift; sourceTree = "<group>"; };
 		E2B8E3B82E435EC000AC6018 /* FSMIndustry_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FSMIndustry_FormulaTemplate.json; sourceTree = "<group>"; };
 		E2B8E3BD2E43652E00AC6018 /* FormulaTemplate_FSMIndustryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_FSMIndustryTests.swift; sourceTree = "<group>"; };
@@ -1006,6 +1011,8 @@
 		BA2352F02F99E9DB002D9345 /* DecoratorUITests */ = {
 			isa = PBXGroup;
 			children = (
+				E2B4CFD22F99F54500F2128D /* DecoratorAPIUITests.swift */,
+				E2B4CFD82F9A060700F2128D /* DecoratorUITestSupport.swift */,
 				BA2352F12F99E9F4002D9345 /* Decorator.json */,
 			);
 			path = DecoratorUITests;
@@ -1854,6 +1861,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BA2352F32F99E9FE002D9346 /* Decorator.json in Resources */,
 				E274CB532E2EA8ED00B35C09 /* ConditionalLogic_FormulaTemplate.json in Resources */,
 				369D451E2E0E51AC00677280 /* FormulaTemplate_TextField.json in Resources */,
 				362746572E24F0D0005B0FA7 /* FormulaTemplate_EqualityOperator.json in Resources */,
@@ -1976,6 +1984,7 @@
 				E2F568A72E2A473D005216A6 /* DisplayTextFieldUITestCases.swift in Sources */,
 				E2F568752E2A4594005216A6 /* ImageFieldUITestCases.swift in Sources */,
 				E2F568762E2A4594005216A6 /* ImageFieldTests.swift in Sources */,
+				E2B4CFD92F9A060700F2128D /* DecoratorUITestSupport.swift in Sources */,
 				E2408A022F7CF023005C4885 /* NavigationGotoUITests.swift in Sources */,
 				E29FF8822F2527790079A614 /* TestMobileViewDuplicateLogic.swift in Sources */,
 				1307CF1E2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift in Sources */,
@@ -1991,6 +2000,7 @@
 				1307CF1C2BE36ECE00B19FBA /* JoyfillUITests.swift in Sources */,
 				E2F568832E2A45BC005216A6 /* ChartFieldTests.swift in Sources */,
 				E2F568902E2A45F9005216A6 /* TableFieldUITestCases.swift in Sources */,
+				E2B4CFD32F99F54500F2128D /* DecoratorAPIUITests.swift in Sources */,
 				E274CA312E2E60A000B35C09 /* OnChangeHandlerUITests.swift in Sources */,
 				E274CA382E2E60A100B35C09 /* FocusCallbackUITests.swift in Sources */,
 				E2F568A22E2A4724005216A6 /* TextFieldUITestCases.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -997,35 +997,27 @@ struct DecoratorEditView: View {
 // MARK: - DecoratorAPIDemoView  (standalone entry from the option list)
 
 private class EditorBox: ObservableObject {
-    @Published var editor: DocumentEditor
+    let editor: DocumentEditor
 
     var onAction: ((String, String) -> Void)?
     var onError:  ((String) -> Void)?
 
-    init() { editor = EditorBox.make(document: sampleJSONDocument(fileName: "Navigation"), config: DecoratorConfig()) }
-
-    func remake(config: DecoratorConfig) {
-        editor = EditorBox.make(document: editor.document, config: config)
-        wire()
+    init() {
+        let handler = DecoratorEventHandler()
+        let ed = DocumentEditor(
+            document: sampleJSONDocument(fileName: "Navigation"),
+            events: handler,
+            validateSchema: false,
+            license: licenseKey
+        )
+        handler.editor = ed
+        self.editor = ed
     }
 
     func wire() {
         guard let h = editor.events as? DecoratorEventHandler else { return }
         h.onDecoratorAction = onAction
         h.onDecoratorError  = onError
-    }
-
-    private static func make(document: JoyDoc, config: DecoratorConfig) -> DocumentEditor {
-        let handler = DecoratorEventHandler()
-        let ed = DocumentEditor(
-            document: document,
-            events: handler,
-            validateSchema: false,
-            license: licenseKey,
-            decoratorConfig: config
-        )
-        handler.editor = ed
-        return ed
     }
 }
 
@@ -1057,9 +1049,6 @@ struct DecoratorAPIDemoView: View {
     @State private var lastPath:   String        = ""
     @State private var showBanner: Bool          = false
     @State private var decoratorError: DecoratorErrorAlert? = nil
-    @State private var visibleLimitInFields: Int = 2
-    @State private var visibleLimitInRows: Int   = 1
-    @State private var showConfigPopover: Bool   = false
     // Persisted across sheet dismissals so the user doesn't have to re-select
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
@@ -1079,7 +1068,6 @@ struct DecoratorAPIDemoView: View {
     }
 
     private func closeOverlaysBeforeExit() {
-        showConfigPopover = false
         showDecoratorManager = false
         decoratorError = nil
     }
@@ -1120,21 +1108,8 @@ struct DecoratorAPIDemoView: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                HStack(spacing: 16) {
-                    Button { showConfigPopover = true } label: {
-                        Image(systemName: "slider.horizontal.3")
-                    }
-                    .popover(isPresented: $showConfigPopover) {
-                        if #available(iOS 16.4, *) {
-                            configPopover
-                                .presentationCompactAdaptation(.popover)
-                        } else {
-                            configPopover
-                        }
-                    }
-                    Button { showDecoratorManager = true } label: {
-                        Label("Decorators", systemImage: "paintbrush.pointed.fill")
-                    }
+                Button { showDecoratorManager = true } label: {
+                    Label("Decorators", systemImage: "paintbrush.pointed.fill")
                 }
             }
         }
@@ -1170,77 +1145,6 @@ struct DecoratorAPIDemoView: View {
                   message: Text(err.message),
                   dismissButton: .default(Text("OK")))
         }
-    }
-
-    // MARK: Config popover
-
-    private var configPopover: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Decorator Config")
-                .font(.headline)
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
-                .padding(.bottom, 12)
-
-            Divider()
-
-            VStack(spacing: 0) {
-                Stepper(value: $visibleLimitInFields, in: 0...10) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Fields & Columns").font(.subheadline)
-                        Text("visibleLimitInFields: \(visibleLimitInFields)")
-                            .font(.caption.monospaced()).foregroundColor(.secondary)
-                    }
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 14)
-
-                Divider().padding(.leading, 20)
-
-                Stepper(value: $visibleLimitInRows, in: 0...10) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Rows").font(.subheadline)
-                        Text("visibleLimitInRows: \(visibleLimitInRows)")
-                            .font(.caption.monospaced()).foregroundColor(.secondary)
-                    }
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 14)
-            }
-
-            Divider()
-
-            HStack(spacing: 0) {
-                Button {
-                    visibleLimitInFields = 2
-                    visibleLimitInRows   = 1
-                } label: {
-                    Text("Reset to defaults")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                }
-
-                Divider().frame(height: 44)
-
-                Button {
-                    box.remake(config: DecoratorConfig(
-                        visibleLimitInFields: visibleLimitInFields,
-                        visibleLimitInRows: visibleLimitInRows
-                    ))
-                    showConfigPopover = false
-                } label: {
-                    Text("Update")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundColor(.blue)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                }
-            }
-        }
-        .frame(minWidth: 300)
-        .background(Color(.systemBackground))
     }
 
     // MARK: Banner

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -1050,6 +1050,7 @@ private class DecoratorEventHandler: FormChangeEvent {
 
 struct DecoratorAPIDemoView: View {
     @StateObject private var box              = EditorBox()
+    @Environment(\.dismiss) private var dismiss
 
     @State private var showDecoratorManager      = false
     @State private var lastAction: String        = ""
@@ -1067,6 +1068,28 @@ struct DecoratorAPIDemoView: View {
     @State private var decoratorColumnID:        String = ""
 
     private var editor: DocumentEditor { box.editor }
+
+    private func cleanupEventCallbacks() {
+        box.onAction = nil
+        box.onError = nil
+        if let h = box.editor.events as? DecoratorEventHandler {
+            h.onDecoratorAction = nil
+            h.onDecoratorError = nil
+        }
+    }
+
+    private func closeOverlaysBeforeExit() {
+        showConfigPopover = false
+        showDecoratorManager = false
+        decoratorError = nil
+    }
+
+    private func handleBackTap() {
+        closeOverlaysBeforeExit()
+        DispatchQueue.main.async {
+            dismiss()
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1086,7 +1109,16 @@ struct DecoratorAPIDemoView: View {
         }
         .navigationTitle("Decorator API Demo")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: handleBackTap) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Back")
+                    }
+                }
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack(spacing: 16) {
                     Button { showConfigPopover = true } label: {
@@ -1128,6 +1160,10 @@ struct DecoratorAPIDemoView: View {
                 decoratorError = DecoratorErrorAlert(message: message)
             }
             box.wire()
+        }
+        .onDisappear {
+            closeOverlaysBeforeExit()
+            cleanupEventCallbacks()
         }
         .alert(item: $decoratorError) { err in
             Alert(title: Text("Decorator Error"),

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -996,37 +996,7 @@ private class DecoratorEventHandler: FormChangeEvent {
     var onDecoratorAction: ((String, String) -> Void)? // (action, path)
     var onDecoratorError: ((String) -> Void)?
 
-    func onFocus(event: Event) {
-        guard let fieldEvent = event.fieldEvent,
-              let action = fieldEvent.type, !action.isEmpty else { return }
-
-        // Build the decorator path from the event
-        guard let editor = editor,
-              let pageID = fieldEvent.pageID,
-              let fieldPositionId = fieldEvent.fieldPositionId else { return }
-
-        let basePath = "\(pageID)/\(fieldPositionId)"
-        let path: String
-        if let columnID = fieldEvent.columnId {
-            let rowID = fieldEvent.rowIds?.first ?? "-"
-            path = "\(basePath)/\(rowID)/\(columnID)"
-        } else if let rowID = fieldEvent.rowIds?.first {
-            path = "\(basePath)/\(rowID)"
-        } else {
-            path = basePath
-        }
-
-        onDecoratorAction?(action, path)
-
-        // Update the tapped decorator to show it was viewed
-        var updated = Decorator()
-        updated.action = action
-        updated.icon   = "eye"
-        updated.label  = "Viewed"
-        updated.color  = "#10B981"
-        editor.updateDecorator(path: path, action: action, decorator: updated)
-    }
-
+    func onFocus(event: Event) {}
     func onChange(changes: [Change], document: JoyDoc) { }
     func onBlur(event: Event) { }
     func onUpload(event: UploadEvent) { }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -125,6 +125,7 @@ struct DecoratorManagerView: View {
     @State private var draft:           DecoratorDraft? = nil
     @State private var selectedSchemaKey: String = ""
     @State private var selectedColumnID:  String = ""
+    @State private var selectedRowID:     String? = nil
 
     // MARK: Derived — pages
 
@@ -187,6 +188,13 @@ struct DecoratorManagerView: View {
         selectedField?.schema?[selectedSchemaKey]
     }
 
+    // MARK: Derived — rows (table only, for row-specific decorators)
+
+    private var tableRows: [ValueElement] {
+        guard isTable else { return [] }
+        return (selectedField?.valueToValueElements ?? []).filter { !($0.deleted ?? false) }
+    }
+
     // MARK: Derived — columns
 
     /// Columns for the currently active scope:
@@ -214,19 +222,19 @@ struct DecoratorManagerView: View {
         return "\(selectedPageID)/\(selectedFieldPositionID)"
     }
 
-    /// "pageId/fieldPositionId/rowId"
-    /// For collections: uses the first row that belongs to the selected schema so the
-    /// path resolver can derive the correct schemaKey.
-    /// For tables: uses the first root row (schema resolution short-circuits to nil anyway).
+    /// "pageId/fieldPositionId/rows" for table common row decorators,
+    /// or "pageId/fieldPositionId/{rowId}" for collection (uses first row of selected schema).
     private var rowPath: String? {
         guard let base = fieldPath else { return nil }
-        let rowID: String?
-        if isCollection {
-            rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField)
-        } else {
-            rowID = selectedField?.valueToValueElements?.first?.id
-        }
-        guard let rowID = rowID else { return nil }
+        if isTable { return "\(base)/rows" }
+        guard let rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField) else { return nil }
+        return "\(base)/\(rowID)"
+    }
+
+    /// "pageId/fieldPositionId/{rowId}" — row-specific decorators (table only).
+    private var rowSpecificPath: String? {
+        guard isTable, let base = fieldPath,
+              let rowID = selectedRowID ?? tableRows.first?.id else { return nil }
         return "\(base)/\(rowID)"
     }
 
@@ -318,7 +326,7 @@ struct DecoratorManagerView: View {
                                 }
                             } header: {
                                 decoratorSectionHeader(title: "Field Decorators", symbol: "tag.fill",
-                                                       count: fieldDecs.count, badge: .blue)
+                                                       count: fieldDecs.count, badge: .blue, path: path)
                             }
 
                             // ── Table / Collection only ──────────────────────
@@ -331,19 +339,20 @@ struct DecoratorManagerView: View {
                                     } header: { Text("Select Schema").textCase(nil) }
                                 }
 
-                                // Row decorators
+                                // Common row decorators
                                 if let rPath = rowPath {
                                     let rowDecs = editor.getDecorators(path: rPath)
                                     Section {
                                         ForEach(rowDecs, id: \.action) { decoratorRow($0, path: rPath) }
-                                        if rowDecs.isEmpty { emptyHint("No row decorators — tap + to add one") }
+                                        if rowDecs.isEmpty { emptyHint("No common row decorators — tap + to add one") }
                                         addButton(badge: .orange) {
                                             draft = DecoratorDraft(path: rPath, editAction: nil,
                                                                    icon: "flag", label: "", color: "#F97316", action: "")
                                         }
                                     } header: {
-                                        decoratorSectionHeader(title: "Row Decorators", symbol: "list.bullet.rectangle",
-                                                               count: rowDecs.count, badge: .orange)
+                                        decoratorSectionHeader(title: isTable ? "Common Row Decorators" : "Row Decorators",
+                                                               symbol: "list.bullet.rectangle",
+                                                               count: rowDecs.count, badge: .orange, path: rPath)
                                     }
                                 } else {
                                     Section {
@@ -351,6 +360,28 @@ struct DecoratorManagerView: View {
                                     } header: {
                                         decoratorSectionHeader(title: "Row Decorators", symbol: "list.bullet.rectangle",
                                                                count: 0, badge: .orange)
+                                    }
+                                }
+
+                                // Row-specific decorators (table only)
+                                if isTable, !tableRows.isEmpty {
+                                    Section {
+                                        rowPickerRow
+                                    } header: { Text("Select Row").textCase(nil) }
+
+                                    if let rsPath = rowSpecificPath {
+                                        let rowSpecDecs = editor.getDecorators(path: rsPath)
+                                        Section {
+                                            ForEach(rowSpecDecs, id: \.action) { decoratorRow($0, path: rsPath) }
+                                            if rowSpecDecs.isEmpty { emptyHint("No row-specific decorators — tap + to add one (copies common decorators first)") }
+                                            addButton(badge: .red) {
+                                                draft = DecoratorDraft(path: rsPath, editAction: nil,
+                                                                       icon: "flag", label: "", color: "#EF4444", action: "")
+                                            }
+                                        } header: {
+                                            decoratorSectionHeader(title: "Row-Specific Decorators", symbol: "person.text.rectangle",
+                                                                   count: rowSpecDecs.count, badge: .red, path: rsPath)
+                                        }
                                     }
                                 }
 
@@ -372,7 +403,7 @@ struct DecoratorManagerView: View {
                                             }
                                         } header: {
                                             decoratorSectionHeader(title: "Column Decorators", symbol: "tablecells",
-                                                                   count: colDecs.count, badge: .purple)
+                                                                   count: colDecs.count, badge: .purple, path: cPath)
                                         }
                                     }
                                 }
@@ -395,6 +426,7 @@ struct DecoratorManagerView: View {
                     .onChange(of: selectedFieldPositionID) { _ in
                         selectedSchemaKey = sortedSchemas.first?.key ?? ""
                         selectedColumnID  = sortedColumns.first?.id ?? ""
+                        selectedRowID     = nil
                     }
                     .onChange(of: selectedSchemaKey) { _ in
                         selectedColumnID = sortedColumns.first?.id ?? ""
@@ -486,6 +518,22 @@ struct DecoratorManagerView: View {
         }
     }
 
+    private var rowPickerRow: some View {
+        let rows = tableRows
+        let currentID = selectedRowID ?? rows.first?.id
+        return Menu {
+            ForEach(rows, id: \.id) { row in
+                Button {
+                    selectedRowID = row.id
+                } label: {
+                    Label(row.id ?? "", systemImage: currentID == row.id ? "checkmark" : "list.bullet")
+                }
+            }
+        } label: {
+            pickerLabel(icon: "list.bullet", color: .red, text: currentID ?? "Select a row")
+        }
+    }
+
     private var columnPickerRow: some View {
         Menu {
             ForEach(sortedColumns, id: \.id) { col in
@@ -518,15 +566,23 @@ struct DecoratorManagerView: View {
 
     // MARK: Section header / row helpers
 
-    private func decoratorSectionHeader(title: String, symbol: String, count: Int, badge: Color) -> some View {
-        HStack(spacing: 6) {
-            Label(title, systemImage: symbol).textCase(nil)
-            Spacer()
-            if count > 0 {
-                Text("\(count)")
-                    .font(.caption2.weight(.bold)).foregroundColor(.white)
-                    .padding(.horizontal, 6).padding(.vertical, 2)
-                    .background(badge).clipShape(Capsule())
+    private func decoratorSectionHeader(title: String, symbol: String, count: Int, badge: Color, path: String? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Label(title, systemImage: symbol).textCase(nil)
+                Spacer()
+                if count > 0 {
+                    Text("\(count)")
+                        .font(.caption2.weight(.bold)).foregroundColor(.white)
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(badge).clipShape(Capsule())
+                }
+            }
+            if let path = path {
+                Text(path)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
             }
         }
     }
@@ -788,14 +844,12 @@ struct DecoratorEditView: View {
 
 private class DecoratorEventHandler: FormChangeEvent {
     weak var editor: DocumentEditor?
-    var onDecoratorAction: ((String) -> Void)?
+    var onDecoratorAction: ((String, String) -> Void)? // (action, path)
     var onDecoratorError: ((String) -> Void)?
 
     func onFocus(event: Event) {
         guard let fieldEvent = event.fieldEvent,
               let action = fieldEvent.type, !action.isEmpty else { return }
-
-        onDecoratorAction?(action)
 
         // Build the decorator path from the event
         guard let editor = editor,
@@ -812,6 +866,8 @@ private class DecoratorEventHandler: FormChangeEvent {
         } else {
             path = basePath
         }
+
+        onDecoratorAction?(action, path)
 
         // Update the tapped decorator to show it was viewed
         var updated = Decorator()
@@ -840,6 +896,7 @@ struct DecoratorAPIDemoView: View {
 
     @State private var showDecoratorManager      = false
     @State private var lastAction: String        = ""
+    @State private var lastPath:   String        = ""
     @State private var showBanner: Bool          = false
     @State private var decoratorError: DecoratorErrorAlert? = nil
     // Persisted across sheet dismissals so the user doesn't have to re-select
@@ -899,8 +956,9 @@ struct DecoratorAPIDemoView: View {
             )
         }
         .onAppear {
-            eventHandler?.onDecoratorAction = { action in
+            eventHandler?.onDecoratorAction = { action, path in
                 lastAction = action
+                lastPath   = path
                 showBanner = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { showBanner = false }
             }
@@ -918,16 +976,21 @@ struct DecoratorAPIDemoView: View {
     // MARK: Banner
 
     private var bannerView: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "cursorarrow.rays")
-            Text("Action fired: \"\(lastAction)\"")
-                .font(.subheadline.weight(.medium))
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "cursorarrow.rays")
+                Text("Action: \"\(lastAction)\"")
+                    .font(.subheadline.weight(.medium))
+            }
+            Text("Path: \(lastPath)")
+                .font(.caption.monospaced())
+                .opacity(0.85)
         }
         .foregroundColor(.white)
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(.black.opacity(0.82))
-        .cornerRadius(24)
+        .cornerRadius(16)
     }
 
 }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -141,6 +141,14 @@ struct DecoratorManagerView: View {
 
     @State private var draft: DecoratorDraft? = nil
 
+    // Ad-hoc path tester — paste / type any path and exercise the four
+    // decorator APIs against it. Useful for poking at edge cases (malformed
+    // paths, deleted rows, schema-graph violations, …) without rebuilding
+    // the whole picker chain.
+    @State private var customPath: String = ""
+    @State private var customPathReadResult: String = ""
+    @State private var customPathActionInput: String = ""
+
     // MARK: Derived — pages
 
     private var sortedPages: [Page] {
@@ -350,6 +358,9 @@ struct DecoratorManagerView: View {
                             } header: { Text("Select Field").textCase(nil) }
                         }
 
+                        // ── Custom path tester ───────────────────────────────
+                        customPathSection
+
                         if let path = fieldPath {
 
                             // ── Field-level decorators ───────────────────────
@@ -504,6 +515,113 @@ struct DecoratorManagerView: View {
         hopChain = []
         pendingSchema = ""
         selectedColumnID = sortedColumns.first?.id ?? ""
+    }
+
+    // MARK: Custom path tester
+
+    @ViewBuilder
+    private var customPathSection: some View {
+        Section {
+            if #available(iOS 16.0, *) {
+                TextField("page-id/field-position-id/...", text: $customPath, axis: .vertical)
+                    .font(.system(.footnote, design: .monospaced))
+                    .lineLimit(2...5)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+            } else {
+                TextField("page-id/field-position-id/...", text: $customPath)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+            }
+
+            HStack {
+                Button {
+                    runCustomGet()
+                } label: {
+                    Label("Get", systemImage: "magnifyingglass")
+                }
+                .buttonStyle(.bordered)
+                .disabled(customPath.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                Button {
+                    runCustomAdd()
+                } label: {
+                    Label("Add", systemImage: "plus.circle")
+                }
+                .buttonStyle(.bordered)
+                .disabled(customPath.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    customPath = ""
+                    customPathReadResult = ""
+                    customPathActionInput = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill").foregroundColor(.secondary)
+                }
+                .buttonStyle(.borderless)
+            }
+
+            HStack {
+                TextField("action (for remove)", text: $customPathActionInput)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                Button {
+                    runCustomRemove()
+                } label: {
+                    Label("Remove", systemImage: "minus.circle")
+                }
+                .buttonStyle(.bordered)
+                .disabled(customPath.trimmingCharacters(in: .whitespaces).isEmpty
+                          || customPathActionInput.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+
+            if !customPathReadResult.isEmpty {
+                Text(customPathReadResult)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } header: {
+            Text("Custom Path Tester").textCase(nil)
+        } footer: {
+            Text("Paste any path and call Get / Add / Remove against it. SDK errors surface in the shared alert.")
+                .font(.caption)
+        }
+    }
+
+    private var trimmedCustomPath: String {
+        customPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func runCustomGet() {
+        let path = trimmedCustomPath
+        let decs = editor.getDecorators(path: path)
+        if decs.isEmpty {
+            customPathReadResult = "→ [] (path resolved or didn't — check error alert)"
+        } else {
+            let summary = decs.map { d in
+                "\(d.action ?? "?") (\(d.label ?? "")\(d.icon.map { " \($0)" } ?? ""))"
+            }.joined(separator: ", ")
+            customPathReadResult = "→ \(decs.count): \(summary)"
+        }
+    }
+
+    private func runCustomAdd() {
+        let path = trimmedCustomPath
+        draft = DecoratorDraft(path: path, editAction: nil,
+                               icon: "flag", label: "Custom", color: "#3B82F6",
+                               action: "custom-\(Int(Date().timeIntervalSince1970) % 10_000)")
+    }
+
+    private func runCustomRemove() {
+        let path = trimmedCustomPath
+        let action = customPathActionInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        editor.removeDecorator(path: path, action: action)
+        runCustomGet()
     }
 
     /// Walks `hopChain` against the currently selected field's value tree and

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -469,6 +469,19 @@ struct DecoratorManagerView: View {
                     .onChange(of: pendingSchema) { _ in
                         selectedColumnID = sortedColumns.first?.id ?? ""
                     }
+                    // Selection state (hopChain / selectedColumnID) survives sheet
+                    // dismiss/re-open. If the user deletes a row outside this
+                    // sheet and reopens it, the saved chain may point at a row
+                    // that no longer exists. Without this trim, every body
+                    // pass would call getDecorators on the stale row-self /
+                    // cell paths, the SDK would emit `onError` on each call,
+                    // the alert would pop, dismissing the alert would trigger
+                    // another redraw, and we'd loop. Trim back to the last
+                    // reachable prefix on appear and on editor changes.
+                    .onAppear { trimStaleChainIfNeeded() }
+                    .onReceive(editor.objectWillChange) { _ in
+                        DispatchQueue.main.async { trimStaleChainIfNeeded() }
+                    }
                 }
             }
             .navigationTitle("Decorator Manager")
@@ -491,6 +504,31 @@ struct DecoratorManagerView: View {
         hopChain = []
         pendingSchema = ""
         selectedColumnID = sortedColumns.first?.id ?? ""
+    }
+
+    /// Walks `hopChain` against the currently selected field's value tree and
+    /// drops any trailing hops whose row is missing or soft-deleted. Cheap —
+    /// O(chain depth × siblings per level). Called on appear and after every
+    /// editor publish so the demo never builds a path that points at a row
+    /// the user has just deleted.
+    private func trimStaleChainIfNeeded() {
+        guard let field = selectedField, !hopChain.isEmpty else { return }
+        var current = field.valueToValueElements ?? []
+        var validPrefix: [DecoratorHopStep] = []
+        for (i, hop) in hopChain.enumerated() {
+            guard let row = current.first(where: { $0.id == hop.rowID && $0.deleted != true }) else {
+                break
+            }
+            validPrefix.append(hop)
+            if i == hopChain.count - 1 { return } // whole chain still reachable
+            let nextHop = hopChain[i + 1]
+            guard let sk = nextHop.schemaKey,
+                  let children = row.childrens?[sk]?.valueToValueElements else { break }
+            current = children
+        }
+        guard validPrefix.count != hopChain.count else { return }
+        hopChain = validPrefix
+        pendingSchema = ""
     }
 
     // MARK: Chain navigator UI

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -107,6 +107,16 @@ struct DecoratorDraft: Identifiable {
     var action:     String
 }
 
+// MARK: - Hop step for unbounded-depth path chain
+
+/// One descent step.
+/// `schemaKey == nil` means root-level descent (table or collection root schema).
+/// `schemaKey == "sk"` means we entered this row via `/schemas/sk/` from the parent row.
+struct DecoratorHopStep: Hashable {
+    let schemaKey: String?
+    let rowID: String
+}
+
 // MARK: - DecoratorManagerView
 
 /// Full-screen decorator manager sheet.
@@ -121,11 +131,15 @@ struct DecoratorManagerView: View {
     // Shared error alert state (alert attached here so it renders over this sheet)
     @Binding var decoratorError:          DecoratorErrorAlert?
 
-    // Schema / column reset on each open — less critical to persist.
-    @State private var draft:           DecoratorDraft? = nil
-    @State private var selectedSchemaKey: String = ""
-    @State private var selectedColumnID:  String = ""
-    @State private var selectedRowID:     String? = nil
+    // Unbounded-depth path state — also lifted so it survives dismiss/re-open.
+    //   hopChain       — descent chain (row-id plus optional schema-key entry prefix)
+    //   pendingSchema  — child schema selected for the *next* descent (collection only)
+    //   selectedColumnID — column used for column / cell / row-scoped-column paths
+    @Binding var hopChain:         [DecoratorHopStep]
+    @Binding var pendingSchema:    String
+    @Binding var selectedColumnID: String
+
+    @State private var draft: DecoratorDraft? = nil
 
     // MARK: Derived — pages
 
@@ -139,13 +153,10 @@ struct DecoratorManagerView: View {
 
     // MARK: Derived — field entries (loaded explicitly from the selected page)
 
-    /// (fieldPositionId, field) pairs for the selected page, in layout order.
     private var fieldEntries: [(fieldPositionId: String, field: JoyDocField)] {
         fieldEntriesForPage(selectedPageID)
     }
 
-    /// Local helper: builds (fieldPositionId, field) pairs for any page using only
-    /// public DocumentEditor APIs — no SDK-side method needed.
     private func fieldEntriesForPage(_ pageID: String) -> [(fieldPositionId: String, field: JoyDocField)] {
         guard !pageID.isEmpty,
               let page = editor.pagesForCurrentView.first(where: { $0.id == pageID })
@@ -164,48 +175,84 @@ struct DecoratorManagerView: View {
 
     private var isCollection: Bool { selectedField?.fieldType == .collection }
     private var isTable:      Bool { selectedField?.fieldType == .table }
+    private var isTabular:    Bool { isTable || isCollection }
 
-    // MARK: Derived — schemas (collection fields only)
+    // MARK: Derived — schema helpers
 
-    /// All schemas for the selected collection field, root first then children in declared order.
-    private var sortedSchemas: [(key: String, schema: Schema)] {
-        guard let schemas = selectedField?.schema else { return [] }
-        var result: [(String, Schema)] = []
-        if let rootEntry = schemas.first(where: { $0.value.root == true }) {
-            result.append((rootEntry.key, rootEntry.value))
-            for childKey in rootEntry.value.children ?? [] {
-                if let child = schemas[childKey] { result.append((childKey, child)) }
+    private var collectionRootSchemaKey: String? {
+        selectedField?.schema?.first(where: { $0.value.root == true })?.key
+    }
+
+    /// Schema we're currently "inside" after walking the hop chain.
+    /// - Table: always nil
+    /// - Collection, empty chain: root schema key
+    /// - Collection, after N hops: hopChain.last.schemaKey ?? root
+    private var currentSchemaKey: String? {
+        guard isCollection else { return nil }
+        if hopChain.isEmpty { return collectionRootSchemaKey }
+        return hopChain.last?.schemaKey ?? collectionRootSchemaKey
+    }
+
+    /// Effective schema for column lookup at the current level:
+    /// pendingSchema overrides currentSchemaKey when the user is about to descend.
+    private var effectiveSchemaKey: String? {
+        if !pendingSchema.isEmpty { return pendingSchema }
+        return currentSchemaKey
+    }
+
+    /// Child schemas that can be descended into from the current level.
+    private var availableChildSchemas: [(key: String, schema: Schema)] {
+        guard isCollection,
+              let ck = currentSchemaKey,
+              let current = selectedField?.schema?[ck]
+        else { return [] }
+        return (current.children ?? []).compactMap { key in
+            guard let s = selectedField?.schema?[key] else { return nil }
+            return (key, s)
+        }
+    }
+
+    // MARK: Derived — walking the row tree
+
+    /// Walks the hop chain and returns the ValueElement at the tip (nil if chain empty or broken).
+    private func walkToChainTip() -> ValueElement? {
+        guard let field = selectedField else { return nil }
+        var list: [ValueElement] = field.valueToValueElements ?? []
+        var tip: ValueElement? = nil
+        for (idx, hop) in hopChain.enumerated() {
+            if idx > 0 {
+                guard let sk = hop.schemaKey,
+                      let children = tip?.childrens?[sk]?.valueToValueElements else { return nil }
+                list = children
             }
+            guard let el = list.first(where: { $0.id == hop.rowID && !($0.deleted ?? false) }) else { return nil }
+            tip = el
         }
-        // Append any schemas not reachable from root's children list
-        for (key, schema) in schemas where !result.contains(where: { $0.0 == key }) {
-            result.append((key, schema))
+        return tip
+    }
+
+    /// Rows available for descent at the current level.
+    private var availableRows: [ValueElement] {
+        if hopChain.isEmpty {
+            // Root-level rows (table or collection root schema)
+            guard isTabular else { return [] }
+            return (selectedField?.valueToValueElements ?? []).filter { !($0.deleted ?? false) }
         }
-        return result
+        // Inside a row — need a pending schema to know which child list to show
+        guard isCollection, !pendingSchema.isEmpty, let tip = walkToChainTip() else { return [] }
+        return (tip.childrens?[pendingSchema]?.valueToValueElements ?? []).filter { !($0.deleted ?? false) }
     }
 
-    private var selectedSchema: Schema? {
-        selectedField?.schema?[selectedSchemaKey]
-    }
+    // MARK: Derived — columns for the current level
 
-    // MARK: Derived — rows (table only, for row-specific decorators)
-
-    private var tableRows: [ValueElement] {
-        guard isTable else { return [] }
-        return (selectedField?.valueToValueElements ?? []).filter { !($0.deleted ?? false) }
-    }
-
-    // MARK: Derived — columns
-
-    /// Columns for the currently active scope:
-    /// - Collection: columns from the selected schema entry
-    /// - Table:      columns directly on the field
     private var sortedColumns: [FieldTableColumn] {
         let cols: [FieldTableColumn]?
-        if isCollection {
-            cols = selectedSchema?.tableColumns
-        } else {
+        if isTable {
             cols = selectedField?.tableColumns
+        } else if isCollection, let sk = effectiveSchemaKey {
+            cols = selectedField?.schema?[sk]?.tableColumns
+        } else {
+            cols = nil
         }
         return (cols ?? []).filter { $0.id != nil }
     }
@@ -222,69 +269,57 @@ struct DecoratorManagerView: View {
         return "\(selectedPageID)/\(selectedFieldPositionID)"
     }
 
-    /// "pageId/fieldPositionId/rows" for table common row decorators,
-    /// or "pageId/fieldPositionId/{rowId}" for collection (uses first row of selected schema).
-    private var rowPath: String? {
+    /// Path built by walking every hop — this is the row-self path when chain is non-empty.
+    private var chainRowPath: String? {
         guard let base = fieldPath else { return nil }
-        if isTable { return "\(base)/rows" }
-        guard let rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField) else { return nil }
-        return "\(base)/\(rowID)"
-    }
-
-    /// "pageId/fieldPositionId/{rowId}" — row-specific decorators (table only).
-    private var rowSpecificPath: String? {
-        guard isTable, let base = fieldPath,
-              let rowID = selectedRowID ?? tableRows.first?.id else { return nil }
-        return "\(base)/\(rowID)"
-    }
-
-    /// "pageId/fieldPositionId/columns/columnId" for tables (common column decorators),
-    /// or "pageId/fieldPositionId/{rowId}/{columnId}" for collections (rowId resolves schemaKey).
-    private func columnPath(columnID: String) -> String? {
-        guard let base = fieldPath else { return nil }
-        if isCollection {
-            guard let rowID = firstRowID(forSchemaKey: selectedSchemaKey, in: selectedField)
-            else { return nil }
-            return "\(base)/\(rowID)/\(columnID)"
+        var p = base
+        for hop in hopChain {
+            if let sk = hop.schemaKey { p += "/schemas/\(sk)" }
+            p += "/\(hop.rowID)"
         }
-        // Tables: "columns" keyword routes to common column decorators
-        return "\(base)/columns/\(columnID)"
+        return p
     }
 
-    /// "pageId/fieldPositionId/{rowId}/{columnId}" — cell-specific decorators (table only).
-    private func cellSpecificPath(columnID: String) -> String? {
-        guard isTable, let base = fieldPath,
-              let rowID = selectedRowID ?? tableRows.first?.id else { return nil }
-        return "\(base)/\(rowID)/\(columnID)"
+    /// Prefix at the current "level" — chainRowPath + optional `/schemas/{pending}`.
+    private var currentLevelPrefix: String? {
+        guard let row = chainRowPath else { return nil }
+        if !pendingSchema.isEmpty { return "\(row)/schemas/\(pendingSchema)" }
+        return row
     }
 
-    /// Returns the first rowId that belongs to the given schemaKey in a field's value tree.
-    /// - Root schema: first root-level row.
-    /// - Child schema: first child row found under any parent that has that schema.
-    private func firstRowID(forSchemaKey schemaKey: String, in field: JoyDocField?) -> String? {
-        guard let field = field else { return nil }
-        let rootSchemaKey = field.schema?.first { $0.value.root == true }?.key
-        if schemaKey == rootSchemaKey {
-            return field.valueToValueElements?.first?.id
-        }
-        return findFirstChildRow(forSchemaKey: schemaKey, in: field.valueToValueElements ?? [])
+    /// Common-rows path at the current level.
+    /// Only valid at a level boundary: root (chain empty) OR after a pendingSchema.
+    /// A nested collection row without pendingSchema has no common-rows path because
+    /// the parser requires `/schemas/{sk}/rows` to disambiguate the child list.
+    /// Table never nests, so rows path exists only when chain is empty.
+    private var rowsPath: String? {
+        guard let prefix = currentLevelPrefix else { return nil }
+        if hopChain.isEmpty { return isTabular ? "\(prefix)/rows" : nil }
+        guard isCollection, !pendingSchema.isEmpty else { return nil }
+        return "\(prefix)/rows"
     }
 
-    private func findFirstChildRow(forSchemaKey targetKey: String, in rows: [ValueElement]) -> String? {
-        for row in rows {
-            if let children = row.childrens?[targetKey],
-               let firstID  = children.valueToValueElements?.first?.id {
-                return firstID
-            }
-            if let childrens = row.childrens {
-                for (_, childGroup) in childrens {
-                    if let found = findFirstChildRow(forSchemaKey: targetKey, in: childGroup.valueToValueElements ?? []) {
-                        return found
-                    }
-                }
-            }
-        }
-        return nil
+    /// Row-self path (chain must be non-empty, no pending schema).
+    private var rowSelfPath: String? {
+        guard !hopChain.isEmpty, pendingSchema.isEmpty else { return nil }
+        return chainRowPath
+    }
+
+    /// Common-column path at the current level (for a given column).
+    /// Same level-boundary rule as `rowsPath` — inside a nested collection row
+    /// without pendingSchema, emit nothing (the user would just be looking at
+    /// a row-scoped column, which aliases the cell path).
+    private func commonColumnPath(columnID: String) -> String? {
+        guard let prefix = currentLevelPrefix else { return nil }
+        if hopChain.isEmpty { return isTabular ? "\(prefix)/columns/\(columnID)" : nil }
+        guard isCollection, !pendingSchema.isEmpty else { return nil }
+        return "\(prefix)/columns/\(columnID)"
+    }
+
+    /// Cell-specific path (chain non-empty, pending schema cleared).
+    private func cellPath(columnID: String) -> String? {
+        guard !hopChain.isEmpty, pendingSchema.isEmpty, let row = chainRowPath else { return nil }
+        return "\(row)/\(columnID)"
     }
 
     // MARK: Body
@@ -332,17 +367,20 @@ struct DecoratorManagerView: View {
                             }
 
                             // ── Table / Collection only ──────────────────────
-                            if isTable || isCollection {
+                            if isTabular {
 
-                                // Schema picker (collection only)
-                                if isCollection {
-                                    Section {
-                                        schemaPickerRow
-                                    } header: { Text("Select Schema").textCase(nil) }
+                                // Path chain navigator
+                                Section {
+                                    chainNavigator
+                                } header: {
+                                    Text("Path Chain").textCase(nil)
+                                } footer: {
+                                    Text("Descend into rows (and child schemas for collections) to build arbitrary-depth paths.")
+                                        .font(.caption)
                                 }
 
-                                // Common row decorators
-                                if let rPath = rowPath {
+                                // Common row decorators at current level
+                                if let rPath = rowsPath {
                                     let rowDecs = editor.getDecorators(path: rPath)
                                     Section {
                                         ForEach(rowDecs, id: \.action) { decoratorRow($0, path: rPath) }
@@ -352,66 +390,55 @@ struct DecoratorManagerView: View {
                                                                    icon: "flag", label: "", color: "#F97316", action: "")
                                         }
                                     } header: {
-                                        decoratorSectionHeader(title: isTable ? "Common Row Decorators" : "Row Decorators",
+                                        decoratorSectionHeader(title: "Common Row Decorators",
                                                                symbol: "list.bullet.rectangle",
                                                                count: rowDecs.count, badge: .orange, path: rPath)
                                     }
-                                } else {
-                                    Section {
-                                        emptyHint("Add at least one row to manage row decorators.")
-                                    } header: {
-                                        decoratorSectionHeader(title: "Row Decorators", symbol: "list.bullet.rectangle",
-                                                               count: 0, badge: .orange)
-                                    }
                                 }
 
-                                // Row-specific decorators (table only)
-                                if isTable, !tableRows.isEmpty {
+                                // Row-self decorators (when chain is non-empty)
+                                if let rsPath = rowSelfPath, pendingSchema.isEmpty {
+                                    let rowSelfDecs = editor.getDecorators(path: rsPath)
                                     Section {
-                                        rowPickerRow
-                                    } header: { Text("Select Row").textCase(nil) }
-
-                                    if let rsPath = rowSpecificPath {
-                                        let rowSpecDecs = editor.getDecorators(path: rsPath)
-                                        Section {
-                                            ForEach(rowSpecDecs, id: \.action) { decoratorRow($0, path: rsPath) }
-                                            if rowSpecDecs.isEmpty { emptyHint("No row-specific decorators — tap + to add one (copies common decorators first)") }
-                                            addButton(badge: .red) {
-                                                draft = DecoratorDraft(path: rsPath, editAction: nil,
-                                                                       icon: "flag", label: "", color: "#EF4444", action: "")
-                                            }
-                                        } header: {
-                                            decoratorSectionHeader(title: "Row-Specific Decorators", symbol: "person.text.rectangle",
-                                                                   count: rowSpecDecs.count, badge: .red, path: rsPath)
+                                        ForEach(rowSelfDecs, id: \.action) { decoratorRow($0, path: rsPath) }
+                                        if rowSelfDecs.isEmpty { emptyHint("No row-specific decorators — tap + to add one (copies common row decorators first)") }
+                                        addButton(badge: .red) {
+                                            draft = DecoratorDraft(path: rsPath, editAction: nil,
+                                                                   icon: "flag", label: "", color: "#EF4444", action: "")
                                         }
+                                    } header: {
+                                        decoratorSectionHeader(title: "Row-Specific Decorators",
+                                                               symbol: "person.text.rectangle",
+                                                               count: rowSelfDecs.count, badge: .red, path: rsPath)
                                     }
                                 }
 
-                                // Column picker + column decorators
+                                // Column picker + column / cell decorators
                                 if !sortedColumns.isEmpty {
                                     Section {
                                         columnPickerRow
                                     } header: { Text("Select Column").textCase(nil) }
 
-                                    if let col = selectedColumn, let colID = col.id,
-                                       let cPath = columnPath(columnID: colID) {
-                                        let colDecs = editor.getDecorators(path: cPath)
-                                        Section {
-                                            ForEach(colDecs, id: \.action) { decoratorRow($0, path: cPath) }
-                                            if colDecs.isEmpty { emptyHint("No column decorators — tap + to add one") }
-                                            addButton(badge: .purple) {
-                                                draft = DecoratorDraft(path: cPath, editAction: nil,
-                                                                       icon: "circle-info", label: "", color: "#8B5CF6", action: "")
+                                    if let col = selectedColumn, let colID = col.id {
+                                        // Common column
+                                        if let cPath = commonColumnPath(columnID: colID) {
+                                            let colDecs = editor.getDecorators(path: cPath)
+                                            Section {
+                                                ForEach(colDecs, id: \.action) { decoratorRow($0, path: cPath) }
+                                                if colDecs.isEmpty { emptyHint("No common column decorators — tap + to add one") }
+                                                addButton(badge: .purple) {
+                                                    draft = DecoratorDraft(path: cPath, editAction: nil,
+                                                                           icon: "circle-info", label: "", color: "#8B5CF6", action: "")
+                                                }
+                                            } header: {
+                                                decoratorSectionHeader(title: "Common Column Decorators",
+                                                                       symbol: "tablecells",
+                                                                       count: colDecs.count, badge: .purple, path: cPath)
                                             }
-                                        } header: {
-                                            decoratorSectionHeader(title: isTable ? "Common Column Decorators" : "Column Decorators",
-                                                                   symbol: "tablecells",
-                                                                   count: colDecs.count, badge: .purple, path: cPath)
                                         }
 
-                                        // Cell-specific decorators (table only)
-                                        if isTable, !tableRows.isEmpty,
-                                           let csPath = cellSpecificPath(columnID: colID) {
+                                        // Cell-specific (chain non-empty, pending schema cleared)
+                                        if let csPath = cellPath(columnID: colID) {
                                             let cellDecs = editor.getDecorators(path: csPath)
                                             Section {
                                                 ForEach(cellDecs, id: \.action) { decoratorRow($0, path: csPath) }
@@ -421,7 +448,8 @@ struct DecoratorManagerView: View {
                                                                            icon: "circle-info", label: "", color: "#F97316", action: "")
                                                 }
                                             } header: {
-                                                decoratorSectionHeader(title: "Cell-Specific Decorators", symbol: "rectangle.split.3x1",
+                                                decoratorSectionHeader(title: "Cell-Specific Decorators",
+                                                                       symbol: "rectangle.split.3x1",
                                                                        count: cellDecs.count, badge: .pink, path: csPath)
                                             }
                                         }
@@ -431,24 +459,14 @@ struct DecoratorManagerView: View {
                         }
                     }
                     .listStyle(.insetGrouped)
-                    .onAppear {
-                        // Do not auto-select page — user must pick explicitly so
-                        // paths are always built from a deliberate page choice.
-                        if selectedSchemaKey.isEmpty { selectedSchemaKey = sortedSchemas.first?.key ?? "" }
-                        if selectedColumnID.isEmpty  { selectedColumnID  = sortedColumns.first?.id  ?? "" }
-                    }
                     .onChange(of: selectedPageID) { _ in
-                        // Page changed: clear field selection so user explicitly picks from fresh list
                         selectedFieldPositionID = ""
-                        selectedSchemaKey       = ""
-                        selectedColumnID        = ""
+                        resetChain()
                     }
                     .onChange(of: selectedFieldPositionID) { _ in
-                        selectedSchemaKey = sortedSchemas.first?.key ?? ""
-                        selectedColumnID  = sortedColumns.first?.id ?? ""
-                        selectedRowID     = nil
+                        resetChain()
                     }
-                    .onChange(of: selectedSchemaKey) { _ in
+                    .onChange(of: pendingSchema) { _ in
                         selectedColumnID = sortedColumns.first?.id ?? ""
                     }
                 }
@@ -469,6 +487,123 @@ struct DecoratorManagerView: View {
         }
     }
 
+    private func resetChain() {
+        hopChain = []
+        pendingSchema = ""
+        selectedColumnID = sortedColumns.first?.id ?? ""
+    }
+
+    // MARK: Chain navigator UI
+
+    @ViewBuilder
+    private var chainNavigator: some View {
+        // Breadcrumb
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 4) {
+                Image(systemName: "location.fill").font(.caption2).foregroundColor(.secondary)
+                Text("root")
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.12))
+                    .cornerRadius(4)
+                ForEach(Array(hopChain.enumerated()), id: \.offset) { _, hop in
+                    Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
+                    if let sk = hop.schemaKey {
+                        Text("sk:\(sk)")
+                            .font(.caption.monospaced())
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Color.teal.opacity(0.15)).foregroundColor(.teal)
+                            .cornerRadius(4)
+                        Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
+                    }
+                    Text(shortID(hop.rowID))
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.15)).foregroundColor(.orange)
+                        .cornerRadius(4)
+                }
+                if !pendingSchema.isEmpty {
+                    Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
+                    Text("sk:\(pendingSchema)")
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 6).padding(.vertical, 2)
+                        .background(Color.teal.opacity(0.15)).foregroundColor(.teal)
+                        .cornerRadius(4)
+                }
+            }
+        }
+
+        // Descend into a child schema (collection only)
+        if isCollection, !availableChildSchemas.isEmpty {
+            Menu {
+                Button("(none)") { pendingSchema = "" }
+                ForEach(availableChildSchemas, id: \.key) { entry in
+                    Button {
+                        pendingSchema = entry.key
+                    } label: {
+                        Label(entry.schema.title ?? entry.key,
+                              systemImage: pendingSchema == entry.key ? "checkmark" : "square.stack.3d.up")
+                    }
+                }
+            } label: {
+                pickerLabel(icon: "square.stack.3d.up", color: .teal,
+                            text: pendingSchema.isEmpty ? "Pick child schema (optional)" : "sk: \(pendingSchema)")
+            }
+        }
+
+        // Descend into a row
+        if !availableRows.isEmpty {
+            Menu {
+                ForEach(availableRows, id: \.id) { row in
+                    Button {
+                        descend(into: row)
+                    } label: {
+                        Label(shortID(row.id ?? ""), systemImage: "arrow.down.forward")
+                    }
+                }
+            } label: {
+                pickerLabel(icon: "arrow.down.forward.circle", color: .orange,
+                            text: hopChain.isEmpty ? "Descend into row…" : "Descend further into row…")
+            }
+        } else if isCollection && !hopChain.isEmpty && pendingSchema.isEmpty && !availableChildSchemas.isEmpty {
+            Text("Pick a child schema above to list nested rows.")
+                .font(.caption).foregroundColor(.secondary)
+        }
+
+        // Go up
+        if !hopChain.isEmpty || !pendingSchema.isEmpty {
+            Button {
+                goUp()
+            } label: {
+                Label("Go up one level", systemImage: "arrow.up.left.circle")
+                    .foregroundColor(.blue)
+            }
+        }
+    }
+
+    private func descend(into row: ValueElement) {
+        guard let rid = row.id else { return }
+        let sk: String? = hopChain.isEmpty ? nil : (pendingSchema.isEmpty ? nil : pendingSchema)
+        // Root-level descent must have nil schemaKey; nested descent requires pendingSchema.
+        if !hopChain.isEmpty && pendingSchema.isEmpty { return }
+        hopChain.append(DecoratorHopStep(schemaKey: sk, rowID: rid))
+        pendingSchema = ""
+        selectedColumnID = sortedColumns.first?.id ?? ""
+    }
+
+    private func goUp() {
+        if !pendingSchema.isEmpty {
+            pendingSchema = ""
+        } else if !hopChain.isEmpty {
+            hopChain.removeLast()
+        }
+        selectedColumnID = sortedColumns.first?.id ?? ""
+    }
+
+    private func shortID(_ s: String) -> String {
+        s.count <= 10 ? s : String(s.prefix(6)) + "…" + String(s.suffix(3))
+    }
+
     // MARK: Pickers
 
     private var pagePickerRow: some View {
@@ -476,11 +611,9 @@ struct DecoratorManagerView: View {
             ForEach(sortedPages, id: \.id) { page in
                 Button {
                     let pageID = page.id ?? ""
-                    // Reset all downstream selections when page changes
                     selectedPageID          = pageID
                     selectedFieldPositionID = ""
-                    selectedSchemaKey       = ""
-                    selectedColumnID        = ""
+                    resetChain()
                 } label: {
                     Label(page.name ?? page.id ?? "",
                           systemImage: selectedPageID == page.id ? "checkmark" : "doc.text")
@@ -519,41 +652,6 @@ struct DecoratorManagerView: View {
         }
     }
 
-    private var schemaPickerRow: some View {
-        Menu {
-            ForEach(sortedSchemas, id: \.key) { entry in
-                Button {
-                    selectedSchemaKey = entry.key
-                } label: {
-                    Label(entry.schema.title ?? entry.key,
-                          systemImage: selectedSchemaKey == entry.key ? "checkmark" : "square.stack.3d.up")
-                }
-            }
-        } label: {
-            pickerLabel(
-                icon:  "square.stack.3d.up",
-                color: .teal,
-                text:  selectedSchema?.title ?? (selectedSchemaKey.isEmpty ? "Select a schema" : selectedSchemaKey)
-            )
-        }
-    }
-
-    private var rowPickerRow: some View {
-        let rows = tableRows
-        let currentID = selectedRowID ?? rows.first?.id
-        return Menu {
-            ForEach(rows, id: \.id) { row in
-                Button {
-                    selectedRowID = row.id
-                } label: {
-                    Label(row.id ?? "", systemImage: currentID == row.id ? "checkmark" : "list.bullet")
-                }
-            }
-        } label: {
-            pickerLabel(icon: "list.bullet", color: .red, text: currentID ?? "Select a row")
-        }
-    }
-
     private var columnPickerRow: some View {
         Menu {
             ForEach(sortedColumns, id: \.id) { col in
@@ -573,7 +671,6 @@ struct DecoratorManagerView: View {
         }
     }
 
-    /// Shared chevron-picker label layout.
     private func pickerLabel(icon: String, color: Color, text: String) -> some View {
         HStack(spacing: 10) {
             Image(systemName: icon).font(.caption.weight(.semibold)).foregroundColor(color)
@@ -602,7 +699,7 @@ struct DecoratorManagerView: View {
                 Text(path)
                     .font(.caption.monospaced())
                     .foregroundColor(.secondary)
-                    .lineLimit(2)
+                    .lineLimit(3)
             }
         }
     }
@@ -724,7 +821,6 @@ struct DecoratorEditView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Save") { save() }
-//                        .fontWeight(.bold)
                         .disabled(icon.isEmpty)
                 }
             }
@@ -922,6 +1018,9 @@ struct DecoratorAPIDemoView: View {
     // Persisted across sheet dismissals so the user doesn't have to re-select
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
+    @State private var decoratorHopChain:        [DecoratorHopStep] = []
+    @State private var decoratorPendingSchema:   String = ""
+    @State private var decoratorColumnID:        String = ""
 
     init() {
         let handler = DecoratorEventHandler()
@@ -972,7 +1071,10 @@ struct DecoratorAPIDemoView: View {
                 editor: editor,
                 selectedPageID: $decoratorPageID,
                 selectedFieldPositionID: $decoratorFieldPositionID,
-                decoratorError: $decoratorError
+                decoratorError: $decoratorError,
+                hopChain: $decoratorHopChain,
+                pendingSchema: $decoratorPendingSchema,
+                selectedColumnID: $decoratorColumnID
             )
         }
         .onAppear {

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -1055,7 +1055,12 @@ struct DecoratorAPIDemoView: View {
                         Image(systemName: "slider.horizontal.3")
                     }
                     .popover(isPresented: $showConfigPopover) {
-                        configPopover
+                        if #available(iOS 16.4, *) {
+                            configPopover
+                                .presentationCompactAdaptation(.popover)
+                        } else {
+                            configPopover
+                        }
                     }
                     Button { showDecoratorManager = true } label: {
                         Label("Decorators", systemImage: "paintbrush.pointed.fill")

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -238,10 +238,8 @@ struct DecoratorManagerView: View {
         return "\(base)/\(rowID)"
     }
 
-    /// "pageId/fieldPositionId/rowId/columnId"
-    /// For collections: uses a real rowId from the selected schema so the resolver
-    /// returns the correct schemaKey for column lookup.
-    /// For tables: uses "-" as a positional placeholder (rowId is ignored for table columns).
+    /// "pageId/fieldPositionId/columns/columnId" for tables (common column decorators),
+    /// or "pageId/fieldPositionId/{rowId}/{columnId}" for collections (rowId resolves schemaKey).
     private func columnPath(columnID: String) -> String? {
         guard let base = fieldPath else { return nil }
         if isCollection {
@@ -249,10 +247,14 @@ struct DecoratorManagerView: View {
             else { return nil }
             return "\(base)/\(rowID)/\(columnID)"
         }
-        // Table fields: use a real rowId from rowOrder so the path resolver
-        // can validate it. Column decorators are row-independent for tables,
-        // but the 4-segment path format still requires a valid rowId.
-        guard let rowID = selectedField?.rowOrder?.first else { return nil }
+        // Tables: "columns" keyword routes to common column decorators
+        return "\(base)/columns/\(columnID)"
+    }
+
+    /// "pageId/fieldPositionId/{rowId}/{columnId}" — cell-specific decorators (table only).
+    private func cellSpecificPath(columnID: String) -> String? {
+        guard isTable, let base = fieldPath,
+              let rowID = selectedRowID ?? tableRows.first?.id else { return nil }
         return "\(base)/\(rowID)/\(columnID)"
     }
 
@@ -402,8 +404,26 @@ struct DecoratorManagerView: View {
                                                                        icon: "circle-info", label: "", color: "#8B5CF6", action: "")
                                             }
                                         } header: {
-                                            decoratorSectionHeader(title: "Column Decorators", symbol: "tablecells",
+                                            decoratorSectionHeader(title: isTable ? "Common Column Decorators" : "Column Decorators",
+                                                                   symbol: "tablecells",
                                                                    count: colDecs.count, badge: .purple, path: cPath)
+                                        }
+
+                                        // Cell-specific decorators (table only)
+                                        if isTable, !tableRows.isEmpty,
+                                           let csPath = cellSpecificPath(columnID: colID) {
+                                            let cellDecs = editor.getDecorators(path: csPath)
+                                            Section {
+                                                ForEach(cellDecs, id: \.action) { decoratorRow($0, path: csPath) }
+                                                if cellDecs.isEmpty { emptyHint("No cell-specific decorators — tap + to add one (copies common column decorators first)") }
+                                                addButton(badge: .pink) {
+                                                    draft = DecoratorDraft(path: csPath, editAction: nil,
+                                                                           icon: "circle-info", label: "", color: "#F97316", action: "")
+                                                }
+                                            } header: {
+                                                decoratorSectionHeader(title: "Cell-Specific Decorators", symbol: "rectangle.split.3x1",
+                                                                       count: cellDecs.count, badge: .pink, path: csPath)
+                                            }
                                         }
                                     }
                                 }

--- a/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Decorator Example/DecoratorAPIDemoView.swift
@@ -958,6 +958,39 @@ struct DecoratorEditView: View {
 
 // MARK: - DecoratorAPIDemoView  (standalone entry from the option list)
 
+private class EditorBox: ObservableObject {
+    @Published var editor: DocumentEditor
+
+    var onAction: ((String, String) -> Void)?
+    var onError:  ((String) -> Void)?
+
+    init() { editor = EditorBox.make(document: sampleJSONDocument(fileName: "Navigation"), config: DecoratorConfig()) }
+
+    func remake(config: DecoratorConfig) {
+        editor = EditorBox.make(document: editor.document, config: config)
+        wire()
+    }
+
+    func wire() {
+        guard let h = editor.events as? DecoratorEventHandler else { return }
+        h.onDecoratorAction = onAction
+        h.onDecoratorError  = onError
+    }
+
+    private static func make(document: JoyDoc, config: DecoratorConfig) -> DocumentEditor {
+        let handler = DecoratorEventHandler()
+        let ed = DocumentEditor(
+            document: document,
+            events: handler,
+            validateSchema: false,
+            license: licenseKey,
+            decoratorConfig: config
+        )
+        handler.editor = ed
+        return ed
+    }
+}
+
 private class DecoratorEventHandler: FormChangeEvent {
     weak var editor: DocumentEditor?
     var onDecoratorAction: ((String, String) -> Void)? // (action, path)
@@ -1008,13 +1041,16 @@ private class DecoratorEventHandler: FormChangeEvent {
 }
 
 struct DecoratorAPIDemoView: View {
-    @StateObject private var editor: DocumentEditor
+    @StateObject private var box              = EditorBox()
 
     @State private var showDecoratorManager      = false
     @State private var lastAction: String        = ""
     @State private var lastPath:   String        = ""
     @State private var showBanner: Bool          = false
     @State private var decoratorError: DecoratorErrorAlert? = nil
+    @State private var visibleLimitInFields: Int = 2
+    @State private var visibleLimitInRows: Int   = 1
+    @State private var showConfigPopover: Bool   = false
     // Persisted across sheet dismissals so the user doesn't have to re-select
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
@@ -1022,22 +1058,7 @@ struct DecoratorAPIDemoView: View {
     @State private var decoratorPendingSchema:   String = ""
     @State private var decoratorColumnID:        String = ""
 
-    init() {
-        let handler = DecoratorEventHandler()
-        let editor = DocumentEditor(
-            document: sampleJSONDocument(fileName: "Navigation"),
-            events: handler,
-            validateSchema: false,
-            license: licenseKey
-        )
-        handler.editor = editor
-        _editor = StateObject(wrappedValue: editor)
-    }
-
-    /// The event handler stored inside the editor, cast back to our concrete type.
-    private var eventHandler: DecoratorEventHandler? {
-        editor.events as? DecoratorEventHandler
-    }
+    private var editor: DocumentEditor { box.editor }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1059,10 +1080,16 @@ struct DecoratorAPIDemoView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showDecoratorManager = true
-                } label: {
-                    Label("Decorators", systemImage: "paintbrush.pointed.fill")
+                HStack(spacing: 16) {
+                    Button { showConfigPopover = true } label: {
+                        Image(systemName: "slider.horizontal.3")
+                    }
+                    .popover(isPresented: $showConfigPopover) {
+                        configPopover
+                    }
+                    Button { showDecoratorManager = true } label: {
+                        Label("Decorators", systemImage: "paintbrush.pointed.fill")
+                    }
                 }
             }
         }
@@ -1078,21 +1105,93 @@ struct DecoratorAPIDemoView: View {
             )
         }
         .onAppear {
-            eventHandler?.onDecoratorAction = { action, path in
+            box.onAction = { action, path in
                 lastAction = action
                 lastPath   = path
                 showBanner = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { showBanner = false }
             }
-            eventHandler?.onDecoratorError = { message in
+            box.onError = { message in
                 decoratorError = DecoratorErrorAlert(message: message)
             }
+            box.wire()
         }
         .alert(item: $decoratorError) { err in
             Alert(title: Text("Decorator Error"),
                   message: Text(err.message),
                   dismissButton: .default(Text("OK")))
         }
+    }
+
+    // MARK: Config popover
+
+    private var configPopover: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Decorator Config")
+                .font(.headline)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
+
+            Divider()
+
+            VStack(spacing: 0) {
+                Stepper(value: $visibleLimitInFields, in: 0...10) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Fields & Columns").font(.subheadline)
+                        Text("visibleLimitInFields: \(visibleLimitInFields)")
+                            .font(.caption.monospaced()).foregroundColor(.secondary)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+
+                Divider().padding(.leading, 20)
+
+                Stepper(value: $visibleLimitInRows, in: 0...10) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Rows").font(.subheadline)
+                        Text("visibleLimitInRows: \(visibleLimitInRows)")
+                            .font(.caption.monospaced()).foregroundColor(.secondary)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+            }
+
+            Divider()
+
+            HStack(spacing: 0) {
+                Button {
+                    visibleLimitInFields = 2
+                    visibleLimitInRows   = 1
+                } label: {
+                    Text("Reset to defaults")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+
+                Divider().frame(height: 44)
+
+                Button {
+                    box.remake(config: DecoratorConfig(
+                        visibleLimitInFields: visibleLimitInFields,
+                        visibleLimitInRows: visibleLimitInRows
+                    ))
+                    showConfigPopover = false
+                } label: {
+                    Text("Update")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                }
+            }
+        }
+        .frame(minWidth: 300)
+        .background(Color(.systemBackground))
     }
 
     // MARK: Banner

--- a/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
@@ -113,6 +113,10 @@ struct JoyfillExampleApp: App {
                 Text(appState.focusBlurResult)
                     .accessibilityIdentifier("focusBlurResultfield")
                     .frame(height: 10)
+                
+                if isRunningDecoratorTest() {
+                    DecoratorCommandBridgeView(documentEditor: documentEditor)
+                }
             } else if useQuickTestMode {
                 //Quick test mode: directly open template list with default token
                 NavigationView {
@@ -141,6 +145,13 @@ struct JoyfillExampleApp: App {
         return fullTestName.contains(testClass)
     }
     
+    func isRunningDecoratorTest() -> Bool {
+        let args = CommandLine.arguments
+        guard let idx = args.firstIndex(of: "--test-name"),
+              idx + 1 < args.count else { return false }
+        return args[idx + 1].contains("Decorator")
+    }
+
     func isRunningNavigationTest(_ testClass: String = "NavigationGotoUITests") -> Bool {
         // 1. Must be iPad
         guard UIDevice.current.userInterfaceIdiom == .pad else {

--- a/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/JoyfillExampleApp.swift
@@ -87,6 +87,10 @@ struct JoyfillExampleApp: App {
         
         // Set up crash prevention for UI tests after all properties are initialized
         setupCrashPrevention()
+
+        if CommandLine.arguments.contains("--disable-animations") {
+            UIView.setAnimationsEnabled(false)
+        }
     }
 
     var body: some Scene {

--- a/JoyfillSwiftUIExample/JoyfillExample/UITestFormContainerView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UITestFormContainerView.swift
@@ -1,6 +1,67 @@
 import SwiftUI
+import UIKit
 import Joyfill
 import JoyfillModel
+
+/// UI-test bridge that lets out-of-process XCUITests drive DocumentEditor
+/// decorator APIs without tripping iOS 16+ pasteboard prompts. The test types
+/// a JSON command into the hidden `decorator_command_input` text field, then
+/// taps the `decorator_command_execute` button in the app, which calls
+/// `DecoratorCommandBridge.execute(json:on:)` to dispatch to the matching API.
+/// The view half of the decorator bridge: a TextField the test types JSON
+/// into, and a Button the test taps to trigger execution. We avoid the
+/// pasteboard entirely so no iOS 16+ permission prompt ever appears.
+struct DecoratorCommandBridgeView: View {
+    let documentEditor: DocumentEditor
+    @State private var commandText: String = ""
+
+    var body: some View {
+        HStack(spacing: 4) {
+            TextField("cmd", text: $commandText)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+                .accessibilityIdentifier("decorator_command_input")
+            Button("run-decorator-command") {
+                let payload = commandText
+                commandText = ""
+                DecoratorCommandBridge.execute(json: payload, on: documentEditor)
+            }
+            .accessibilityIdentifier("decorator_command_execute")
+        }
+        .frame(height: 32)
+        .padding(.horizontal, 8)
+    }
+}
+
+enum DecoratorCommandBridge {
+    static func execute(json: String, on documentEditor: DocumentEditor) {
+        guard let data = json.data(using: .utf8),
+              let command = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let op = command["op"] as? String,
+              let path = command["path"] as? String else { return }
+
+        switch op {
+        case "add":
+            if let dicts = command["decorators"] as? [[String: Any]] {
+                let decorators = dicts.map { Decorator(dictionary: $0) }
+                documentEditor.addDecorators(path: path, decorators: decorators)
+            }
+        case "update":
+            if let actionName = command["action"] as? String,
+               let decoratorDict = command["decorator"] as? [String: Any] {
+                documentEditor.updateDecorator(path: path, action: actionName,
+                                               decorator: Decorator(dictionary: decoratorDict))
+            }
+        case "remove":
+            if let actionName = command["action"] as? String {
+                documentEditor.removeDecorator(path: path, action: actionName)
+            }
+        default:
+            break
+        }
+    }
+}
 
 func sampleJSONDocument(fileName: String? = nil) -> JoyDoc {
     let jsonFileName = fileName ?? "Joydocjson"

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -236,6 +236,9 @@ struct FormDestinationView: View {
     @State private var decoratorPageID:          String = ""
     @State private var decoratorFieldPositionID: String = ""
     @State private var decoratorError:           DecoratorErrorAlert? = nil
+    @State private var decoratorHopChain:        [DecoratorHopStep] = []
+    @State private var decoratorPendingSchema:   String = ""
+    @State private var decoratorColumnID:        String = ""
     let enableChangelogs: Bool
     @State var validateSchema: Bool = false
     @State var isPageDuplicated: Bool = true
@@ -382,7 +385,10 @@ struct FormDestinationView: View {
                     editor: editor,
                     selectedPageID: $decoratorPageID,
                     selectedFieldPositionID: $decoratorFieldPositionID,
-                    decoratorError: $decoratorError
+                    decoratorError: $decoratorError,
+                    hopChain: $decoratorHopChain,
+                    pendingSchema: $decoratorPendingSchema,
+                    selectedColumnID: $decoratorColumnID
                 )
             }
         }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorCOWTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorCOWTests.swift
@@ -1,0 +1,141 @@
+//
+//  DecoratorCOWTests.swift
+//  JoyfillTests
+//
+//  Copy-on-write seeding: the first write to a "specific" scope (row-self, cell,
+//  row-scoped column) seeds from the matching "common" scope so the specific
+//  write diverges without dropping previously-inherited decorators.
+//
+
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorCOWTests: XCTestCase {
+
+    // MARK: - rowSelf seeds from commonRows
+
+    func testRowSelf_firstWrite_seedsFromCommonRows_table() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let commonPath = ChangerHandlerSample.tableCommonRowsPath()
+        let selfPath   = ChangerHandlerSample.tableRowSelfPath()
+
+        // Seed common with two decorators
+        editor.addDecorators(path: commonPath, decorators: [
+            makeDecorator(action: "common1"),
+            makeDecorator(action: "common2"),
+        ])
+
+        // First row-self write: new decorator should be appended AFTER the common-seeded ones
+        editor.addDecorators(path: selfPath, decorators: [makeDecorator(action: "specific")])
+
+        let read = editor.getDecorators(path: selfPath)
+        XCTAssertEqual(read.map { $0.action }, ["common1", "common2", "specific"],
+                       "row-self should seed from common rows on first write")
+    }
+
+    func testRowSelf_firstWrite_seedsFromCommonRows_collectionRoot() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "rootCommon")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rootSelf")])
+        let read = editor.getDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath())
+        XCTAssertEqual(read.map { $0.action }, ["rootCommon", "rootSelf"])
+    }
+
+    func testRowSelf_firstWrite_seedsFromCommonRows_collectionNested() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "nCommon")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath(),
+                             decorators: [makeDecorator(action: "nSelf")])
+        let read = editor.getDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath())
+        XCTAssertEqual(read.map { $0.action }, ["nCommon", "nSelf"])
+    }
+
+    // MARK: - cell seeds from commonColumn
+
+    func testCell_firstWrite_seedsFromCommonColumn_table() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let commonPath = ChangerHandlerSample.tableCommonColumnPath()
+        let cellPath   = ChangerHandlerSample.tableCellPath()
+
+        editor.addDecorators(path: commonPath, decorators: [
+            makeDecorator(action: "colCommon1"),
+            makeDecorator(action: "colCommon2"),
+        ])
+        editor.addDecorators(path: cellPath, decorators: [makeDecorator(action: "cellOverride")])
+
+        let read = editor.getDecorators(path: cellPath)
+        XCTAssertEqual(read.map { $0.action }, ["colCommon1", "colCommon2", "cellOverride"],
+                       "cell should seed from common column on first write")
+    }
+
+    func testCell_firstWrite_seedsFromCommonColumn_collectionNested() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonColumnPath(),
+                             decorators: [makeDecorator(action: "nColCommon")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCellPath(),
+                             decorators: [makeDecorator(action: "nCell")])
+        let read = editor.getDecorators(path: ChangerHandlerSample.collectionNestedCellPath())
+        XCTAssertEqual(read.map { $0.action }, ["nColCommon", "nCell"])
+    }
+
+    // MARK: - COW is one-shot (subsequent common changes don't auto-propagate)
+
+    func testRowSelf_subsequentCommonChange_doesNotAffectSpecific() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let commonPath = ChangerHandlerSample.tableCommonRowsPath()
+        let selfPath   = ChangerHandlerSample.tableRowSelfPath()
+
+        editor.addDecorators(path: commonPath, decorators: [makeDecorator(action: "common1")])
+        editor.addDecorators(path: selfPath,   decorators: [makeDecorator(action: "specific")])
+        // At this point selfPath = [common1, specific]
+
+        // Change the common slot
+        editor.addDecorators(path: commonPath, decorators: [makeDecorator(action: "common2")])
+
+        let selfRead = editor.getDecorators(path: selfPath)
+        XCTAssertEqual(selfRead.map { $0.action }, ["common1", "specific"],
+                       "specific scope must not auto-pick up later changes to common")
+        let commonRead = editor.getDecorators(path: commonPath)
+        XCTAssertEqual(commonRead.map { $0.action }, ["common1", "common2"])
+    }
+
+    // MARK: - No seed when common is empty
+
+    func testRowSelf_commonEmpty_firstWriteContainsOnlySpecific() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "loneSelf")])
+        XCTAssertEqual(editor.getDecorators(path: ChangerHandlerSample.tableRowSelfPath()).map { $0.action },
+                       ["loneSelf"])
+    }
+
+    func testCell_commonEmpty_firstWriteContainsOnlyCell() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "loneCell")])
+        XCTAssertEqual(editor.getDecorators(path: ChangerHandlerSample.tableCellPath()).map { $0.action },
+                       ["loneCell"])
+    }
+
+    // MARK: - No seed on second write (specific is already non-empty)
+
+    func testRowSelf_secondWrite_noReSeed() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let commonPath = ChangerHandlerSample.tableCommonRowsPath()
+        let selfPath   = ChangerHandlerSample.tableRowSelfPath()
+
+        editor.addDecorators(path: commonPath, decorators: [makeDecorator(action: "common1")])
+        editor.addDecorators(path: selfPath,   decorators: [makeDecorator(action: "self1")])
+        // selfPath = [common1, self1]
+        editor.addDecorators(path: selfPath,   decorators: [makeDecorator(action: "self2")])
+
+        let read = editor.getDecorators(path: selfPath)
+        XCTAssertEqual(read.map { $0.action }, ["common1", "self1", "self2"],
+                       "second write to row-self must append, not re-seed from common")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorDeepPathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorDeepPathTests.swift
@@ -215,31 +215,11 @@ final class DecoratorDeepPathTests: XCTestCase {
         XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
     }
 
-    /// decorate is a one-way latch — removing the last decorator must not flip it back off
-    /// (the renderer decides per-row whether to show the indicator area; a formerly-decorated
-    /// field stays configured as decorator-capable).
-    func testDecorateFlag_staysTrue_afterRemovingLastDecorator_table() {
-        let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.tableCommonRowsPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
-        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
-
-        editor.removeDecorator(path: path, action: "only")
-
-        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
-                       "decorate is a one-way latch — removing the last decorator must not flip it back off")
-        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
-    }
-
-    func testDecorateFlag_staysTrue_afterRemovingLastDecorator_collectionRoot() {
-        let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.collectionRootCommonRowsPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
-
-        editor.removeDecorator(path: path, action: "only")
-
-        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
-                       "schema-level decorate must also be a one-way latch")
-    }
+    // NOTE: The "one-way latch" assertions that used to live here (decorate stays true
+    // after removing the last decorator) encoded the pre-fix behavior. That was a bug —
+    // `decorate` must flip back to false when the scope goes empty, otherwise the
+    // decorator column renders with no content. The inverted-assertion replacements
+    // live in `DecoratorPublicAPITests.swift`:
+    //   • testDecorateFlag_table_disabledAfterRemovingLastCommonRowsDecorator
+    //   • testDecorateFlag_collectionRoot_disabledAfterRemovingLastCommonRowsDecorator
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorDeepPathTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorDeepPathTests.swift
@@ -1,0 +1,245 @@
+//
+//  DecoratorDeepPathTests.swift
+//  JoyfillTests
+//
+//  Exercises unbounded-depth collection paths and the `/columns/{col}` vs bare
+//  `{col}` aliasing for row-scoped columns / cells.
+//
+
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+final class DecoratorDeepPathTests: XCTestCase {
+
+    // MARK: - Depth-2 writes land on the correct nested element
+
+    func testNestedRowSelf_landsOnNestedValueElement_notRoot() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath(),
+                             decorators: [makeDecorator(action: "nestedSelf")])
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+
+        // Must land on the nested element
+        let nested = findValueElement(in: field, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey,   ChangerHandlerSample.collectionRootRowID),
+            (ChangerHandlerSample.collectionNestedSchemaKey, ChangerHandlerSample.collectionNestedRowID),
+        ])
+        XCTAssertEqual(nested?.decorators?.all.first?.action, "nestedSelf")
+
+        // Root element must be untouched
+        let root = findValueElement(in: field, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey, ChangerHandlerSample.collectionRootRowID)
+        ])
+        XCTAssertNil(root?.decorators?.all.first(where: { $0.action == "nestedSelf" }))
+    }
+
+    func testNestedCell_landsOnNestedValueElementCells() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCellPath(),
+                             decorators: [makeDecorator(action: "nestedCell")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let nested = findValueElement(in: field, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey,   ChangerHandlerSample.collectionRootRowID),
+            (ChangerHandlerSample.collectionNestedSchemaKey, ChangerHandlerSample.collectionNestedRowID),
+        ])
+        XCTAssertEqual(nested?.decorators?.cells[ChangerHandlerSample.collectionNestedColumnID]?.first?.action,
+                       "nestedCell")
+    }
+
+    // MARK: - Scope isolation between root and nested
+
+    func testRootAndNested_sameColumnId_areDistinctScopes() {
+        // NOTE: this test only runs meaningfully if root and nested happen to share
+        // a column ID. The sample document uses distinct IDs so we instead verify
+        // that schema-scoped columns don't cross-pollute via their own IDs.
+        let (editor, _) = makeChangerHandlerEditor()
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonColumnPath(),
+                             decorators: [makeDecorator(action: "rootOnly")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonColumnPath(),
+                             decorators: [makeDecorator(action: "nestedOnly")])
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let rootCol = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        let nestedCol = field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
+
+        XCTAssertEqual(rootCol?.decorators?.map { $0.action ?? "" }, ["rootOnly"])
+        XCTAssertEqual(nestedCol?.decorators?.map { $0.action ?? "" }, ["nestedOnly"])
+    }
+
+    // MARK: - `/columns/col` on a row aliases `/col` (bare) — same storage
+
+    func testRowScopedColumn_aliasesCellStorage_tableRoundTrip() {
+        let (editor, _) = makeChangerHandlerEditor()
+        // Write via `/rowID/columns/colID`
+        editor.addDecorators(path: ChangerHandlerSample.tableRowScopedColumnPath(),
+                             decorators: [makeDecorator(action: "scoped")])
+        // Read via `/rowID/colID` — must return the same decorator.
+        let bareRead = editor.getDecorators(path: ChangerHandlerSample.tableCellPath())
+        XCTAssertEqual(bareRead.map { $0.action }, ["scoped"])
+        // And the reverse direction too
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "bare")])
+        let scopedRead = editor.getDecorators(path: ChangerHandlerSample.tableRowScopedColumnPath())
+        XCTAssertEqual(scopedRead.map { $0.action }, ["scoped", "bare"])
+    }
+
+    func testRowScopedColumn_aliasesCellStorage_collectionNested() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowScopedColumnPath(),
+                             decorators: [makeDecorator(action: "nScoped")])
+        let bareRead = editor.getDecorators(path: ChangerHandlerSample.collectionNestedCellPath())
+        XCTAssertEqual(bareRead.map { $0.action }, ["nScoped"])
+    }
+
+    // MARK: - Common-column at schema level (`/schemas/sk/columns/col` without row)
+
+    func testCommonColumn_atSchemaRoot_withoutEnteringAnyRow() {
+        // Path: fp/schemas/rootSK/columns/rootCol — no row in between
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas/\(ChangerHandlerSample.collectionRootSchemaKey)/columns/\(ChangerHandlerSample.collectionRootColumnID)"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "schemaLevelCol")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        XCTAssertEqual(col?.decorators?.first?.action, "schemaLevelCol")
+    }
+
+    func testCommonRows_atSchemaRoot_withoutEnteringAnyRow() {
+        // Path: fp/schemas/rootSK/rows — no row in between
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas/\(ChangerHandlerSample.collectionRootSchemaKey)/rows"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "schemaLevelRows")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action,
+                       "schemaLevelRows")
+    }
+
+    // MARK: - decorate flag auto-enable
+
+    func testDecorateFlag_table_enabledAfterRowSelfAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "x")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "adding row-self decorator must auto-enable decorate on the table field")
+    }
+
+    func testDecorateFlag_table_enabledAfterCommonRowsAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+    }
+
+    func testDecorateFlag_collectionRootSchema_enabledAfterRowSelfAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let field0 = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNotEqual(field0?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "x")])
+
+        let field1 = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field1?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                       "decorate should flip on the schema entry the row lives in")
+    }
+
+    func testDecorateFlag_collectionNestedSchema_enabledAfterNestedCommonRowsAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true)
+    }
+
+    /// Cell writes are column-scope — they don't affect decorate (which gates the row indicator area).
+    func testDecorateFlag_notEnabledByCellWrite() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "x")])
+        // Cell writes should NOT flip the decorate flag (per ensureDecorateEnabled implementation)
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+    }
+
+    /// Common-column writes are column-scope too — they must not flip decorate on either field or schema.
+    func testDecorateFlag_notEnabledByCommonColumnWrite_table() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonColumnPath(),
+                             decorators: [makeDecorator(action: "x")])
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+    }
+
+    func testDecorateFlag_notEnabledByCommonColumnWrite_collectionRoot() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonColumnPath(),
+                             decorators: [makeDecorator(action: "x")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNotEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+    }
+
+    /// Nested row-self flips the nested schema's decorate, not the root schema's
+    /// (uses `hops.last?.schemaKey` in ensureDecorateEnabled).
+    func testDecorateFlag_nestedRowSelf_flipsNestedSchemaOnly_notRoot() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath(),
+                             decorators: [makeDecorator(action: "x")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true,
+                       "nested row-self must flip the nested schema's decorate")
+        XCTAssertNotEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                          "nested row-self must NOT flip the root schema's decorate")
+    }
+
+    /// Collection writes must not leak into the unrelated table field's decorate flag.
+    func testDecorateFlag_collectionRowsWrite_doesNotAffectTableField() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                          "collection row writes must not affect table field's decorate flag")
+    }
+
+    /// Schema-root common-rows path (`fp/schemas/sk/rows`, no row in between) also auto-enables decorate.
+    func testDecorateFlag_flipsVia_schemaRootCommonRowsPath() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas/\(ChangerHandlerSample.collectionRootSchemaKey)/rows"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "x")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+    }
+
+    /// decorate is a one-way latch — removing the last decorator must not flip it back off
+    /// (the renderer decides per-row whether to show the indicator area; a formerly-decorated
+    /// field stays configured as decorator-capable).
+    func testDecorateFlag_staysTrue_afterRemovingLastDecorator_table() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "decorate is a one-way latch — removing the last decorator must not flip it back off")
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0)
+    }
+
+    func testDecorateFlag_staysTrue_afterRemovingLastDecorator_collectionRoot() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+
+        editor.removeDecorator(path: path, action: "only")
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                       "schema-level decorate must also be a one-way latch")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -7,6 +7,12 @@
 //  cached state refreshed via `decoratorsDidChange()` — so the UI reflects
 //  the change without rebuilding the modal.
 //
+//  Scope mapping under the new-grammar:
+//    - `/rows`            → schema.rowDecorators          (row-indicator column)
+//    - `/columns/{col}`   → tableColumns[col].decorators  (column indicator)
+//    - `/{rowID}`         → ValueElement.decorators.all   (row-self)
+//    - `/{rowID}/{col}`   → ValueElement.decorators.cells (cell)
+//
 
 import XCTest
 import Foundation
@@ -66,26 +72,32 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         return CollectionViewModel(tableDataModel: model!)
     }
 
-    // MARK: - TableViewModel
+    // MARK: - TableViewModel — common rows / common columns (cache-backed)
 
-    func testTableViewModel_addRowDecorator_updatesRowDecoratorsCache() {
+    func testTableViewModel_addCommonRowDecorator_refreshesRowDecoratorCache() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
-        XCTAssertTrue(vm.tableDataModel.rowDecorators.isEmpty)
 
-        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
                              decorators: [makeDecorator(action: "live-row")])
         waitForMainQueueToDrain()
 
-        XCTAssertEqual(vm.tableDataModel.rowDecorators.first?.action, "live-row")
-        XCTAssertTrue(vm.showRowDecorators)
+        // Source of truth — field got the decorator + decorate flag
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        XCTAssertEqual(field?.rowDecorators?.first?.action, "live-row")
+        XCTAssertEqual(field?.decorate, true)
+
+        // Delegate refresh — per-row cache populated with the common-row decorator
+        let cached = vm.tableDataModel.tableRowDecorators[ChangerHandlerSample.tableRowID] ?? []
+        XCTAssertEqual(cached.first?.action, "live-row",
+                       "decoratorsDidChange must refresh tableRowDecorators from field.rowDecorators")
     }
 
-    func testTableViewModel_addColumnDecorator_updatesTableColumnsDecorators() {
+    func testTableViewModel_addCommonColumnDecorator_updatesTableColumnsDecorators() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
 
-        editor.addDecorators(path: ChangerHandlerSample.tableColumnPath(),
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonColumnPath(),
                              decorators: [makeDecorator(action: "live-col")])
         waitForMainQueueToDrain()
 
@@ -93,27 +105,27 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         XCTAssertEqual(col?.decorators?.first?.action, "live-col")
     }
 
-    func testTableViewModel_removeRowDecorator_updatesCache() {
+    func testTableViewModel_removeCommonColumnDecorator_updatesCache() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
-        let path = ChangerHandlerSample.tableRowPath()
+        let path = ChangerHandlerSample.tableCommonColumnPath()
         editor.addDecorators(path: path, decorators: [
             makeDecorator(action: "a"),
             makeDecorator(action: "b"),
         ])
         waitForMainQueueToDrain()
-        XCTAssertEqual(vm.tableDataModel.rowDecorators.count, 2)
 
         editor.removeDecorator(path: path, action: "a")
         waitForMainQueueToDrain()
 
-        XCTAssertEqual(vm.tableDataModel.rowDecorators.map { $0.action }, ["b"])
+        let col = vm.tableDataModel.tableColumns.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.map { $0.action ?? "" }, ["b"])
     }
 
-    func testTableViewModel_updateRowDecorator_updatesCache() {
+    func testTableViewModel_updateCommonColumnDecorator_updatesCache() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
-        let path = ChangerHandlerSample.tableRowPath()
+        let path = ChangerHandlerSample.tableCommonColumnPath()
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "a", label: "Old")])
         waitForMainQueueToDrain()
 
@@ -121,51 +133,76 @@ final class DecoratorLiveUpdateTests: XCTestCase {
                                decorator: makeDecorator(action: "a", label: "New"))
         waitForMainQueueToDrain()
 
-        XCTAssertEqual(vm.tableDataModel.rowDecorators.first?.label, "New")
+        let col = vm.tableDataModel.tableColumns.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertEqual(col?.decorators?.first?.label, "New")
     }
 
-    // MARK: - CollectionViewModel
+    // MARK: - TableViewModel — row-self / cell (lands on ValueElement)
 
-    func testCollectionViewModel_addRootRowDecorator_updatesSchemaAndCache() {
+    func testTableViewModel_addRowSelfDecorator_persistsOnValueElement() {
+        let (editor, _) = makeChangerHandlerEditor()
+        _ = makeTableViewModel(editor: editor) // ensure delegate wired
+
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+        waitForMainQueueToDrain()
+
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.tableFieldID),
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "rowSelf")
+    }
+
+    func testTableViewModel_addCellDecorator_persistsOnValueElementCells() {
+        let (editor, _) = makeChangerHandlerEditor()
+        _ = makeTableViewModel(editor: editor)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "cell")])
+        waitForMainQueueToDrain()
+
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.tableFieldID),
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.cells[ChangerHandlerSample.tableColumnID]?.first?.action, "cell")
+    }
+
+    // MARK: - CollectionViewModel — common-rows / common-columns
+
+    func testCollectionViewModel_addRootCommonRowDecorator_updatesSchemaAndCache() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeCollectionViewModel(editor: editor)
         waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
 
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
                              decorators: [makeDecorator(action: "rootRow")])
         waitForMainQueueToDrain()
-
-        // The DecoratorLocal cache used for rendering
-        let cached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionRootSchemaKey]
-        XCTAssertEqual(cached?.first?.action, "rootRow")
 
         // The schema mirror that backs `hasAnyRowDecorators`
         let schemaRow = vm.tableDataModel.schema[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators
         XCTAssertEqual(schemaRow?.first?.action, "rootRow")
     }
 
-    func testCollectionViewModel_addNestedRowDecorator_updatesNestedSchema() {
+    func testCollectionViewModel_addNestedCommonRowDecorator_updatesNestedSchema() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeCollectionViewModel(editor: editor)
         waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
 
-        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
                              decorators: [makeDecorator(action: "nested")])
         waitForMainQueueToDrain()
 
-        let cached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionNestedSchemaKey]
-        XCTAssertEqual(cached?.first?.action, "nested")
-        // Should not appear in the root schema cache
-        let rootCached = vm.tableDataModel.rowDecoratorsBySchemaKey[ChangerHandlerSample.collectionRootSchemaKey] ?? []
-        XCTAssertNil(rootCached.first(where: { $0.action == "nested" }))
+        let nestedSchemaRow = vm.tableDataModel.schema[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators
+        XCTAssertEqual(nestedSchemaRow?.first?.action, "nested")
+        // Should not appear in the root schema
+        let rootSchemaRow = vm.tableDataModel.schema[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators ?? []
+        XCTAssertNil(rootSchemaRow.first(where: { $0.action == "nested" }))
     }
 
-    func testCollectionViewModel_addRootColumnDecorator_updatesRootTableColumns() {
+    func testCollectionViewModel_addRootCommonColumnDecorator_updatesRootTableColumns() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeCollectionViewModel(editor: editor)
         waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
 
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootColumnPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonColumnPath(),
                              decorators: [makeDecorator(action: "rootCol")])
         waitForMainQueueToDrain()
 
@@ -183,12 +220,12 @@ final class DecoratorLiveUpdateTests: XCTestCase {
                        "columnsMap must be rebuilt so the navigation view reads fresh column decorators")
     }
 
-    func testCollectionViewModel_addNestedColumnDecorator_updatesSchemaTableColumns() {
+    func testCollectionViewModel_addNestedCommonColumnDecorator_updatesSchemaTableColumns() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeCollectionViewModel(editor: editor)
         waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
 
-        editor.addDecorators(path: ChangerHandlerSample.collectionNestedColumnPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonColumnPath(),
                              decorators: [makeDecorator(action: "nestedCol")])
         waitForMainQueueToDrain()
 
@@ -203,22 +240,57 @@ final class DecoratorLiveUpdateTests: XCTestCase {
                        "nested column decorators must be reflected in columnsMap")
     }
 
+    // MARK: - CollectionViewModel — row-self / cell (ValueElement storage)
+
+    func testCollectionViewModel_addRootRowSelfDecorator_persistsOnValueElement() {
+        let (editor, _) = makeChangerHandlerEditor()
+        _ = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rootSelf")])
+        waitForMainQueueToDrain()
+
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.collectionFieldID),
+                                   hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                           ChangerHandlerSample.collectionRootRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "rootSelf")
+    }
+
+    func testCollectionViewModel_addNestedRowSelfDecorator_persistsOnNestedValueElement() {
+        let (editor, _) = makeChangerHandlerEditor()
+        _ = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath(),
+                             decorators: [makeDecorator(action: "nestedSelf")])
+        waitForMainQueueToDrain()
+
+        let nested = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.collectionFieldID),
+                                      hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                              ChangerHandlerSample.collectionRootRowID),
+                                             (ChangerHandlerSample.collectionNestedSchemaKey,
+                                              ChangerHandlerSample.collectionNestedRowID)])
+        XCTAssertEqual(nested?.decorators?.all.first?.action, "nestedSelf")
+    }
+
     /// Regression: before the fix, `tableDataModel.schema` was not refreshed in `decoratorsDidChange()`,
     /// so `hasAnyRowDecorators` (which reads from `schema.values`) returned false even after a row
     /// decorator was added — meaning the row decorator column never appeared.
-    func testCollectionViewModel_hasAnyRowDecorators_flipsTrueAfterFirstAdd() {
+    func testCollectionViewModel_hasAnyRowDecorators_flipsTrueAfterFirstCommonRowAdd() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeCollectionViewModel(editor: editor)
         waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertFalse(vm.tableDataModel.hasAnyRowDecorators, "starts with no row decorators")
+        let rootSK = ChangerHandlerSample.collectionRootSchemaKey
+        XCTAssertFalse(vm.tableDataModel.hasAnyRowDecorators(schemaKey: rootSK), "starts with no row decorators")
 
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
                              decorators: [makeDecorator(action: "first")])
         waitForMainQueueToDrain()
 
-        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators,
+        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators(schemaKey: rootSK),
                       "schema must be refreshed so hasAnyRowDecorators sees the new row decorator")
-        XCTAssertTrue(vm.showRowDecorators)
+        XCTAssertTrue(vm.showRowDecorators(forSchemaKey: rootSK))
     }
 
     // MARK: - Lazy delegate creation
@@ -228,7 +300,7 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         // No view model registered for the table field yet.
         XCTAssertNil(editor.delegateMap[ChangerHandlerSample.tableFieldID]?.value)
 
-        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
                              decorators: [makeDecorator(action: "lazy")])
         waitForMainQueueToDrain()
 
@@ -242,11 +314,11 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let tableVM = makeTableViewModel(editor: editor)
 
         // Mutate the COLLECTION field — table VM should not be touched.
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
                              decorators: [makeDecorator(action: "collOnly")])
         waitForMainQueueToDrain()
 
-        XCTAssertTrue(tableVM.tableDataModel.rowDecorators.isEmpty,
-                      "table view model must be untouched when a different field changes")
+        XCTAssertFalse(tableVM.showRowDecorators,
+                       "table view model must be untouched when a different field changes")
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -74,6 +74,99 @@ final class DecoratorLiveUpdateTests: XCTestCase {
 
     // MARK: - TableViewModel — common rows / common columns (cache-backed)
 
+    // MARK: - `decorate` flag — live vs snapshot behavior
+
+    /// Pinned behavior: `TableDataModel.decorate` is a `let` captured at init, and
+    /// `TableViewModel.showRowDecorators` reads that snapshot — so on a view model
+    /// that already exists, the row-indicator column does NOT appear live when a
+    /// common-row decorator is added afterwards. The underlying field flag DOES
+    /// flip (source of truth is correct); only the cached UI-facing property lags.
+    ///
+    /// Fix (whenever we decide to): have `showRowDecorators` read `decorate` live
+    /// from `documentEditor.field(...)`. When that lands, flip this test's
+    /// `XCTAssertFalse` → `XCTAssertTrue`.
+    func testTableViewModel_showRowDecorators_doesNotFlipLive_currentLimitation() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+        XCTAssertFalse(vm.showRowDecorators, "starts false — no decorators yet")
+
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        waitForMainQueueToDrain()
+
+        // Field-level source of truth did flip.
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+        // …but the VM's snapshot-backed computed property did not.
+        XCTAssertFalse(vm.showRowDecorators,
+                       "known limitation: TableDataModel.decorate is captured at init and never refreshed")
+    }
+
+    /// Inverse: if the VM is built AFTER the decorator exists, the snapshot picks
+    /// up the true flag and the row-indicator column renders correctly. This path
+    /// is what currently keeps tables usable — the UI typically constructs the VM
+    /// fresh when the modal opens.
+    func testTableViewModel_showRowDecorators_trueWhenBuiltAfterDecoratorExists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "pre-existing")])
+
+        let vm = makeTableViewModel(editor: editor)
+        XCTAssertTrue(vm.showRowDecorators,
+                      "VM built after the decorator exists must see decorate=true on its snapshot")
+    }
+
+    /// Collection counterpart — `hasAnyRowDecorators(schemaKey:)` reads from
+    /// `tableDataModel.schema`, which `decoratorsDidChange()` does refresh.
+    /// So the collection UI picks up the flag live (unlike tables).
+    func testCollectionViewModel_hasAnyRowDecorators_flipsLive_onCommonRowAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+        let rootSK = ChangerHandlerSample.collectionRootSchemaKey
+        XCTAssertFalse(vm.tableDataModel.hasAnyRowDecorators(schemaKey: rootSK))
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators(schemaKey: rootSK),
+                      "collection's schema mirror IS refreshed, so hasAnyRowDecorators flips live")
+    }
+
+    /// Collection nested schema — same live-flip behavior.
+    func testCollectionViewModel_hasAnyRowDecorators_flipsLive_onNestedCommonRowAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+        let nestedSK = ChangerHandlerSample.collectionNestedSchemaKey
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "x")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators(schemaKey: nestedSK))
+        // Root schema must NOT flip from a nested-only write.
+        XCTAssertFalse(vm.tableDataModel.hasAnyRowDecorators(schemaKey: ChangerHandlerSample.collectionRootSchemaKey))
+    }
+
+    /// Row-self write also flips the schema's `decorate`, reaching
+    /// `hasAnyRowDecorators` live via the refreshed schema mirror.
+    func testCollectionViewModel_hasAnyRowDecorators_flipsLive_onRowSelfAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeCollectionViewModel(editor: editor)
+        waitForDelegate(editor, fieldID: ChangerHandlerSample.collectionFieldID)
+        let rootSK = ChangerHandlerSample.collectionRootSchemaKey
+
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "x")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(vm.tableDataModel.hasAnyRowDecorators(schemaKey: rootSK),
+                      "row-self writes flip the schema's decorate flag, visible live through the mirror")
+    }
+
+    // MARK: - Row decorator cache (works correctly on tables too)
+
     func testTableViewModel_addCommonRowDecorator_refreshesRowDecoratorCache() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
@@ -82,15 +175,19 @@ final class DecoratorLiveUpdateTests: XCTestCase {
                              decorators: [makeDecorator(action: "live-row")])
         waitForMainQueueToDrain()
 
-        // Source of truth — field got the decorator + decorate flag
+        // Source of truth — field got the decorator + decorate flag.
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
         XCTAssertEqual(field?.rowDecorators?.first?.action, "live-row")
         XCTAssertEqual(field?.decorate, true)
 
-        // Delegate refresh — per-row cache populated with the common-row decorator
+        // Delegate refresh — per-row cache populated with the common-row decorator.
         let cached = vm.tableDataModel.tableRowDecorators[ChangerHandlerSample.tableRowID] ?? []
         XCTAssertEqual(cached.first?.action, "live-row",
                        "decoratorsDidChange must refresh tableRowDecorators from field.rowDecorators")
+
+        // Known limitation: `TableDataModel.decorate` is a `let` captured at init,
+        // so `vm.showRowDecorators` cannot flip true post-init. The UI currently
+        // relies on the init-time snapshot for the row-indicator column on tables.
     }
 
     func testTableViewModel_addCommonColumnDecorator_updatesTableColumnsDecorators() {

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -44,7 +44,8 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
         let header = FieldHeaderModel(title: field?.title, required: field?.required,
                                       tipDescription: field?.tipDescription,
-                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible,
+                                      visibleLimitInFields: editor.decoratorConfig.visibleLimitInFields)
         let model = TableDataModel(
             fieldHeaderModel: header,
             mode: .fill,
@@ -60,7 +61,8 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
         let header = FieldHeaderModel(title: field?.title, required: field?.required,
                                       tipDescription: field?.tipDescription,
-                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+                                      tipTitle: field?.tipTitle, tipVisible: field?.tipVisible,
+                                      visibleLimitInFields: editor.decoratorConfig.visibleLimitInFields)
         let model = TableDataModel(
             fieldHeaderModel: header,
             mode: .fill,

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorLiveUpdateTests.swift
@@ -76,16 +76,10 @@ final class DecoratorLiveUpdateTests: XCTestCase {
 
     // MARK: - `decorate` flag — live vs snapshot behavior
 
-    /// Pinned behavior: `TableDataModel.decorate` is a `let` captured at init, and
-    /// `TableViewModel.showRowDecorators` reads that snapshot — so on a view model
-    /// that already exists, the row-indicator column does NOT appear live when a
-    /// common-row decorator is added afterwards. The underlying field flag DOES
-    /// flip (source of truth is correct); only the cached UI-facing property lags.
-    ///
-    /// Fix (whenever we decide to): have `showRowDecorators` read `decorate` live
-    /// from `documentEditor.field(...)`. When that lands, flip this test's
-    /// `XCTAssertFalse` → `XCTAssertTrue`.
-    func testTableViewModel_showRowDecorators_doesNotFlipLive_currentLimitation() {
+    /// `TableViewModel.showRowDecorators` flips live when a common-row decorator
+    /// is added to an already-built view model — `decoratorsDidChange()` refreshes
+    /// `tableDataModel.decorate` from the field, and the computed property re-reads it.
+    func testTableViewModel_showRowDecorators_flipsLive_onCommonRowAdd() {
         let (editor, _) = makeChangerHandlerEditor()
         let vm = makeTableViewModel(editor: editor)
         XCTAssertFalse(vm.showRowDecorators, "starts false — no decorators yet")
@@ -94,11 +88,39 @@ final class DecoratorLiveUpdateTests: XCTestCase {
                              decorators: [makeDecorator(action: "x")])
         waitForMainQueueToDrain()
 
-        // Field-level source of truth did flip.
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
-        // …but the VM's snapshot-backed computed property did not.
+        XCTAssertTrue(vm.showRowDecorators,
+                      "decoratorsDidChange must refresh tableDataModel.decorate so the row-indicator column appears live")
+    }
+
+    /// Row-self writes also flip `decorate` on the field (per ensureDecorateEnabled),
+    /// so the VM must pick it up live too.
+    func testTableViewModel_showRowDecorators_flipsLive_onRowSelfAdd() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+        XCTAssertFalse(vm.showRowDecorators)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "x")])
+        waitForMainQueueToDrain()
+
+        XCTAssertTrue(vm.showRowDecorators,
+                      "row-self writes flip field.decorate too, must reach showRowDecorators live")
+    }
+
+    /// Cell / common-column writes do NOT flip `decorate`, so `showRowDecorators` stays false.
+    func testTableViewModel_showRowDecorators_notFlipped_byCellOrCommonColumnWrites() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let vm = makeTableViewModel(editor: editor)
+
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "cell")])
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonColumnPath(),
+                             decorators: [makeDecorator(action: "col")])
+        waitForMainQueueToDrain()
+
         XCTAssertFalse(vm.showRowDecorators,
-                       "known limitation: TableDataModel.decorate is captured at init and never refreshed")
+                       "column-scope writes must not flip the row-indicator area")
     }
 
     /// Inverse: if the VM is built AFTER the decorator exists, the snapshot picks
@@ -184,10 +206,6 @@ final class DecoratorLiveUpdateTests: XCTestCase {
         let cached = vm.tableDataModel.tableRowDecorators[ChangerHandlerSample.tableRowID] ?? []
         XCTAssertEqual(cached.first?.action, "live-row",
                        "decoratorsDidChange must refresh tableRowDecorators from field.rowDecorators")
-
-        // Known limitation: `TableDataModel.decorate` is a `let` captured at init,
-        // so `vm.showRowDecorators` cannot flip true post-init. The UI currently
-        // relies on the init-time snapshot for the row-indicator column on tables.
     }
 
     func testTableViewModel_addCommonColumnDecorator_updatesTableColumnsDecorators() {

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -358,4 +358,57 @@ final class DecoratorPathResolutionTests: XCTestCase {
         XCTAssertNil(nested?.decorators?.all.first(where: { $0.action == "invalidNestedHop" }),
                      "failed path must not write row-self decorators")
     }
+
+    // MARK: - First-hop schema must equal the root schema
+
+    /// Path `/schemas/{nestedSK}/{rowID}` from the field root. Nested
+    /// schemas have no top-level rows; the chain walker scans top-level
+    /// rows by id only at the first hop and ignores `hop.schemaKey`.
+    /// Without the resolver guard, a row id that exists at top level
+    /// (e.g. the root row's id) would match — the writer would mutate
+    /// the root row, and `ensureDecorateEnabled` would flip the wrong
+    /// schema's `decorate` flag.
+    func testInvalidPath_firstHopWithNestedSchema_rejectsAndPreservesState() {
+        let (editor, mock) = makeChangerHandlerEditor()
+
+        let buggyPath = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas/\(ChangerHandlerSample.collectionNestedSchemaKey)/\(ChangerHandlerSample.collectionRootRowID)"
+
+        let before = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let rootRowDecsBefore = (findValueElement(in: before,
+                                                  hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                                          ChangerHandlerSample.collectionRootRowID)])?
+            .decorators?.all ?? []).count
+        let nestedDecorateBefore = before?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate
+
+        editor.addDecorators(path: buggyPath, decorators: [makeDecorator(action: "leak")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "first-hop schema-vs-storage mismatch must reject")
+
+        let after = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let rootRowDecsAfter = (findValueElement(in: after,
+                                                 hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                                         ChangerHandlerSample.collectionRootRowID)])?
+            .decorators?.all ?? []).count
+        XCTAssertEqual(rootRowDecsBefore, rootRowDecsAfter,
+                       "rejected path must not mutate the root row's decorators")
+        XCTAssertEqual(nestedDecorateBefore,
+                       after?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate,
+                       "rejected path must not flip the nested schema's decorate flag")
+    }
+
+    /// Sanity: `/schemas/{rootSK}/{rowID}` is the verbose-but-equivalent
+    /// spelling of `/{rowID}` — must keep resolving so the fix doesn't
+    /// over-reject.
+    func testValidPath_firstHopVerboseRootSpelling_resolves() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let verbose = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas/\(ChangerHandlerSample.collectionRootSchemaKey)/\(ChangerHandlerSample.collectionRootRowID)"
+
+        editor.addDecorators(path: verbose, decorators: [makeDecorator(action: "ok")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 0)
+        XCTAssertEqual(editor.getDecorators(path: verbose).map { $0.action }, ["ok"])
+        XCTAssertEqual(editor.getDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath()).map { $0.action }, ["ok"],
+                       "verbose and short spellings must address the same scope")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -2,8 +2,10 @@
 //  DecoratorPathResolutionTests.swift
 //  JoyfillTests
 //
-//  Tests for the path-based decorator API: parsing, target resolution,
-//  schema-key resolution, and the cross-page shared-fp regression.
+//  Tests for the path-based decorator API under the keyword grammar:
+//    rows / columns / schemas / {rowID} / {colID}
+//  Covers: field / common-rows / common-column / row-self / cell / row-scoped column,
+//  for both table and collection (root + nested), plus invalid-path errors.
 //
 
 import XCTest
@@ -18,80 +20,151 @@ final class DecoratorPathResolutionTests: XCTestCase {
     func testValidFieldPath_resolves() {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = ChangerHandlerSample.tableFieldPath()
-        // No decorators yet → empty list, but no error.
         XCTAssertEqual(editor.getDecorators(path: path).count, 0)
         XCTAssertEqual(mock.decoratorErrorCount, 0)
-        // Round trip: write then read.
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "fieldA")])
         XCTAssertEqual(editor.getDecorators(path: path).first?.action, "fieldA")
     }
 
-    // MARK: - Row path
+    // MARK: - Common rows (`/rows`)
 
-    func testValidRowPath_table_resolves() {
+    func testCommonRows_table_writesToFieldRowDecorators() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.tableRowPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableRow")])
-        let read = editor.getDecorators(path: path)
-        XCTAssertEqual(read.count, 1)
-        XCTAssertEqual(read.first?.action, "tableRow")
-        // Verify it landed on field.rowDecorators (table-scope).
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "tRows")])
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
-        XCTAssertEqual(field?.rowDecorators?.first?.action, "tableRow")
+        XCTAssertEqual(field?.rowDecorators?.first?.action, "tRows")
     }
 
-    func testValidRowPath_collectionRoot_resolves() {
+    func testCommonRows_collectionRoot_writesToRootSchemaRowDecorators() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.collectionRootRowPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "rootRow")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "rootRows")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRow")
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRows")
     }
 
-    func testValidRowPath_collectionNested_resolves() {
+    func testCommonRows_collectionNested_writesToNestedSchemaRowDecorators() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.collectionNestedRowPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "nestedRow")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "nestedRows")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRow")
-        // Should NOT have leaked into the root schema.
-        XCTAssertNil(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first(where: { $0.action == "nestedRow" }))
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRows")
+        // Must not leak into root schema
+        XCTAssertNil(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+                        .rowDecorators?.first(where: { $0.action == "nestedRows" }))
     }
 
-    // MARK: - Column path
+    // MARK: - Row-self (`/{rowID}` — row's own decorators on the ValueElement)
 
-    func testValidColumnPath_table_resolves() {
+    func testRowSelf_table_writesToValueElementAll() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.tableColumnPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "tableCol")])
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "tSelf")])
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let row = findValueElement(in: field,
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "tSelf")
+        // Should NOT appear in field.rowDecorators (that's the common-rows slot)
+        XCTAssertNil(field?.rowDecorators?.first(where: { $0.action == "tSelf" }))
+    }
+
+    func testRowSelf_collectionRoot_writesToValueElementAll() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rootSelf")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let row = findValueElement(in: field,
+                                   hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                           ChangerHandlerSample.collectionRootRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "rootSelf")
+    }
+
+    func testRowSelf_collectionNested_writesToValueElementAll() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowSelfPath(),
+                             decorators: [makeDecorator(action: "nestedSelf")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let row = findValueElement(in: field, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey,   ChangerHandlerSample.collectionRootRowID),
+            (ChangerHandlerSample.collectionNestedSchemaKey, ChangerHandlerSample.collectionNestedRowID),
+        ])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "nestedSelf")
+    }
+
+    // MARK: - Common column (`/columns/{col}`)
+
+    func testCommonColumn_table_writesToTableColumnDecorators() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonColumnPath(),
+                             decorators: [makeDecorator(action: "tCol")])
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
         let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
-        XCTAssertEqual(col?.decorators?.first?.action, "tableCol")
+        XCTAssertEqual(col?.decorators?.first?.action, "tCol")
     }
 
-    func testValidColumnPath_collectionRoot_resolves() {
+    func testCommonColumn_collectionRoot_writesToRootSchemaColumn() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.collectionRootColumnPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "rootCol")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonColumnPath(),
+                             decorators: [makeDecorator(action: "rootCol")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
         XCTAssertEqual(col?.decorators?.first?.action, "rootCol")
     }
 
-    func testValidColumnPath_collectionNested_resolves() {
+    func testCommonColumn_collectionNested_writesToNestedSchemaColumn() {
         let (editor, _) = makeChangerHandlerEditor()
-        let path = ChangerHandlerSample.collectionNestedColumnPath()
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "nestedCol")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonColumnPath(),
+                             decorators: [makeDecorator(action: "nestedCol")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        let col = field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
+        let col = field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionNestedColumnID })
         XCTAssertEqual(col?.decorators?.first?.action, "nestedCol")
     }
 
-    // MARK: - Shared field position regression
+    // MARK: - Cell (`/{rowID}/{colID}` — bare column id)
 
-    /// Navigation.json has `6970918d350238d0738dd5c9` as a field-position ID on BOTH page 1 and
-    /// page 2, pointing to two different text fields. Each page-scoped path must resolve to the
-    /// page's own field, not the first page's field.
+    func testCell_table_writesToValueElementCells() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "tCell")])
+        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
+        let row = findValueElement(in: field,
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.cells[ChangerHandlerSample.tableColumnID]?.first?.action, "tCell")
+        // Column-common slot must be untouched
+        let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
+        XCTAssertNil(col?.decorators?.first(where: { $0.action == "tCell" }))
+    }
+
+    func testCell_collectionNested_writesToValueElementCells() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCellPath(),
+                             decorators: [makeDecorator(action: "nCell")])
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        let row = findValueElement(in: field, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey,   ChangerHandlerSample.collectionRootRowID),
+            (ChangerHandlerSample.collectionNestedSchemaKey, ChangerHandlerSample.collectionNestedRowID),
+        ])
+        XCTAssertEqual(row?.decorators?.cells[ChangerHandlerSample.collectionNestedColumnID]?.first?.action, "nCell")
+    }
+
+    // MARK: - Row-scoped column (`/{rowID}/columns/{colID}` — aliases cell)
+
+    func testRowScopedColumn_table_aliasesCellStorage() {
+        let (editor, _) = makeChangerHandlerEditor()
+        // Write via the row-scoped-column spelling
+        editor.addDecorators(path: ChangerHandlerSample.tableRowScopedColumnPath(),
+                             decorators: [makeDecorator(action: "scoped")])
+        // Read back via the bare-cell spelling — same storage
+        let read = editor.getDecorators(path: ChangerHandlerSample.tableCellPath())
+        XCTAssertEqual(read.first?.action, "scoped",
+                       "row-scoped column and cell must share the same storage slot")
+    }
+
+    // MARK: - Shared field position regression (cross-page)
+
     func testSharedFieldPositionId_resolvesToCorrectPage() {
         let (editor, _) = makeNavigationEditor()
         let page1Path = "\(NavigationSample.page1ID)/\(NavigationSample.sharedFieldPositionID)"
@@ -102,12 +175,11 @@ final class DecoratorPathResolutionTests: XCTestCase {
 
         XCTAssertEqual(editor.field(fieldID: NavigationSample.page1FieldID)?.decorators?.first?.action, "p1")
         XCTAssertEqual(editor.field(fieldID: NavigationSample.page2FieldID)?.decorators?.first?.action, "p2")
-        // No cross-contamination
         XCTAssertNil(editor.field(fieldID: NavigationSample.page1FieldID)?.decorators?.first(where: { $0.action == "p2" }))
         XCTAssertNil(editor.field(fieldID: NavigationSample.page2FieldID)?.decorators?.first(where: { $0.action == "p1" }))
     }
 
-    // MARK: - Invalid paths
+    // MARK: - Invalid paths — structural
 
     func testInvalidPageId_returnsEmptyAndFiresOnError() {
         let (editor, mock) = makeChangerHandlerEditor()
@@ -115,13 +187,11 @@ final class DecoratorPathResolutionTests: XCTestCase {
         XCTAssertEqual(editor.getDecorators(path: path).count, 0)
         XCTAssertEqual(mock.decoratorErrorCount, 1)
         XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
-        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains(path) ?? false)
     }
 
     func testInvalidFieldPositionId_firesOnError() {
         let (editor, mock) = makeChangerHandlerEditor()
-        let path = "\(ChangerHandlerSample.pageID)/bogusFp"
-        _ = editor.getDecorators(path: path)
+        _ = editor.getDecorators(path: "\(ChangerHandlerSample.pageID)/bogusFp")
         XCTAssertEqual(mock.decoratorErrorCount, 1)
     }
 
@@ -133,7 +203,7 @@ final class DecoratorPathResolutionTests: XCTestCase {
 
     func testPathWithExtraSlashes_parsesCorrectly() {
         let (editor, mock) = makeChangerHandlerEditor()
-        // Double slashes between segments should still parse to 2 segments → field path.
+        // Double slashes must collapse (empty segments filtered)
         let path = "\(ChangerHandlerSample.pageID)//\(ChangerHandlerSample.tableFieldPositionID)"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "fieldA")])
         XCTAssertEqual(mock.decoratorErrorCount, 0)
@@ -148,34 +218,66 @@ final class DecoratorPathResolutionTests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "fieldA")
     }
 
-    // MARK: - Extra path segments
+    // MARK: - Invalid grammar shapes
 
-    /// parsePath reads only the first 4 segments and silently discards the rest.
-    /// A 5-segment path resolves as a valid column path — the extra segment is ignored.
-    func testPathWithExtraSegments_resolvesAsColumnPath() {
+    /// `rows` / `columns` must appear at terminal positions — anything after rejects.
+    func testInvalidGrammar_rowsFollowedByExtra_firesOnError() {
         let (editor, mock) = makeChangerHandlerEditor()
-        let path = "\(ChangerHandlerSample.tableColumnPath())/extraSegment"
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "extra")])
-        XCTAssertEqual(mock.decoratorErrorCount, 0,
-                       "extra segments are silently discarded by parsePath")
-        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
-        let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
-        XCTAssertEqual(col?.decorators?.first?.action, "extra")
+        let path = "\(ChangerHandlerSample.tableCommonRowsPath())/extra"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "extra segments after /rows must reject")
     }
 
-    // MARK: - Schema key resolution behaviour (verified via the public API result)
+    func testInvalidGrammar_columnsMissingId_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/columns"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "columns with no id must reject")
+    }
 
-    // MARK: - rowId / columnId validation (resolver must reject unknown IDs)
+    func testInvalidGrammar_schemasMissingKey_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/schemas"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "schemas with no key must reject")
+    }
+
+    func testInvalidGrammar_schemasOnTable_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // Tables have no schema tree — `/schemas/...` must reject
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/schemas/anyKey/rows"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "tables must reject the schemas keyword")
+    }
+
+    func testInvalidGrammar_rowFollowedByRows_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // `fp/rowID/rows` isn't defined — you need /schemas/sk/rows to descend into children.
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/\(ChangerHandlerSample.tableRowID)/rows"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
+    }
+
+    func testInvalidGrammar_consecutiveRowIDsCollection_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        // Two row ids back-to-back without /schemas/ between them is ill-formed for collections.
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/\(ChangerHandlerSample.collectionNestedRowID)"
+        _ = editor.getDecorators(path: path)
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "consecutive row ids without /schemas/ must reject (or be interpreted as cell on a non-existent column → also an error)")
+    }
+
+    // MARK: - Unknown IDs
 
     func testInvalidRowId_collection_firesOnError_doesNotPersist() {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/unknownRowID"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghost")])
-
-        XCTAssertEqual(mock.decoratorErrorCount, 1,
-                       "unknown rowId on collection must fire a decoratorError")
-        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
-
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
         for (_, schema) in field?.schema ?? [:] {
             XCTAssertNil(schema.rowDecorators?.first(where: { $0.action == "ghost" }))
@@ -186,64 +288,15 @@ final class DecoratorPathResolutionTests: XCTestCase {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/bogusRowId"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostTableRow")])
-
-        XCTAssertEqual(mock.decoratorErrorCount, 1,
-                       "unknown rowId on table must fire a decoratorError (no silent writes)")
+        XCTAssertEqual(mock.decoratorErrorCount, 1)
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
-        XCTAssertNil(field?.rowDecorators?.first(where: { $0.action == "ghostTableRow" }),
-                     "the decorator must not leak into the field's global rowDecorators list")
-    }
-
-    // MARK: - Cross-schema rowId / columnId mismatch
-
-    /// Passes a root-schema rowId with a nested-schema columnId. The column
-    /// exists in the field but belongs to a different schema than the row.
-    /// The resolver must reject this — otherwise the setter silently no-ops
-    /// because the column is not found in the row's resolved schema.
-    func testCrossSchemaColumnMismatch_rootRowNestedColumn_firesOnError() {
-        let (editor, mock) = makeChangerHandlerEditor()
-        // Root rowId + nested columnId → cross-schema mismatch
-        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/\(ChangerHandlerSample.collectionNestedColumnID)"
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "crossSchema")])
-
-        XCTAssertEqual(mock.decoratorErrorCount, 1,
-                       "cross-schema rowId/columnId mismatch must fire a decoratorError")
-        XCTAssertTrue(mock.lastDecoratorErrorMessage?.contains("Failed to resolve path") ?? false)
-
-        // Must not write to any schema
-        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        for (_, schema) in field?.schema ?? [:] {
-            for col in schema.tableColumns ?? [] {
-                XCTAssertNil(col.decorators?.first(where: { $0.action == "crossSchema" }),
-                             "cross-schema decorator must not leak into any schema's columns")
-            }
-        }
-    }
-
-    /// The inverse: nested-schema rowId with a root-schema columnId.
-    func testCrossSchemaColumnMismatch_nestedRowRootColumn_firesOnError() {
-        let (editor, mock) = makeChangerHandlerEditor()
-        // Nested rowId + root columnId → cross-schema mismatch
-        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionNestedRowID)/\(ChangerHandlerSample.collectionRootColumnID)"
-        editor.addDecorators(path: path, decorators: [makeDecorator(action: "crossSchemaReverse")])
-
-        XCTAssertEqual(mock.decoratorErrorCount, 1,
-                       "cross-schema rowId/columnId mismatch must fire a decoratorError")
-
-        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        for (_, schema) in field?.schema ?? [:] {
-            for col in schema.tableColumns ?? [] {
-                XCTAssertNil(col.decorators?.first(where: { $0.action == "crossSchemaReverse" }),
-                             "cross-schema decorator must not leak into any schema's columns")
-            }
-        }
+        XCTAssertNil(field?.rowDecorators?.first(where: { $0.action == "ghostTableRow" }))
     }
 
     func testInvalidColumnId_collection_firesOnError_doesNotPersist() {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/bogusColId"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostCol")])
-
         XCTAssertEqual(mock.decoratorErrorCount, 1)
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
         for (_, schema) in field?.schema ?? [:] {
@@ -257,11 +310,24 @@ final class DecoratorPathResolutionTests: XCTestCase {
         let (editor, mock) = makeChangerHandlerEditor()
         let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.tableFieldPositionID)/\(ChangerHandlerSample.tableRowID)/bogusColId"
         editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghostTableCol")])
-
         XCTAssertEqual(mock.decoratorErrorCount, 1)
-        let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
-        for col in field?.tableColumns ?? [] {
-            XCTAssertNil(col.decorators?.first(where: { $0.action == "ghostTableCol" }))
+    }
+
+    // MARK: - Cross-schema mismatch
+
+    /// Root row id + nested column id on the same path must reject — the column
+    /// isn't part of the row's resolved schema.
+    func testCrossSchemaColumnMismatch_rootRowNestedColumn_firesOnError() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let path = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/\(ChangerHandlerSample.collectionNestedColumnID)"
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "crossSchema")])
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "cross-schema rowId/columnId mismatch must reject")
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        for (_, schema) in field?.schema ?? [:] {
+            for col in schema.tableColumns ?? [] {
+                XCTAssertNil(col.decorators?.first(where: { $0.action == "crossSchema" }))
+            }
         }
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPathResolutionTests.swift
@@ -330,4 +330,32 @@ final class DecoratorPathResolutionTests: XCTestCase {
             }
         }
     }
+
+    /// Regression guard: nested row hops must be validated against the current branch,
+    /// not just "row exists somewhere in the field".
+    /// Here we use the ROOT row id at a nested hop:
+    ///   fp/{rootRow}/schemas/{nestedSchema}/{rootRow}
+    /// That trailing row id exists globally in the collection, but not under nestedSchema.
+    /// Expected: path resolve failure + no decorate/state mutation.
+    func testInvalidNestedHop_rowExistsGloballyButNotUnderCurrentBranch_rejectsPath() {
+        let (editor, mock) = makeChangerHandlerEditor()
+        let invalidPath = "\(ChangerHandlerSample.pageID)/\(ChangerHandlerSample.collectionFieldPositionID)/\(ChangerHandlerSample.collectionRootRowID)/schemas/\(ChangerHandlerSample.collectionNestedSchemaKey)/\(ChangerHandlerSample.collectionRootRowID)"
+
+        let before = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNotEqual(before?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true)
+
+        editor.addDecorators(path: invalidPath, decorators: [makeDecorator(action: "invalidNestedHop")])
+
+        XCTAssertEqual(mock.decoratorErrorCount, 1,
+                       "invalid nested hop should fail path resolution")
+        let after = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNotEqual(after?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true,
+                          "failed path must not flip decorate")
+        let nested = findValueElement(in: after, hops: [
+            (ChangerHandlerSample.collectionRootSchemaKey, ChangerHandlerSample.collectionRootRowID),
+            (ChangerHandlerSample.collectionNestedSchemaKey, ChangerHandlerSample.collectionNestedRowID),
+        ])
+        XCTAssertNil(nested?.decorators?.all.first(where: { $0.action == "invalidNestedHop" }),
+                     "failed path must not write row-self decorators")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -296,6 +296,27 @@ final class DecoratorPublicAPITests: XCTestCase {
                        "decorate must stay true because a common decorator still exists")
     }
 
+    /// Regression guard: deleted rows must not keep `decorate` pinned on.
+    /// If the only remaining row-self decorator belongs to a soft-deleted row,
+    /// removing the last common row decorator should flip `decorate` off.
+    func testDecorateFlag_table_deletedRowSelfDoesNotKeepDecoratePinned() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "common")])
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+
+        let fieldIdentifier = editor.getFieldIdentifier(for: ChangerHandlerSample.tableFieldID)
+        _ = editor.deleteRows(rowIDs: [ChangerHandlerSample.tableRowID],
+                              fieldIdentifier: fieldIdentifier,
+                              shouldSendEvent: false)
+        editor.removeDecorator(path: ChangerHandlerSample.tableCommonRowsPath(), action: "common")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                          "row-self decorators on deleted rows must be ignored when deciding decorate emptiness")
+    }
+
     // -- Collection root schema
 
     func testDecorateFlag_collectionRoot_disabledAfterRemovingLastCommonRowsDecorator() {
@@ -335,6 +356,39 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
                         .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
                        "root schema's decorate must stay true because a row-specific decorator remains")
+    }
+
+    /// Same deleted-row regression at collection root schema scope.
+    func testDecorateFlag_collectionRoot_deletedRowSelfDoesNotKeepDecoratePinned() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "common")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                        .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+
+        // Simulate a soft-deleted root row (collection delete APIs hard-delete).
+        if var field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID) {
+            var rows = field.valueToValueElements ?? []
+            if let idx = rows.firstIndex(where: { $0.id == ChangerHandlerSample.collectionRootRowID }) {
+                var row = rows[idx]
+                row.setDeleted()
+                rows[idx] = row
+                field.value = ValueUnion.valueElementArray(rows)
+                editor.updateField(field: field)
+            } else {
+                XCTFail("Expected sample root collection row not found")
+            }
+        } else {
+            XCTFail("Expected sample collection field not found")
+        }
+
+        editor.removeDecorator(path: ChangerHandlerSample.collectionRootCommonRowsPath(), action: "common")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                            .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                          "deleted root row decorators must not keep root decorate true")
     }
 
     // -- Collection nested schema

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -497,4 +497,101 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
                        "decorate must remain true after a displayable update")
     }
+
+    // MARK: - Soft-deleted row path resolution
+    //
+    // A path that targets a soft-deleted row (`deleted == true`) must resolve to
+    // nil at the row level. Reads return `[]`; writes are silent no-ops that
+    // never mutate the deleted element.
+
+    /// Helper: soft-delete a single root row in the sample collection field.
+    private func softDeleteCollectionRootRow(_ editor: DocumentEditor, rowID: String) {
+        guard var field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID) else {
+            XCTFail("Expected sample collection field"); return
+        }
+        var rows = field.valueToValueElements ?? []
+        guard let idx = rows.firstIndex(where: { $0.id == rowID }) else {
+            XCTFail("Expected sample row \(rowID)"); return
+        }
+        var row = rows[idx]
+        row.setDeleted()
+        rows[idx] = row
+        field.value = ValueUnion.valueElementArray(rows)
+        editor.updateField(field: field)
+    }
+
+    /// Helper: soft-delete a row in the table field (table value array).
+    private func softDeleteTableRow(_ editor: DocumentEditor, rowID: String) {
+        guard var field = editor.field(fieldID: ChangerHandlerSample.tableFieldID) else {
+            XCTFail("Expected sample table field"); return
+        }
+        var rows = field.valueToValueElements ?? []
+        guard let idx = rows.firstIndex(where: { $0.id == rowID }) else {
+            XCTFail("Expected sample row \(rowID)"); return
+        }
+        var row = rows[idx]
+        row.setDeleted()
+        rows[idx] = row
+        field.value = ValueUnion.valueElementArray(rows)
+        editor.updateField(field: field)
+    }
+
+    func testGetDecorators_tableRowSelf_deletedRow_returnsEmpty() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a")])
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1)
+
+        softDeleteTableRow(editor, rowID: ChangerHandlerSample.tableRowID)
+
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "soft-deleted row paths must resolve to no decorators")
+    }
+
+    func testGetDecorators_tableCell_deletedRow_returnsEmpty() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCellPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "c")])
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1)
+
+        softDeleteTableRow(editor, rowID: ChangerHandlerSample.tableRowID)
+
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "cell decorators on a soft-deleted row must not be returned")
+    }
+
+    func testGetDecorators_collectionRootRowSelf_deletedRow_returnsEmpty() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a")])
+        XCTAssertEqual(editor.getDecorators(path: path).count, 1)
+
+        softDeleteCollectionRootRow(editor, rowID: ChangerHandlerSample.collectionRootRowID)
+
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "soft-deleted root row paths must resolve to no decorators")
+    }
+
+    func testAddDecorators_onDeletedRow_doesNotMutateUnderlyingRow() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableRowSelfPath()
+        softDeleteTableRow(editor, rowID: ChangerHandlerSample.tableRowID)
+
+        // Snapshot the deleted row's existing decorators.
+        let beforeRow = editor.field(fieldID: ChangerHandlerSample.tableFieldID)?
+            .valueToValueElements?
+            .first(where: { $0.id == ChangerHandlerSample.tableRowID })
+        let beforeCount = beforeRow?.decorators?.all.count ?? 0
+
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "ghost")])
+
+        let afterRow = editor.field(fieldID: ChangerHandlerSample.tableFieldID)?
+            .valueToValueElements?
+            .first(where: { $0.id == ChangerHandlerSample.tableRowID })
+        let afterCount = afterRow?.decorators?.all.count ?? 0
+        XCTAssertEqual(beforeCount, afterCount,
+                       "writes targeting a deleted row must not mutate its decorators")
+        XCTAssertEqual(editor.getDecorators(path: path).count, 0,
+                       "reads on the deleted row path must remain empty")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -3,7 +3,8 @@
 //  JoyfillTests
 //
 //  Happy-path tests for getDecorators / addDecorators / removeDecorator / updateDecorator
-//  on field, row, and column scopes for both table and collection fields.
+//  across every scope of the new grammar:
+//    field, common rows, row-self, common column, cell.
 //
 
 import XCTest
@@ -23,13 +24,11 @@ final class DecoratorPublicAPITests: XCTestCase {
     func testGetDecorators_returnsWhatWasWritten() {
         let (editor, _) = makeChangerHandlerEditor()
         let path = ChangerHandlerSample.tableFieldPath()
-        let decs = [makeDecorator(action: "a"), makeDecorator(action: "b")]
-        editor.addDecorators(path: path, decorators: decs)
-        let read = editor.getDecorators(path: path)
-        XCTAssertEqual(read.map { $0.action }, ["a", "b"])
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a"), makeDecorator(action: "b")])
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["a", "b"])
     }
 
-    // MARK: - addDecorators
+    // MARK: - addDecorators — field scope
 
     func testAddDecorators_toEmptyField_appendsAll() {
         let (editor, _) = makeChangerHandlerEditor()
@@ -57,45 +56,82 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["first", "second"])
     }
 
-    func testAddDecorators_tableRow_persists() {
+    // MARK: - addDecorators — common rows
+
+    func testAddDecorators_tableCommonRows_persistsOnField() {
         let (editor, _) = makeChangerHandlerEditor()
-        editor.addDecorators(path: ChangerHandlerSample.tableRowPath(),
-                             decorators: [makeDecorator(action: "row1")])
-        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "row1")
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "rows1")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.rowDecorators?.first?.action, "rows1")
     }
 
-    func testAddDecorators_collectionRootRow_persists() {
+    func testAddDecorators_collectionRootCommonRows_persistsOnRootSchema() {
         let (editor, _) = makeChangerHandlerEditor()
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowPath(),
-                             decorators: [makeDecorator(action: "rootRow")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "rootRows")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRow")
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.rowDecorators?.first?.action, "rootRows")
     }
 
-    func testAddDecorators_collectionNestedRow_persistsToCorrectSchema() {
+    func testAddDecorators_collectionNestedCommonRows_persistsOnNestedSchema() {
         let (editor, _) = makeChangerHandlerEditor()
-        editor.addDecorators(path: ChangerHandlerSample.collectionNestedRowPath(),
-                             decorators: [makeDecorator(action: "nestedRow")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "nestedRows")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRow")
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.rowDecorators?.first?.action, "nestedRows")
     }
 
-    func testAddDecorators_tableColumn_persists() {
+    // MARK: - addDecorators — row-self
+
+    func testAddDecorators_tableRowSelf_persistsOnValueElement() {
         let (editor, _) = makeChangerHandlerEditor()
-        editor.addDecorators(path: ChangerHandlerSample.tableColumnPath(),
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "self1")])
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.tableFieldID),
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "self1")
+    }
+
+    func testAddDecorators_collectionRootRowSelf_persistsOnValueElement() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rootSelf")])
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.collectionFieldID),
+                                   hops: [(ChangerHandlerSample.collectionRootSchemaKey,
+                                           ChangerHandlerSample.collectionRootRowID)])
+        XCTAssertEqual(row?.decorators?.all.first?.action, "rootSelf")
+    }
+
+    // MARK: - addDecorators — common column
+
+    func testAddDecorators_tableCommonColumn_persists() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonColumnPath(),
                              decorators: [makeDecorator(action: "col1")])
         let field = editor.field(fieldID: ChangerHandlerSample.tableFieldID)
         let col = field?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.tableColumnID })
         XCTAssertEqual(col?.decorators?.first?.action, "col1")
     }
 
-    func testAddDecorators_collectionColumn_persists() {
+    func testAddDecorators_collectionRootCommonColumn_persists() {
         let (editor, _) = makeChangerHandlerEditor()
-        editor.addDecorators(path: ChangerHandlerSample.collectionRootColumnPath(),
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonColumnPath(),
                              decorators: [makeDecorator(action: "rootCol")])
         let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
-        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
+        let col = field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?
+            .tableColumns?.first(where: { $0.id == ChangerHandlerSample.collectionRootColumnID })
         XCTAssertEqual(col?.decorators?.first?.action, "rootCol")
+    }
+
+    // MARK: - addDecorators — cell
+
+    func testAddDecorators_tableCell_persistsOnValueElementCells() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCellPath(),
+                             decorators: [makeDecorator(action: "cell1")])
+        let row = findValueElement(in: editor.field(fieldID: ChangerHandlerSample.tableFieldID),
+                                   hops: [(nil, ChangerHandlerSample.tableRowID)])
+        XCTAssertEqual(row?.decorators?.cells[ChangerHandlerSample.tableColumnID]?.first?.action, "cell1")
     }
 
     // MARK: - removeDecorator
@@ -103,10 +139,7 @@ final class DecoratorPublicAPITests: XCTestCase {
     func testRemoveDecorator_existingAction_reducesList() {
         let (editor, _) = makeChangerHandlerEditor()
         let path = ChangerHandlerSample.tableFieldPath()
-        editor.addDecorators(path: path, decorators: [
-            makeDecorator(action: "a"),
-            makeDecorator(action: "b"),
-        ])
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "a"), makeDecorator(action: "b")])
         editor.removeDecorator(path: path, action: "a")
         XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["b"])
     }
@@ -119,6 +152,22 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.getDecorators(path: path).count, 0)
     }
 
+    func testRemoveDecorator_rowSelf_roundTrip() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "keep"), makeDecorator(action: "toss")])
+        editor.removeDecorator(path: path, action: "toss")
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["keep"])
+    }
+
+    func testRemoveDecorator_cell_roundTrip() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCellPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "cellKeep"), makeDecorator(action: "cellToss")])
+        editor.removeDecorator(path: path, action: "cellToss")
+        XCTAssertEqual(editor.getDecorators(path: path).map { $0.action }, ["cellKeep"])
+    }
+
     // MARK: - updateDecorator
 
     func testUpdateDecorator_existingAction_replacesAtSameIndex() {
@@ -126,15 +175,15 @@ final class DecoratorPublicAPITests: XCTestCase {
         let path = ChangerHandlerSample.tableFieldPath()
         editor.addDecorators(path: path, decorators: [
             makeDecorator(action: "a", icon: "flag", label: "Flag", color: "#FF0000"),
-            makeDecorator(action: "b", icon: "eye", label: "Eye", color: "#00FF00"),
+            makeDecorator(action: "b", icon: "eye",  label: "Eye",  color: "#00FF00"),
         ])
-        let replacement = makeDecorator(action: "a", icon: "camera", label: "Updated", color: "#0000FF")
-        editor.updateDecorator(path: path, action: "a", decorator: replacement)
+        editor.updateDecorator(path: path, action: "a",
+                               decorator: makeDecorator(action: "a", icon: "camera", label: "Updated", color: "#0000FF"))
         let read = editor.getDecorators(path: path)
-        XCTAssertEqual(read.map { $0.action }, ["a", "b"]) // index preserved
+        XCTAssertEqual(read.map { $0.action }, ["a", "b"])
         XCTAssertEqual(read.first?.label, "Updated")
         XCTAssertEqual(read.first?.color, "#0000FF")
-        XCTAssertEqual(read.first?.icon, "camera")
+        XCTAssertEqual(read.first?.icon,  "camera")
     }
 
     func testUpdateDecorator_preservesOtherDecorators() {
@@ -145,7 +194,8 @@ final class DecoratorPublicAPITests: XCTestCase {
             makeDecorator(action: "b"),
             makeDecorator(action: "c"),
         ])
-        editor.updateDecorator(path: path, action: "b", decorator: makeDecorator(action: "b", label: "B-prime"))
+        editor.updateDecorator(path: path, action: "b",
+                               decorator: makeDecorator(action: "b", label: "B-prime"))
         let read = editor.getDecorators(path: path)
         XCTAssertEqual(read.map { $0.action }, ["a", "b", "c"])
         XCTAssertEqual(read[1].label, "B-prime")

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -222,4 +222,225 @@ final class DecoratorPublicAPITests: XCTestCase {
                              decorators: [makeDecorator(action: "live")])
         XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorators?.first?.action, "live")
     }
+
+    // MARK: - decorate flag: flips off when scope becomes empty
+    //
+    // Mirror of ensureDecorateEnabled on add. After remove/update, if the
+    // affected scope (table field, root schema, or nested schema) has no
+    // displayable decorators left — neither common rowDecorators nor any
+    // row-specific decorator on any row in that scope — decorate flips to false.
+
+    // -- Table field
+
+    func testDecorateFlag_table_disabledAfterRemovingLastCommonRowsDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                          "decorate should flip off once the last common row decorator is removed")
+    }
+
+    func testDecorateFlag_table_disabledAfterRemovingLastRowSelfDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                          "decorate should flip off once the last row-self decorator is removed")
+    }
+
+    func testDecorateFlag_table_staysTrueWhenAnotherCommonRowsDecoratorRemains() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [
+            makeDecorator(action: "a"),
+            makeDecorator(action: "b"),
+        ])
+
+        editor.removeDecorator(path: path, action: "a")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "decorate must stay true while any common row decorator remains")
+    }
+
+    func testDecorateFlag_table_staysTrueWhenRowSelfExistsAfterCommonRemoved() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "common")])
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.tableCommonRowsPath(), action: "common")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "decorate must stay true because a row-specific decorator still exists")
+    }
+
+    func testDecorateFlag_table_staysTrueWhenCommonExistsAfterRowSelfRemoved() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "common")])
+        editor.addDecorators(path: ChangerHandlerSample.tableRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.tableRowSelfPath(), action: "rowSelf")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "decorate must stay true because a common decorator still exists")
+    }
+
+    // -- Collection root schema
+
+    func testDecorateFlag_collectionRoot_disabledAfterRemovingLastCommonRowsDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                        .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                            .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                          "root schema's decorate should flip off after last common decorator removed")
+    }
+
+    func testDecorateFlag_collectionRoot_disabledAfterRemovingLastRowSelfDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionRootRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                            .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+    }
+
+    func testDecorateFlag_collectionRoot_staysTrueWhenRowSelfExistsAfterCommonRemoved() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "common")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootRowSelfPath(),
+                             decorators: [makeDecorator(action: "rowSelf")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.collectionRootCommonRowsPath(), action: "common")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                        .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                       "root schema's decorate must stay true because a row-specific decorator remains")
+    }
+
+    // -- Collection nested schema
+
+    func testDecorateFlag_collectionNested_disabledAfterRemovingLastCommonRowsDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionNestedCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                        .schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true)
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                            .schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true)
+    }
+
+    func testDecorateFlag_collectionNested_disabledAfterRemovingLastRowSelfDecorator() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.collectionNestedRowSelfPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only")])
+
+        editor.removeDecorator(path: path, action: "only")
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                            .schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true)
+    }
+
+    // -- Scope isolation
+
+    /// Removing a table decorator must not flip the collection's decorate flag.
+    func testDecorateFlag_tableRemoval_doesNotAffectCollectionDecorate() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.tableCommonRowsPath(),
+                             decorators: [makeDecorator(action: "t")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "c")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.tableCommonRowsPath(), action: "t")
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.collectionFieldID)?
+                        .schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                       "collection's decorate must not flip off when a table decorator is removed")
+    }
+
+    /// Removing from nested schema must not flip the root schema's decorate off.
+    func testDecorateFlag_nestedRemoval_doesNotFlipRootDecorate() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "root")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "nested")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.collectionNestedCommonRowsPath(), action: "nested")
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true,
+                       "root schema's decorate must stay true — only the nested schema scope went empty")
+        XCTAssertNotEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true,
+                          "nested schema's decorate must flip off")
+    }
+
+    /// Removing from root must not flip the nested schema's decorate off.
+    func testDecorateFlag_rootRemoval_doesNotFlipNestedDecorate() {
+        let (editor, _) = makeChangerHandlerEditor()
+        editor.addDecorators(path: ChangerHandlerSample.collectionRootCommonRowsPath(),
+                             decorators: [makeDecorator(action: "root")])
+        editor.addDecorators(path: ChangerHandlerSample.collectionNestedCommonRowsPath(),
+                             decorators: [makeDecorator(action: "nested")])
+
+        editor.removeDecorator(path: ChangerHandlerSample.collectionRootCommonRowsPath(), action: "root")
+
+        let field = editor.field(fieldID: ChangerHandlerSample.collectionFieldID)
+        XCTAssertNotEqual(field?.schema?[ChangerHandlerSample.collectionRootSchemaKey]?.decorate, true)
+        XCTAssertEqual(field?.schema?[ChangerHandlerSample.collectionNestedSchemaKey]?.decorate, true,
+                       "nested schema's decorate must stay true — only the root scope went empty")
+    }
+
+    // -- updateDecorator path
+
+    /// Updating a decorator to remove its icon AND label makes it non-displayable.
+    /// If it was the only one, decorate must flip off.
+    func testDecorateFlag_disabledAfterUpdateMakesLastDecoratorNonDisplayable() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only", icon: "flag", label: "Flag")])
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true)
+
+        // Update to a decorator with empty icon AND empty label → isDisplayable = false
+        let emptyDecorator = makeDecorator(action: "only", icon: "", label: "")
+        editor.updateDecorator(path: path, action: "only", decorator: emptyDecorator)
+
+        XCTAssertNotEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                          "decorate should flip off when the only remaining decorator becomes non-displayable")
+    }
+
+    /// Updating a decorator but keeping it displayable must leave decorate on.
+    func testDecorateFlag_staysTrueAfterUpdateKeepsDecoratorDisplayable() {
+        let (editor, _) = makeChangerHandlerEditor()
+        let path = ChangerHandlerSample.tableCommonRowsPath()
+        editor.addDecorators(path: path, decorators: [makeDecorator(action: "only", icon: "flag", label: "Flag")])
+
+        editor.updateDecorator(path: path, action: "only",
+                               decorator: makeDecorator(action: "only", icon: "warning", label: "Warning"))
+
+        XCTAssertEqual(editor.field(fieldID: ChangerHandlerSample.tableFieldID)?.decorate, true,
+                       "decorate must remain true after a displayable update")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorTestSupport.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorTestSupport.swift
@@ -33,16 +33,64 @@ enum ChangerHandlerSample {
     static let collectionNestedRowID     = "68575bc1921b69c15fad6c3f"
     static let collectionNestedColumnID  = "68575394ffa57501fba78c4c"
 
-    // Path helpers
-    static func tableFieldPath()  -> String { "\(pageID)/\(tableFieldPositionID)" }
-    static func tableRowPath()    -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)" }
-    static func tableColumnPath() -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)/\(tableColumnID)" }
+    // MARK: - Path helpers (new grammar)
+    //
+    // Grammar reference:
+    //   /rows                    → common rows at that level
+    //   /columns/{col}           → common column at that level
+    //   /{rowID}                 → row-self (row's own decorators)
+    //   /{rowID}/{col}           → cell (bare column id after row)
+    //   /{rowID}/columns/{col}   → row-scoped column (aliases cell)
+    //   /schemas/{sk}/...        → descend into child schema (collection only)
 
+    // -- Field level
+    static func tableFieldPath()      -> String { "\(pageID)/\(tableFieldPositionID)" }
     static func collectionFieldPath() -> String { "\(pageID)/\(collectionFieldPositionID)" }
-    static func collectionRootRowPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)" }
-    static func collectionNestedRowPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionNestedRowID)" }
-    static func collectionRootColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/\(collectionRootColumnID)" }
-    static func collectionNestedColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionNestedRowID)/\(collectionNestedColumnID)" }
+
+    // -- Table: common row / column
+    static func tableCommonRowsPath()   -> String { "\(pageID)/\(tableFieldPositionID)/rows" }
+    static func tableCommonColumnPath() -> String { "\(pageID)/\(tableFieldPositionID)/columns/\(tableColumnID)" }
+
+    // -- Table: row-self / cell / row-scoped column
+    static func tableRowSelfPath()         -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)" }
+    static func tableCellPath()            -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)/\(tableColumnID)" }
+    static func tableRowScopedColumnPath() -> String { "\(pageID)/\(tableFieldPositionID)/\(tableRowID)/columns/\(tableColumnID)" }
+
+    // -- Collection root schema: common row / column
+    static func collectionRootCommonRowsPath()   -> String { "\(pageID)/\(collectionFieldPositionID)/rows" }
+    static func collectionRootCommonColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/columns/\(collectionRootColumnID)" }
+
+    // -- Collection root schema: row-self / cell / row-scoped column
+    static func collectionRootRowSelfPath()         -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)" }
+    static func collectionRootCellPath()            -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/\(collectionRootColumnID)" }
+    static func collectionRootRowScopedColumnPath() -> String { "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/columns/\(collectionRootColumnID)" }
+
+    // -- Collection nested schema (reached via root row, full chain required)
+    static func collectionNestedCommonRowsPath() -> String {
+        "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/schemas/\(collectionNestedSchemaKey)/rows"
+    }
+    static func collectionNestedCommonColumnPath() -> String {
+        "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/schemas/\(collectionNestedSchemaKey)/columns/\(collectionNestedColumnID)"
+    }
+    static func collectionNestedRowSelfPath() -> String {
+        "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/schemas/\(collectionNestedSchemaKey)/\(collectionNestedRowID)"
+    }
+    static func collectionNestedCellPath() -> String {
+        "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/schemas/\(collectionNestedSchemaKey)/\(collectionNestedRowID)/\(collectionNestedColumnID)"
+    }
+    static func collectionNestedRowScopedColumnPath() -> String {
+        "\(pageID)/\(collectionFieldPositionID)/\(collectionRootRowID)/schemas/\(collectionNestedSchemaKey)/\(collectionNestedRowID)/columns/\(collectionNestedColumnID)"
+    }
+
+    // MARK: Deprecated compatibility aliases
+    // (the original names — kept so older tests compile while migration is in progress)
+    static func tableRowPath()                -> String { tableRowSelfPath() }
+    static func tableColumnPath()             -> String { tableCellPath() }
+    static func collectionRootRowPath()       -> String { collectionRootRowSelfPath() }
+    static func collectionRootColumnPath()    -> String { collectionRootCellPath() }
+    /// Full chain required — the old `fp/nestedRowID` spelling no longer resolves.
+    static func collectionNestedRowPath()     -> String { collectionNestedRowSelfPath() }
+    static func collectionNestedColumnPath()  -> String { collectionNestedCellPath() }
 }
 
 /// Constants for `Navigation.json` — used only for the shared-field-position-ID regression test.
@@ -77,6 +125,28 @@ class MockDecoratorEvents: FormChangeEvent {
     func onUpload(event: UploadEvent) {}
     func onCapture(event: CaptureEvent) {}
     func onError(error: JoyfillError) { capturedErrors.append(error) }
+}
+
+// MARK: - Value-element tree walker (for storage-level assertions)
+
+/// Walks the row tree in `field.valueToValueElements` by the given chain of row IDs,
+/// descending via `childrens[schemaKey]` between hops. Returns the element at the tip.
+/// Pass `hops` as `[(schemaKey?, rowID)]` — `schemaKey` is `nil` for the root hop.
+func findValueElement(in field: JoyDocField?,
+                      hops: [(schemaKey: String?, rowID: String)]) -> ValueElement? {
+    guard let field = field, !hops.isEmpty else { return nil }
+    var current: [ValueElement] = field.valueToValueElements ?? []
+    var tip: ValueElement? = nil
+    for (i, hop) in hops.enumerated() {
+        if i > 0 {
+            guard let sk = hop.schemaKey,
+                  let children = tip?.childrens?[sk]?.valueToValueElements else { return nil }
+            current = children
+        }
+        guard let el = current.first(where: { $0.id == hop.rowID }) else { return nil }
+        tip = el
+    }
+    return tip
 }
 
 // MARK: - Decorator factory

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
@@ -25,7 +25,7 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
     
     private func createCollectionViewModel(documentEditor: DocumentEditor) async throws -> CollectionViewModel {
         let field = documentEditor.field(fieldID: tableFieldID)
-        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible, visibleLimitInFields: documentEditor.decoratorConfig.visibleLimitInFields)
         let tableDataModel = TableDataModel(
             fieldHeaderModel: fieldHeaderModel,
             mode: Mode.fill,

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerMetadataTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerMetadataTests.swift
@@ -46,7 +46,7 @@ final class DocumentEditorChangeHandlerMetadataTests: XCTestCase {
     
     private func createCollectionViewModel(documentEditor: DocumentEditor) async throws -> CollectionViewModel {
         let field = documentEditor.field(fieldID: collectionFieldID)
-        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible, visibleLimitInFields: documentEditor.decoratorConfig.visibleLimitInFields)
         let tableDataModel = TableDataModel(
             fieldHeaderModel: fieldHeaderModel,
             mode: Mode.fill,
@@ -327,7 +327,7 @@ final class DocumentEditorChangeHandlerMetadataTests: XCTestCase {
 
     private func createTableViewModel(documentEditor: DocumentEditor) -> TableViewModel {
         let field = documentEditor.field(fieldID: tableFieldID)
-        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible, visibleLimitInFields: documentEditor.decoratorConfig.visibleLimitInFields)
         let tableDataModel = TableDataModel(
             fieldHeaderModel: fieldHeaderModel,
             mode: Mode.fill,

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
@@ -25,7 +25,7 @@ final class TableViewModelDocumentEditorDelegateTests: XCTestCase {
     
     private func createTableViewModel(documentEditor: DocumentEditor) -> TableViewModel {
         let field = documentEditor.field(fieldID: tableFieldID)
-        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible)
+        let fieldHeaderModel = FieldHeaderModel(title: field?.title, required: field?.required, tipDescription: field?.tipDescription, tipTitle: field?.tipTitle, tipVisible: field?.tipVisible, visibleLimitInFields: documentEditor.decoratorConfig.visibleLimitInFields)
         let tableDataModel = TableDataModel(
             fieldHeaderModel: fieldHeaderModel,
             mode: Mode.fill,

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
@@ -1,0 +1,800 @@
+{
+  "_id" : "691f3762738ed0e8e217abff",
+  "metadata" : {
+
+  },
+  "name" : "QA Template: External Navigator",
+  "createdOn" : 1763653482316,
+  "stage" : "draft",
+  "files" : [
+    {
+      "_id" : "691f3762c80bfb0005c57b48",
+      "styles" : {
+        "margin" : 4
+      },
+      "pages" : [
+        {
+          "padding" : 24,
+          "layout" : "grid",
+          "metadata" : {
+
+          },
+          "width" : 816,
+          "_id" : "69709dc281b4c8ab68c4db52",
+          "presentation" : "normal",
+          "cols" : 8,
+          "margin" : 0,
+          "borderWidth" : 0,
+          "fieldPositions" : [
+            {
+              "_id" : "6970918d350238d0738dd5c9",
+              "x" : 0,
+              "height" : 8,
+              "y" : 9,
+              "width" : 4,
+              "field" : "69709dc23a74ed2c22308a1d",
+              "type" : "text",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "69709192a4e9c0c281851275",
+              "x" : 0,
+              "height" : 8,
+              "y" : 40,
+              "width" : 4,
+              "field" : "69709dc27cd3bfd9bef49981",
+              "type" : "number",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970919451f1adb30fcff9ea",
+              "format" : "MM\/DD\/YYYY hh:mma",
+              "x" : 0,
+              "y" : 48,
+              "height" : 8,
+              "width" : 4,
+              "field" : "69709dc20c0673a9cd2c366a",
+              "type" : "date",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970919a6ce635a6b14913ed",
+              "x" : 0,
+              "targetValue" : "697090a341643827a785818a",
+              "y" : 56,
+              "height" : 7,
+              "width" : 4,
+              "field" : "69709dc2da522657a9776c6d",
+              "type" : "dropdown",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970919b1dae0701c3bc081a",
+              "x" : 0,
+              "targetValue" : "697090a37a793921f4a0288b",
+              "y" : 63,
+              "height" : 15,
+              "width" : 4,
+              "field" : "69709dc240f1e385f35abd36",
+              "type" : "multiSelect",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970926d749c733958ca8d87",
+              "x" : 0,
+              "height" : 23,
+              "y" : 17,
+              "width" : 4,
+              "field" : "69709dc257014ad5cfbece98",
+              "type" : "textarea",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "69709462236416126c166efe",
+              "x" : 0,
+              "height" : 27,
+              "y" : 101,
+              "width" : 8,
+              "field" : "69709dc20ad9d5e65e2ccb17",
+              "type" : "table",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970a3eceab9374076e43a0b",
+              "x" : 0,
+              "height" : 27,
+              "y" : 128,
+              "width" : 8,
+              "field" : "6970a3ec734506f1afc2f7ee",
+              "type" : "collection",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "6970b0a3c9a139feb869a179",
+              "fontSize" : 28,
+              "x" : 0,
+              "y" : 0,
+              "fontWeight" : "bold",
+              "width" : 8,
+              "height" : 9,
+              "field" : "6970b0a3d3b603b2b8d271c0",
+              "type" : "block",
+              "displayType" : "original"
+            },
+            {
+              "_id" : "699dc39215368dcda91a60a6",
+              "x" : 0,
+              "height" : 23,
+              "y" : 78,
+              "width" : 2,
+              "field" : "699dc392acb30df81f5a694a",
+              "type" : "image",
+              "displayType" : "original"
+            }
+          ],
+          "hidden" : false,
+          "height" : 1056,
+          "rowHeight" : 8,
+          "name" : "Page 1 "
+        }
+      ],
+      "pageOrder" : [
+        "69709dc281b4c8ab68c4db52"
+      ],
+      "version" : 1,
+      "views" : [
+
+      ],
+      "metadata" : {
+
+      },
+      "name" : "QA Template: External Navigator"
+    }
+  ],
+  "type" : "template",
+  "categories" : [
+
+  ],
+  "identifier" : "template_691f3762738ed0e8e217abff",
+  "deleted" : false,
+  "fields" : [
+    {
+      "title" : "Text",
+      "identifier" : "field_6970918d6d04413439c39d8b",
+      "value" : "",
+      "type" : "text",
+      "file" : "691f3762c80bfb0005c57b48",
+      "_id" : "69709dc23a74ed2c22308a1d",
+      "hidden" : false
+    },
+    {
+      "_id" : "69709dc257014ad5cfbece98",
+      "file" : "691f3762c80bfb0005c57b48",
+      "identifier" : "field_6970926dcdc8d62e14a5569b",
+      "title" : "Multiline Text",
+      "hidden" : false,
+      "type" : "textarea",
+      "value" : ""
+    },
+    {
+      "file" : "691f3762c80bfb0005c57b48",
+      "value" : "",
+      "options" : [
+        {
+          "_id" : "697090a341643827a785818a",
+          "value" : "Yes",
+          "deleted" : false
+        },
+        {
+          "_id" : "697090a3faaca53c54bbcdd9",
+          "value" : "No",
+          "deleted" : false
+        },
+        {
+          "_id" : "697090a3402da316e4adb130",
+          "value" : "N\/A",
+          "deleted" : false
+        }
+      ],
+      "type" : "dropdown",
+      "identifier" : "field_6970919a75995220e45bfc93",
+      "title" : "Dropdown",
+      "_id" : "69709dc2da522657a9776c6d",
+      "hidden" : false
+    },
+    {
+      "type" : "date",
+      "file" : "691f3762c80bfb0005c57b48",
+      "identifier" : "field_69709194481a4d3136631293",
+      "hidden" : false,
+      "_id" : "69709dc20c0673a9cd2c366a",
+      "title" : "Date Time"
+    },
+    {
+      "value" : "Normal Page ",
+      "type" : "block",
+      "file" : "691f3762c80bfb0005c57b48",
+      "_id" : "6970b0a3d3b603b2b8d271c0",
+      "identifier" : "field_6970b0a3d3b603b2b8d271c0",
+      "title" : "Heading Text"
+    },
+    {
+      "_id" : "699dc392acb30df81f5a694a",
+      "identifier" : "field_699dc392acb30df81f5a694a",
+      "type" : "image",
+      "file" : "691f3762c80bfb0005c57b48",
+      "title" : "Image"
+    },
+    {
+      "schema" : {
+        "level2Table1" : {
+          "tableColumns" : [
+            {
+              "deleted" : false,
+              "_id" : "69e8827e72fb2149cfd944a4",
+              "title" : "Barcode Column",
+              "type" : "barcode",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e8827e72fb2149cfd944a4"
+            },
+            {
+              "deleted" : false,
+              "_id" : "69e882823a859e62135ac927",
+              "title" : "Signature Column",
+              "type" : "signature",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e882823a859e62135ac927"
+            },
+            {
+              "deleted" : false,
+              "_id" : "69e882887e1edd77bb645e65",
+              "title" : "Label Column",
+              "type" : "block",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e882887e1edd77bb645e65"
+            }
+          ],
+          "title" : "New Table",
+          "children" : [
+
+          ],
+          "hidden" : false
+        },
+        "level1Table1" : {
+          "tableColumns" : [
+            {
+              "_id" : "69e88266152a89811c37dc7f",
+              "deleted" : false,
+              "title" : "MultiSelect Column",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e88266152a89811c37dc7f",
+              "type" : "multiSelect",
+              "options" : [
+                {
+                  "_id" : "69e882660d4a54bf8a089d1f",
+                  "value" : "Option 1",
+                  "deleted" : false
+                },
+                {
+                  "_id" : "69e88266d6e9a98702738a47",
+                  "value" : "Option 2",
+                  "deleted" : false
+                },
+                {
+                  "_id" : "69e882669d923c3b5d7c3d56",
+                  "value" : "Option 3",
+                  "deleted" : false
+                }
+              ]
+            },
+            {
+              "deleted" : false,
+              "_id" : "69e88271f01247c98f791c65",
+              "title" : "Number Column",
+              "type" : "number",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e88271f01247c98f791c65"
+            },
+            {
+              "deleted" : false,
+              "_id" : "69e882743566028390aec760",
+              "title" : "Date Column",
+              "type" : "date",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_69e882743566028390aec760"
+            }
+          ],
+          "title" : "New Table",
+          "children" : [
+            "level2Table1"
+          ],
+          "hidden" : false
+        },
+        "collectionSchemaId" : {
+          "title" : "Main Collection",
+          "root" : true,
+          "children" : [
+            "level1Table1"
+          ],
+          "tableColumns" : [
+            {
+              "_id" : "697090a3e627059c068c4858",
+              "title" : "Text",
+              "type" : "text",
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_697090a3e627059c068c4858",
+              "width" : 0
+            },
+            {
+              "width" : 0,
+              "options" : [
+                {
+                  "_id" : "697090a35812c6bf953c6936",
+                  "value" : "High"
+                },
+                {
+                  "_id" : "697090a323ac48fa2ecc1661",
+                  "value" : "Medium"
+                },
+                {
+                  "_id" : "697090a3497d9eb5101cde92",
+                  "value" : "Low"
+                }
+              ],
+              "_id" : "697090a3d15efe9ec5b4db9d",
+              "type" : "dropdown",
+              "title" : "Dropdown",
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_697090a3d15efe9ec5b4db9d"
+            },
+            {
+              "_id" : "697090a3a578efbca5eae4b5",
+              "title" : "Image",
+              "type" : "image",
+              "width" : 0,
+              "identifier" : "6970a3ec734506f1afc2f7ee_column_697090a3a578efbca5eae4b5"
+            }
+          ]
+        }
+      },
+      "hidden" : false,
+      "type" : "collection",
+      "_id" : "6970a3ec734506f1afc2f7ee",
+      "title" : "Collection",
+      "value" : [
+        {
+          "children" : {
+            "level1Table1" : {
+              "value" : [
+                {
+                  "_id" : "69e9b22cfd38eae1ab39d5d9",
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+                        {
+                          "cells" : {
+
+                          },
+                          "_id" : "69e9b22ecf5e7ef1df59f37a",
+                          "children" : {
+
+                          }
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "cells" : {
+
+                          },
+                          "_id" : "69e9b843190b09534329d2b3"
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "cells" : {
+
+                          },
+                          "_id" : "69e9b843dd84c8ae780ace3c"
+                        }
+                      ]
+                    }
+                  },
+                  "cells" : {
+
+                  }
+                },
+                {
+                  "cells" : {
+
+                  },
+                  "_id" : "69e9b841909a6cdaad626432",
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  }
+                },
+                {
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  },
+                  "cells" : {
+
+                  },
+                  "_id" : "69e9b84199b865ea53760fbf"
+                }
+              ]
+            }
+          },
+          "_id" : "6970a40230cef1a03fc19d81",
+          "cells" : {
+
+          }
+        },
+        {
+          "children" : {
+            "level1Table1" : {
+              "value" : [
+                {
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+                        {
+                          "children" : {
+
+                          },
+                          "_id" : "69e9b83d1797c430c53c45bd",
+                          "cells" : {
+
+                          }
+                        },
+                        {
+                          "_id" : "69e9b83d6cb58af1e749d737",
+                          "children" : {
+
+                          },
+                          "cells" : {
+
+                          }
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "_id" : "69e9b83e5f80967f92b160ec",
+                          "cells" : {
+
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "_id" : "69e9b83351a2532dfd602819",
+                  "cells" : {
+
+                  }
+                },
+                {
+                  "cells" : {
+
+                  },
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  },
+                  "_id" : "69e9b8336233adc9f83b8f53"
+                },
+                {
+                  "cells" : {
+
+                  },
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  },
+                  "_id" : "69e9b83c095077a5e1a48848"
+                }
+              ]
+            }
+          },
+          "_id" : "69e9b8309d0510fadb7357c4",
+          "cells" : {
+
+          }
+        },
+        {
+          "cells" : {
+
+          },
+          "children" : {
+            "level1Table1" : {
+              "value" : [
+                {
+                  "_id" : "69e9b835b226373e47bf8f30",
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+                        {
+                          "children" : {
+
+                          },
+                          "cells" : {
+
+                          },
+                          "_id" : "69e9b8384eb45bbdf1de3d97"
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "_id" : "69e9b83988d4b27f10567d4c",
+                          "cells" : {
+
+                          }
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "_id" : "69e9b839f518fe13b241d605",
+                          "cells" : {
+
+                          }
+                        },
+                        {
+                          "children" : {
+
+                          },
+                          "_id" : "69e9b83950919e93c4da4b3f",
+                          "cells" : {
+
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "cells" : {
+
+                  }
+                },
+                {
+                  "cells" : {
+
+                  },
+                  "_id" : "69e9b835815f33f0a5ccd0ea",
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  }
+                },
+                {
+                  "_id" : "69e9b83548aa5efc20a4be9e",
+                  "children" : {
+                    "level2Table1" : {
+                      "value" : [
+
+                      ]
+                    }
+                  },
+                  "cells" : {
+
+                  }
+                }
+              ]
+            }
+          },
+          "_id" : "69e9b831f5d8f86b5ba20088"
+        }
+      ],
+      "file" : "691f3762c80bfb0005c57b48",
+      "identifier" : "field_6970a3ec734506f1afc2f7ee"
+    },
+    {
+      "title" : "Number",
+      "identifier" : "field_6970919241e6da770b498311",
+      "value" : "",
+      "file" : "691f3762c80bfb0005c57b48",
+      "_id" : "69709dc27cd3bfd9bef49981",
+      "hidden" : false,
+      "type" : "number"
+    },
+    {
+      "tableColumnOrder" : [
+        "697090a35fe3eb39f20fa2d8",
+        "697090a3c7a4091e881bcb8d",
+        "6970a3d0679e77d2137d7cc3",
+        "6970a3d2cc86179447a861bd",
+        "6970a3d36cb11bd2082f5fb4",
+        "6970a3d5cf96e6389c348511",
+        "6970a3d6375d0e18d81b40fe",
+        "6970a3d7fae2228b700c13b9",
+        "6970a3d8674ffc5901c6070a"
+      ],
+      "value" : [
+        {
+          "cells" : {
+
+          },
+          "deleted" : false,
+          "_id" : "697090a399394f50229899a9"
+        },
+        {
+          "cells" : {
+
+          },
+          "deleted" : false,
+          "_id" : "697090a359f1d7f5c25ba27a"
+        },
+        {
+          "_id" : "697090a31a65a3133e84bdd2",
+          "cells" : {
+
+          },
+          "deleted" : false
+        }
+      ],
+      "tableColumns" : [
+        {
+          "deleted" : false,
+          "_id" : "697090a35fe3eb39f20fa2d8",
+          "title" : "Text Column",
+          "type" : "text",
+          "width" : 0,
+          "identifier" : "69709462be820cc2c7c39a90_column_697090a35fe3eb39f20fa2d8"
+        },
+        {
+          "_id" : "697090a3c7a4091e881bcb8d",
+          "deleted" : false,
+          "title" : "Dropdown Column",
+          "width" : 0,
+          "identifier" : "69709462be820cc2c7c39a90_column_697090a3c7a4091e881bcb8d",
+          "type" : "dropdown",
+          "options" : [
+            {
+              "_id" : "697090a3c6b86257d402b161",
+              "value" : "Yes",
+              "deleted" : false
+            },
+            {
+              "_id" : "697090a339dbced456e51719",
+              "value" : "No",
+              "deleted" : false
+            },
+            {
+              "_id" : "697090a3e8cf594520ba21b3",
+              "value" : "N\/A",
+              "deleted" : false
+            }
+          ]
+        },
+        {
+          "_id" : "6970a3d0679e77d2137d7cc3",
+          "deleted" : false,
+          "title" : "MultiSelect Column",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d0679e77d2137d7cc3",
+          "type" : "multiSelect",
+          "options" : [
+            {
+              "_id" : "6970a3d0aacd45dfefd11269",
+              "value" : "Option 1",
+              "deleted" : false
+            },
+            {
+              "_id" : "6970a3d0df755396ed99d3e9",
+              "value" : "Option 2",
+              "deleted" : false
+            },
+            {
+              "_id" : "6970a3d0ae7d314c60d88711",
+              "value" : "Option 3",
+              "deleted" : false
+            }
+          ]
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d2cc86179447a861bd",
+          "title" : "Image Column",
+          "type" : "image",
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d2cc86179447a861bd"
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d36cb11bd2082f5fb4",
+          "title" : "Number Column",
+          "type" : "number",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d36cb11bd2082f5fb4"
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d5cf96e6389c348511",
+          "title" : "Date Column",
+          "type" : "date",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d5cf96e6389c348511"
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d6375d0e18d81b40fe",
+          "title" : "Block Column",
+          "type" : "block",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d6375d0e18d81b40fe"
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d7fae2228b700c13b9",
+          "title" : "Barcode Column",
+          "type" : "barcode",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d7fae2228b700c13b9"
+        },
+        {
+          "deleted" : false,
+          "_id" : "6970a3d8674ffc5901c6070a",
+          "title" : "Signature Column",
+          "type" : "signature",
+          "width" : 0,
+          "identifier" : "69709dc20ad9d5e65e2ccb17_column_6970a3d8674ffc5901c6070a"
+        }
+      ],
+      "type" : "table",
+      "rowOrder" : [
+        "697090a399394f50229899a9",
+        "697090a359f1d7f5c25ba27a",
+        "697090a31a65a3133e84bdd2"
+      ],
+      "file" : "691f3762c80bfb0005c57b48",
+      "identifier" : "field_69709462be820cc2c7c39a90",
+      "_id" : "69709dc20ad9d5e65e2ccb17",
+      "title" : "Table",
+      "hidden" : false
+    },
+    {
+      "options" : [
+        {
+          "_id" : "697090a37a793921f4a0288b",
+          "value" : "Yes",
+          "deleted" : false
+        },
+        {
+          "_id" : "697090a3fb7fe623a3c32684",
+          "value" : "No",
+          "deleted" : false
+        },
+        {
+          "_id" : "697090a38e45773b4a132c2c",
+          "value" : "N\/A",
+          "deleted" : false
+        }
+      ],
+      "file" : "691f3762c80bfb0005c57b48",
+      "hidden" : false,
+      "type" : "multiSelect",
+      "value" : [
+
+      ],
+      "identifier" : "field_6970919bd97fff64eb72f865",
+      "title" : "Multiple Choice",
+      "_id" : "69709dc240f1e385f35abd36",
+      "multi" : true
+    }
+  ]
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+// MARK: - IDs from Decorator.json (text field scope)
+
+private let pageID = "69709dc281b4c8ab68c4db52"
+private let fpTextField = "6970918d350238d0738dd5c9"
+
+/// Exercises every DocumentEditor decorator API (`addDecorators`, `updateDecorator`,
+/// `removeDecorator`) against a text field using a fully test-driven workflow:
+/// the test calls `run(...)` to trigger each API, then asserts the UI reflects it
+/// before moving to the next step.
+///
+/// `getDecorators` is read-only with no UI surface and is covered by unit tests.
+final class DecoratorTextFieldAPIUITests: JoyfillUITestsBaseClass {
+
+    override func getJSONFileNameForTest() -> String {
+        return "Decorator"
+    }
+
+    private var fieldPath: String { "\(pageID)/\(fpTextField)" }
+
+    /// Tapping a decorator can emit a regular field-focus event in addition to
+    /// the decorator focus, so we search for the focus event whose fieldEvent
+    /// carries the decorator action in its `type`.
+    private func decoratorFocusEvent(action: String) -> [String: Any]? {
+        return focusBlurOptionalResults().first { event in
+            guard event["kind"] as? String == "focus",
+                  let fe = event["fieldEvent"] as? [String: Any] else { return false }
+            return (fe["type"] as? String) == action
+        }?["fieldEvent"] as? [String: Any]
+    }
+
+    // MARK: - Full lifecycle: single decorator
+
+    func testFlagDecoratorLifecycle() throws {
+        typealias S = DecoratorUITestSupport
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+        XCTAssertFalse(flag.exists, "Decorator should not exist before add")
+
+        // 1. add → button appears with original label.
+        S.run(S.addCommand(path: fieldPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1),
+                      "Decorator button should appear after addDecorators")
+        XCTAssertEqual(flag.label, "Flag")
+        XCTAssertTrue(flag.isHittable)
+
+        // 2. update → identifier persists, label changes.
+        S.run(S.updateCommand(path: fieldPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(1) { flag.label == "Done" },
+                      "Decorator label should change to 'Done' after updateDecorator")
+
+        // 3. tap → onFocus fires with decorator action as type & target.
+        flag.tap()
+        XCTAssertTrue(
+            waitUntil(1) { self.decoratorFocusEvent(action: "flag") != nil },
+            "Expected a decorator-scoped focus event for 'flag' after tap"
+        )
+        let fieldEvent = decoratorFocusEvent(action: "flag") ?? [:]
+        XCTAssertEqual(fieldEvent["type"] as? String, "flag")
+        XCTAssertEqual(fieldEvent["target"] as? String, "flag")
+        XCTAssertEqual(fieldEvent["pageID"] as? String, pageID)
+        XCTAssertEqual(fieldEvent["fieldPositionId"] as? String, fpTextField)
+
+        // 4. remove → button disappears.
+        S.run(S.removeCommand(path: fieldPath, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(1) { !flag.exists },
+                      "Decorator button should disappear after removeDecorator")
+    }
+
+    // MARK: - Full lifecycle: multiple decorators
+
+    func testMultipleDecoratorsLifecycle() throws {
+        typealias S = DecoratorUITestSupport
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+        let comment = app.buttons[S.fieldDecoratorID(action: "comment")]
+        let share = app.buttons[S.fieldDecoratorID(action: "share")]
+
+        // 1. add → all three appear.
+        S.run(S.addCommand(path: fieldPath, decorators: [
+            S.decorator(action: "flag", icon: "flag", label: "Flag"),
+            S.decorator(action: "comment", icon: "comment", label: "Comment"),
+            S.decorator(action: "share", icon: "share", label: "Share")
+        ]), in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        XCTAssertTrue(comment.exists)
+        XCTAssertTrue(share.exists)
+        XCTAssertEqual(comment.label, "Comment")
+
+        // 2. update → only targeted decorator changes.
+        S.run(S.updateCommand(path: fieldPath, action: "comment",
+                              decorator: S.decorator(action: "comment", icon: "comment", label: "Reviewed")),
+              in: app)
+        XCTAssertTrue(waitUntil(1) { comment.label == "Reviewed" },
+                      "Only the targeted decorator should update")
+        XCTAssertEqual(flag.label, "Flag", "Untouched decorator should keep its label")
+        XCTAssertEqual(share.label, "Share", "Untouched decorator should keep its label")
+
+        // 3. tap → onFocus fires with the tapped decorator's action.
+        comment.tap()
+        XCTAssertTrue(
+            waitUntil(1) { self.decoratorFocusEvent(action: "comment") != nil },
+            "Expected a decorator-scoped focus event for 'comment' after tap"
+        )
+        let fieldEvent = decoratorFocusEvent(action: "comment") ?? [:]
+        XCTAssertEqual(fieldEvent["type"] as? String, "comment")
+        XCTAssertEqual(fieldEvent["target"] as? String, "comment")
+
+        // 4. remove → only the targeted decorator is removed.
+        S.run(S.removeCommand(path: fieldPath, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(1) { !flag.exists },
+                      "Removed decorator should disappear")
+        XCTAssertTrue(comment.exists, "Sibling decorator should remain after removal")
+        XCTAssertTrue(share.exists, "Sibling decorator should remain after removal")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
@@ -1,119 +1,783 @@
 import XCTest
 
-// MARK: - IDs from Decorator.json (text field scope)
+// MARK: - Shared IDs (from Decorator.json)
 
 private let pageID = "69709dc281b4c8ab68c4db52"
+
+// Table field position and rows
+private let fpTable  = "69709462236416126c166efe"
+private let tableRow1 = "697090a399394f50229899a9"
+private let tColText  = "697090a35fe3eb39f20fa2d8"
+
+// Collection field position and root rows
+private let fpCollection = "6970a3eceab9374076e43a0b"
+private let collRootRow1 = "6970a40230cef1a03fc19d81"
+private let collRootRow2 = "69e9b8309d0510fadb7357c4"
+private let collRootRow3 = "69e9b831f5d8f86b5ba20088"
+private let cColText     = "697090a3e627059c068c4858"
+
+// Level-1 schema and rows (under collRootRow2)
+private let schemaL1          = "level1Table1"
+private let l1Row1UnderRoot2  = "69e9b83351a2532dfd602819"
+private let cL1ColMultiSelect = "69e88266152a89811c37dc7f"
+
+// Level-2 schema and rows (under collRootRow3 / l1Row1UnderRoot3)
+private let schemaL2         = "level2Table1"
+private let l1Row1UnderRoot3 = "69e9b835b226373e47bf8f30"
+private let l2Row1           = "69e9b8384eb45bbdf1de3d97"
+private let cL2ColBarcode    = "69e8827e72fb2149cfd944a4"
+
+// Text field
 private let fpTextField = "6970918d350238d0738dd5c9"
 
-/// Exercises every DocumentEditor decorator API (`addDecorators`, `updateDecorator`,
-/// `removeDecorator`) against a text field using a fully test-driven workflow:
-/// the test calls `run(...)` to trigger each API, then asserts the UI reflects it
-/// before moving to the next step.
-///
-/// `getDecorators` is read-only with no UI surface and is covered by unit tests.
-final class DecoratorTextFieldAPIUITests: JoyfillUITestsBaseClass {
+// MARK: - Decorator base (disables animations for all decorator tests)
 
-    override func getJSONFileNameForTest() -> String {
-        return "Decorator"
+class DecoratorAPIUITestsBase: JoyfillUITestsBaseClass {
+    override func getGotoLaunchArguments() -> [(String, String?)] {
+        return [("--disable-animations", nil)]
     }
+}
+
+// MARK: - Text Field
+
+final class DecoratorTextFieldAPIUITests: DecoratorAPIUITestsBase {
+
+    override func getJSONFileNameForTest() -> String { "Decorator" }
 
     private var fieldPath: String { "\(pageID)/\(fpTextField)" }
 
-    /// Tapping a decorator can emit a regular field-focus event in addition to
-    /// the decorator focus, so we search for the focus event whose fieldEvent
-    /// carries the decorator action in its `type`.
-    private func decoratorFocusEvent(action: String) -> [String: Any]? {
-        return focusBlurOptionalResults().first { event in
-            guard event["kind"] as? String == "focus",
-                  let fe = event["fieldEvent"] as? [String: Any] else { return false }
-            return (fe["type"] as? String) == action
-        }?["fieldEvent"] as? [String: Any]
-    }
-
-    // MARK: - Full lifecycle: single decorator
-
-    func testFlagDecoratorLifecycle() throws {
+    func testDecoratorLifecycle() {
         typealias S = DecoratorUITestSupport
         let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
-        XCTAssertFalse(flag.exists, "Decorator should not exist before add")
 
-        // 1. add → button appears with original label.
         S.run(S.addCommand(path: fieldPath,
                            decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
               in: app)
-        XCTAssertTrue(flag.waitForExistence(timeout: 1),
-                      "Decorator button should appear after addDecorators")
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
         XCTAssertEqual(flag.label, "Flag")
-        XCTAssertTrue(flag.isHittable)
 
-        // 2. update → identifier persists, label changes.
         S.run(S.updateCommand(path: fieldPath, action: "flag",
                               decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
               in: app)
-        XCTAssertTrue(waitUntil(1) { flag.label == "Done" },
-                      "Decorator label should change to 'Done' after updateDecorator")
+        XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
 
-        // 3. tap → onFocus fires with decorator action as type & target.
         flag.tap()
-        XCTAssertTrue(
-            waitUntil(1) { self.decoratorFocusEvent(action: "flag") != nil },
-            "Expected a decorator-scoped focus event for 'flag' after tap"
-        )
-        let fieldEvent = decoratorFocusEvent(action: "flag") ?? [:]
-        XCTAssertEqual(fieldEvent["type"] as? String, "flag")
-        XCTAssertEqual(fieldEvent["target"] as? String, "flag")
-        XCTAssertEqual(fieldEvent["pageID"] as? String, pageID)
-        XCTAssertEqual(fieldEvent["fieldPositionId"] as? String, fpTextField)
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTextField)
 
-        // 4. remove → button disappears.
         S.run(S.removeCommand(path: fieldPath, action: "flag"), in: app)
-        XCTAssertTrue(waitUntil(1) { !flag.exists },
-                      "Decorator button should disappear after removeDecorator")
+        XCTAssertTrue(waitUntil(2) { !flag.exists })
+    }
+}
+
+// MARK: - Table (Common Row / Specific Row / Cell)
+
+final class DecoratorTableAPIUITests: DecoratorAPIUITestsBase {
+
+    override func getJSONFileNameForTest() -> String { "Decorator" }
+
+    private var rowsPath:         String { "\(pageID)/\(fpTable)/rows" }
+    private var row1Path:         String { "\(pageID)/\(fpTable)/\(tableRow1)" }
+    private var cell1Path:        String { "\(pageID)/\(fpTable)/\(tableRow1)/\(tColText)" }
+    private var commonCell1Path:  String { "\(pageID)/\(fpTable)/columns/\(tColText)" }
+
+    // Common row: decorator appears on every row
+    func testCommonRowDecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openTableDetailView(in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: rowsPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: rowsPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTable)
+
+        S.run(S.removeCommand(path: rowsPath, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
     }
 
-    // MARK: - Full lifecycle: multiple decorators
-
-    func testMultipleDecoratorsLifecycle() throws {
+    // Specific row: decorator appears only on the targeted row
+    func testSpecificRowDecoratorLifecycle() {
         typealias S = DecoratorUITestSupport
-        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
-        let comment = app.buttons[S.fieldDecoratorID(action: "comment")]
-        let share = app.buttons[S.fieldDecoratorID(action: "share")]
+        S.openTableDetailView(in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
 
-        // 1. add → all three appear.
-        S.run(S.addCommand(path: fieldPath, decorators: [
-            S.decorator(action: "flag", icon: "flag", label: "Flag"),
-            S.decorator(action: "comment", icon: "comment", label: "Comment"),
-            S.decorator(action: "share", icon: "share", label: "Share")
-        ]), in: app)
-        XCTAssertTrue(flag.waitForExistence(timeout: 1))
-        XCTAssertTrue(comment.exists)
-        XCTAssertTrue(share.exists)
-        XCTAssertEqual(comment.label, "Comment")
+        S.run(S.addCommand(path: row1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
 
-        // 2. update → only targeted decorator changes.
-        S.run(S.updateCommand(path: fieldPath, action: "comment",
+        S.run(S.updateCommand(path: row1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTable)
+
+        S.run(S.removeCommand(path: row1Path, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // COW: add common first, then specific → kebab appears → verify popover → update → tap → remove
+    func testCOWSpecificRowKebabLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openTableDetailView(in: app)
+
+        let kebab   = app.buttons[S.rowDecoratorMenuID]
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        // add common flag → all rows show flag button
+        S.run(S.addCommand(path: rowsPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1),
+                      "Common flag should appear on every row")
+
+        // add comment to row 1 → COW seeds [flag + comment] → kebab appears on row 1
+        S.run(S.addCommand(path: row1Path,
+                           decorators: [S.decorator(action: "comment", icon: "comment", label: "Comment")]),
+              in: app)
+        XCTAssertTrue(kebab.waitForExistence(timeout: 1),
+                      "Row 1 should show kebab after COW seeding")
+
+        // tap kebab → popover lists both decorators
+        kebab.tap()
+        XCTAssertTrue(app.buttons["Flag"].waitForExistence(timeout: 1),
+                      "Popover should show Flag decorator")
+        XCTAssertTrue(app.buttons["Comment"].exists,
+                      "Popover should show Comment decorator")
+
+        // update comment on row 1 → label changes in popover
+        S.run(S.updateCommand(path: row1Path, action: "comment",
                               decorator: S.decorator(action: "comment", icon: "comment", label: "Reviewed")),
               in: app)
-        XCTAssertTrue(waitUntil(1) { comment.label == "Reviewed" },
-                      "Only the targeted decorator should update")
-        XCTAssertEqual(flag.label, "Flag", "Untouched decorator should keep its label")
-        XCTAssertEqual(share.label, "Share", "Untouched decorator should keep its label")
+        XCTAssertTrue(kebab.waitForExistence(timeout: 1))
+        kebab.tap()
+        XCTAssertTrue(app.buttons["Reviewed"].waitForExistence(timeout: 1),
+                      "Popover should show updated label 'Reviewed'")
 
-        // 3. tap → onFocus fires with the tapped decorator's action.
-        comment.tap()
-        XCTAssertTrue(
-            waitUntil(1) { self.decoratorFocusEvent(action: "comment") != nil },
-            "Expected a decorator-scoped focus event for 'comment' after tap"
-        )
-        let fieldEvent = decoratorFocusEvent(action: "comment") ?? [:]
-        XCTAssertEqual(fieldEvent["type"] as? String, "comment")
-        XCTAssertEqual(fieldEvent["target"] as? String, "comment")
+        // tap 'Reviewed' → onFocus fires for comment action
+        app.buttons["Reviewed"].tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "comment", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "comment", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "comment")
+        XCTAssertEqual(fe["target"] as? String, "comment")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTable)
 
-        // 4. remove → only the targeted decorator is removed.
-        S.run(S.removeCommand(path: fieldPath, action: "flag"), in: app)
-        XCTAssertTrue(waitUntil(1) { !flag.exists },
-                      "Removed decorator should disappear")
-        XCTAssertTrue(comment.exists, "Sibling decorator should remain after removal")
-        XCTAssertTrue(share.exists, "Sibling decorator should remain after removal")
+        // remove comment from row 1 → kebab disappears, single flag button returns
+        S.run(S.removeCommand(path: row1Path, action: "comment"), in: app)
+        XCTAssertTrue(waitUntil(2) { !kebab.exists },
+                      "Kebab should disappear after removing the specific decorator")
+        XCTAssertTrue(app.buttons[S.rowDecoratorID(action: "flag")].waitForExistence(timeout: 1),
+                      "Row 1 should show single flag button again")
+    }
+
+    // Cell COW: flag at common cell scope (all rows, text column) → flag shows in every row's edit form
+    // then comment at specific cell (row 1, text column) → COW seeds row 1's cell with [flag + comment]
+    // navigate to row 2 → only flag (comment is row-1-specific) → back to row 1 → update → tap → remove
+    func testCOWSpecificCellLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openTableDetailView(in: app)
+
+        let flagButton    = app.buttons[S.fieldDecoratorID(action: "flag")]
+        let commentButton = app.buttons[S.fieldDecoratorID(action: "comment")]
+
+        // add flag at common cell scope → text column shows flag in ALL rows' edit forms
+        S.run(S.addCommand(path: commonCell1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should appear in row 1 edit form")
+
+        // navigate to row 2 → flag also present (it's common across all rows for this column)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should appear in row 2 edit form too")
+        S.navigateToPreviousRowInEditForm(in: app)
+        S.dismissRowEditForm(in: app)
+
+        // add comment at specific cell (row 1, text column) → COW seeds [flag + comment] on row 1's cell
+        S.run(S.addCommand(path: cell1Path,
+                           decorators: [S.decorator(action: "comment", icon: "comment", label: "Comment")]),
+              in: app)
+
+        // open row 1 edit form → both flag and comment present
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(commentButton.exists, "Comment button should appear alongside flag in row 1")
+        XCTAssertEqual(commentButton.label, "Comment")
+
+        // navigate to row 2 → only flag (comment is specific to row 1's cell)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should still appear in row 2")
+        XCTAssertTrue(waitUntil(2) { !commentButton.exists },
+                      "Comment should not appear in row 2 — it is cell-specific to row 1")
+
+        // navigate back to row 1 → both reappear
+        S.navigateToPreviousRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(commentButton.exists)
+        S.dismissRowEditForm(in: app)
+
+        // update comment → open form → verify label changed
+        S.run(S.updateCommand(path: cell1Path, action: "comment",
+                              decorator: S.decorator(action: "comment", icon: "comment", label: "Reviewed")),
+              in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { commentButton.label == "Reviewed" })
+
+        // tap comment → onFocus fires
+        XCTAssertTrue(commentButton.waitForExistence(timeout: 1))
+        commentButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "comment", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "comment", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "comment")
+        XCTAssertEqual(fe["target"] as? String, "comment")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTable)
+        S.dismissRowEditForm(in: app)
+
+        // remove comment → open form → only flag remains
+        S.run(S.removeCommand(path: cell1Path, action: "comment"), in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should still be present")
+        XCTAssertTrue(waitUntil(2) { !commentButton.exists },
+                      "Comment button should be gone after remove")
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Cell: decorator appears inside the row edit form
+    func testCellDecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openTableDetailView(in: app)
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+
+        S.run(S.addCommand(path: cell1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        XCTAssertEqual(flag.label, "Flag")
+
+        // navigate to row 2 → decorator must be absent (cell-specific to row 1)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists },
+                      "Flag should not appear in row 2 — it is cell-specific to row 1")
+        S.navigateToPreviousRowInEditForm(in: app)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.updateCommand(path: cell1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
+
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        flag.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpTable)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.removeCommand(path: cell1Path, action: "flag"), in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists })
+        S.dismissRowEditForm(in: app)
+    }
+}
+
+// MARK: - Collection (Root Common / Root Specific / Root Cell / Nested L1 & L2 / Nested Cell L1 & L2)
+
+final class DecoratorCollectionAPIUITests: DecoratorAPIUITestsBase {
+
+    override func getJSONFileNameForTest() -> String { "Decorator" }
+
+    private var rootRowsPath:       String { "\(pageID)/\(fpCollection)/rows" }
+    private var rootRow1Path:       String { "\(pageID)/\(fpCollection)/\(collRootRow1)" }
+    private var rootCell1Path:      String { "\(pageID)/\(fpCollection)/\(collRootRow1)/\(cColText)" }
+    private var commonRootCell1Path: String { "\(pageID)/\(fpCollection)/columns/\(cColText)" }
+
+    private var l1RowsPath: String {
+        "\(pageID)/\(fpCollection)/\(collRootRow2)/schemas/\(schemaL1)/rows"
+    }
+    private var l1Row1Path: String {
+        "\(pageID)/\(fpCollection)/\(collRootRow2)/schemas/\(schemaL1)/\(l1Row1UnderRoot2)"
+    }
+    private var l2Row1Path: String {
+        "\(pageID)/\(fpCollection)/\(collRootRow3)/schemas/\(schemaL1)/\(l1Row1UnderRoot3)/schemas/\(schemaL2)/\(l2Row1)"
+    }
+    private var l1CellPath: String {
+        "\(pageID)/\(fpCollection)/\(collRootRow2)/schemas/\(schemaL1)/\(l1Row1UnderRoot2)/\(cL1ColMultiSelect)"
+    }
+    private var l2CellPath: String {
+        "\(pageID)/\(fpCollection)/\(collRootRow3)/schemas/\(schemaL1)/\(l1Row1UnderRoot3)/schemas/\(schemaL2)/\(l2Row1)/\(cL2ColBarcode)"
+    }
+
+    // Common root row: decorator appears on every root row
+    func testCommonRootRowDecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: rootRowsPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: rootRowsPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        S.run(S.removeCommand(path: rootRowsPath, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // Specific root row: decorator appears only on the targeted root row
+    func testSpecificRootRowDecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: rootRow1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: rootRow1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        S.run(S.removeCommand(path: rootRow1Path, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // COW: add common first, then specific → kebab appears → verify popover → update → tap → remove
+    func testCOWSpecificRootRowKebabLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+
+        let kebab    = app.buttons[S.rowDecoratorMenuID]
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        // add common flag → all root rows show flag button
+        S.run(S.addCommand(path: rootRowsPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1),
+                      "Common flag should appear on every root row")
+
+        // add comment to root row 1 → COW seeds [flag + comment] → kebab appears on root row 1
+        S.run(S.addCommand(path: rootRow1Path,
+                           decorators: [S.decorator(action: "comment", icon: "comment", label: "Comment")]),
+              in: app)
+        XCTAssertTrue(kebab.waitForExistence(timeout: 1),
+                      "Root row 1 should show kebab after COW seeding")
+
+        // tap kebab → popover lists both decorators
+        kebab.tap()
+        XCTAssertTrue(app.buttons["Flag"].waitForExistence(timeout: 1),
+                      "Popover should show Flag decorator")
+        XCTAssertTrue(app.buttons["Comment"].exists,
+                      "Popover should show Comment decorator")
+
+        // update comment on root row 1 → label changes in popover
+        S.run(S.updateCommand(path: rootRow1Path, action: "comment",
+                              decorator: S.decorator(action: "comment", icon: "comment", label: "Reviewed")),
+              in: app)
+        XCTAssertTrue(kebab.waitForExistence(timeout: 1))
+        kebab.tap()
+        XCTAssertTrue(app.buttons["Reviewed"].waitForExistence(timeout: 1),
+                      "Popover should show updated label 'Reviewed'")
+
+        // tap 'Reviewed' → onFocus fires for comment action
+        app.buttons["Reviewed"].tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "comment", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "comment", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "comment")
+        XCTAssertEqual(fe["target"] as? String, "comment")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        // remove comment from root row 1 → kebab disappears, single flag button returns
+        S.run(S.removeCommand(path: rootRow1Path, action: "comment"), in: app)
+        XCTAssertTrue(waitUntil(2) { !kebab.exists },
+                      "Kebab should disappear after removing the specific decorator")
+        XCTAssertTrue(app.buttons[S.rowDecoratorID(action: "flag")].waitForExistence(timeout: 1),
+                      "Root row 1 should show single flag button again")
+    }
+
+    // Root cell COW: flag at common cell scope (all rows, text column) → flag shows in every row's edit form
+    // then comment at specific cell (root row 1, text column) → COW seeds [flag + comment] on row 1's cell
+    // navigate to row 2 → only flag (comment is root-row-1-specific) → back to row 1 → update → tap → remove
+    func testCOWSpecificRootCellLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+
+        let flagButton    = app.buttons[S.fieldDecoratorID(action: "flag")]
+        let commentButton = app.buttons[S.fieldDecoratorID(action: "comment")]
+
+        // add flag at common cell scope → text column shows flag in ALL root rows' edit forms
+        S.run(S.addCommand(path: commonRootCell1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should appear in root row 1 edit form")
+
+        // navigate to root row 2 → flag also present (common across all rows for this column)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should appear in root row 2 edit form too")
+        S.navigateToPreviousRowInEditForm(in: app)
+        S.dismissRowEditForm(in: app)
+
+        // add comment at specific cell (root row 1, text column) → COW seeds [flag + comment]
+        S.run(S.addCommand(path: rootCell1Path,
+                           decorators: [S.decorator(action: "comment", icon: "comment", label: "Comment")]),
+              in: app)
+
+        // open root row 1 edit form → both flag and comment present
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(commentButton.exists, "Comment button should appear alongside flag in root row 1")
+        XCTAssertEqual(commentButton.label, "Comment")
+
+        // navigate to root row 2 → only flag (comment is specific to root row 1's cell)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should still appear in root row 2")
+        XCTAssertTrue(waitUntil(2) { !commentButton.exists },
+                      "Comment should not appear in root row 2 — it is cell-specific to root row 1")
+
+        // navigate back to root row 1 → both reappear
+        S.navigateToPreviousRowInEditForm(in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(commentButton.exists)
+        S.dismissRowEditForm(in: app)
+
+        // update comment → open form → verify label changed
+        S.run(S.updateCommand(path: rootCell1Path, action: "comment",
+                              decorator: S.decorator(action: "comment", icon: "comment", label: "Reviewed")),
+              in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { commentButton.label == "Reviewed" })
+
+        // tap comment → onFocus fires
+        XCTAssertTrue(commentButton.waitForExistence(timeout: 1))
+        commentButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "comment", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "comment", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "comment")
+        XCTAssertEqual(fe["target"] as? String, "comment")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+        S.dismissRowEditForm(in: app)
+
+        // remove comment → open form → only flag remains
+        S.run(S.removeCommand(path: rootCell1Path, action: "comment"), in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flagButton.waitForExistence(timeout: 1),
+                      "Common cell flag should still be present")
+        XCTAssertTrue(waitUntil(2) { !commentButton.exists },
+                      "Comment button should be gone after remove")
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Root cell: decorator appears inside the root row edit form
+    func testRootCellDecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+
+        S.run(S.addCommand(path: rootCell1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        XCTAssertEqual(flag.label, "Flag")
+
+        // navigate to root row 2 → decorator must be absent (cell-specific to root row 1)
+        S.navigateToNextRowInEditForm(in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists },
+                      "Flag should not appear in root row 2 — it is cell-specific to root row 1")
+        S.navigateToPreviousRowInEditForm(in: app)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.updateCommand(path: rootCell1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
+        S.dismissRowEditForm(in: app)
+
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        flag.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.removeCommand(path: rootCell1Path, action: "flag"), in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists })
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Nested common row (L1): decorator appears on all L1 rows under root row 2
+    func testNestedCommonRowLevel1DecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 2, in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: l1RowsPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: l1RowsPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        S.run(S.removeCommand(path: l1RowsPath, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // Nested specific row (L1): decorator appears only on targeted L1 row
+    func testNestedSpecificRowLevel1DecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 2, in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: l1Row1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: l1Row1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        S.run(S.removeCommand(path: l1Row1Path, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // Nested specific row (L2): decorator appears only on targeted L2 row
+    func testNestedSpecificRowLevel2DecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 3, in: app)
+        S.expandCollectionNestedRow(at: 1, in: app)
+        let allFlags = { self.app.buttons.matching(identifier: S.rowDecoratorID(action: "flag")) }
+
+        S.run(S.addCommand(path: l2Row1Path,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(allFlags().element(boundBy: 0).waitForExistence(timeout: 1))
+        XCTAssertEqual(allFlags().element(boundBy: 0).label, "Flag")
+
+        S.run(S.updateCommand(path: l2Row1Path, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().element(boundBy: 0).label == "Done" })
+
+        allFlags().element(boundBy: 0).tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+
+        S.run(S.removeCommand(path: l2Row1Path, action: "flag"), in: app)
+        XCTAssertTrue(waitUntil(2) { allFlags().count == 0 })
+    }
+
+    // Nested cell (L1): decorator appears inside the L1 row edit form
+    func testNestedCellLevel1DecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 2, in: app)
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+
+        S.run(S.addCommand(path: l1CellPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        XCTAssertEqual(flag.label, "Flag")
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.updateCommand(path: l1CellPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+        XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
+        S.dismissRowEditForm(in: app)
+
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        flag.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.removeCommand(path: l1CellPath, action: "flag"), in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists })
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Nested cell (L2): decorator appears inside the L2 row edit form
+    func testNestedCellLevel2DecoratorLifecycle() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 3, in: app)
+        S.expandCollectionNestedRow(at: 1, in: app)
+        let flag = app.buttons[S.fieldDecoratorID(action: "flag")]
+
+        S.run(S.addCommand(path: l2CellPath,
+                           decorators: [S.decorator(action: "flag", icon: "flag", label: "Flag")]),
+              in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        XCTAssertEqual(flag.label, "Flag")
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.updateCommand(path: l2CellPath, action: "flag",
+                              decorator: S.decorator(action: "flag", icon: "flag", label: "Done")),
+              in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
+        S.dismissRowEditForm(in: app)
+
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+        XCTAssertTrue(flag.waitForExistence(timeout: 1))
+        flag.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: "flag", in: self.focusBlurOptionalResults()) != nil
+        })
+        let fe = S.decoratorFocusEvent(action: "flag", in: focusBlurOptionalResults()) ?? [:]
+        XCTAssertEqual(fe["type"] as? String, "flag")
+        XCTAssertEqual(fe["target"] as? String, "flag")
+        XCTAssertEqual(fe["pageID"] as? String, pageID)
+        XCTAssertEqual(fe["fieldPositionId"] as? String, fpCollection)
+        S.dismissRowEditForm(in: app)
+
+        S.run(S.removeCommand(path: l2CellPath, action: "flag"), in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+        XCTAssertTrue(waitUntil(2) { !flag.exists })
+        S.dismissRowEditForm(in: app)
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
@@ -69,4 +69,125 @@ enum DecoratorUITestSupport {
 
     /// Identifier for the row hamburger menu button (shown when multiple decorators exist on a row).
     static let rowDecoratorMenuID = "row_decorator_menu"
+
+    // MARK: - Focus event helper
+
+    /// Find the decorator-scoped focus event for `action` within a batch of focusBlur results.
+    /// Searches for a focus event whose fieldEvent carries the decorator action as `type`.
+    static func decoratorFocusEvent(action: String, in results: [[String: Any]]) -> [String: Any]? {
+        return results.first { event in
+            guard event["kind"] as? String == "focus",
+                  let fe = event["fieldEvent"] as? [String: Any] else { return false }
+            return (fe["type"] as? String) == action
+        }?["fieldEvent"] as? [String: Any]
+    }
+
+    // MARK: - Navigation helpers
+
+    /// Navigate into the table detail view (TableModalView).
+    /// Row decorator buttons only render inside this view, not in the quick-view on the main form.
+    static func openTableDetailView(in app: XCUIApplication) {
+        let btn = app.buttons.matching(identifier: "TableDetailViewIdentifier").firstMatch
+        if !btn.waitForExistence(timeout: 3) {
+            app.swipeUp()
+            _ = btn.waitForExistence(timeout: 3)
+        }
+        btn.tap()
+        spinRunloop(0.2)
+    }
+
+    /// Navigate into the collection detail view (CollectionModalView).
+    static func openCollectionDetailView(in app: XCUIApplication) {
+        let btn = app.buttons.matching(identifier: "CollectionDetailViewIdentifier").firstMatch
+        if !btn.waitForExistence(timeout: 3) {
+            app.swipeUp()
+            _ = btn.waitForExistence(timeout: 3)
+        }
+        btn.tap()
+        spinRunloop(0.2)
+    }
+
+    /// Expand (or collapse) a root row in the collection modal view.
+    /// `index` is 1-based, matching the row display index.
+    static func expandCollectionRootRow(at index: Int, in app: XCUIApplication) {
+        let expander = app.images.matching(identifier: "CollectionExpandCollapseButton\(index)").firstMatch
+        if expander.waitForExistence(timeout: 3) {
+            expander.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    /// Expand (or collapse) a nested row in the collection modal view.
+    /// `index` is 1-based within its parent's nested list.
+    static func expandCollectionNestedRow(at index: Int, in app: XCUIApplication) {
+        let expander = app.images.matching(identifier: "CollectionExpandCollapseNestedButton\(index)").firstMatch
+        if expander.waitForExistence(timeout: 3) {
+            expander.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    // MARK: - Row edit form helpers (for cell decorator tests)
+    // Cell decorators (path: pageID/field/rowId/colId) appear inside the
+    // row edit form (EditMultipleRowsSheetView / CollectionEditMultipleRowsSheetView),
+    // not in column headers on row selection alone.
+
+    /// Open the table row edit form for a given row.
+    /// `rowIndex` is 1-based; internally maps to 0-based SingleClickEditButton{rowIndex-1}.
+    static func openTableRowEditForm(rowIndex: Int, in app: XCUIApplication) {
+        let editBtn = app.images.matching(identifier: "SingleClickEditButton\(rowIndex - 1)").firstMatch
+        if editBtn.waitForExistence(timeout: 1) {
+            editBtn.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    /// Open the collection root-row edit form for a given row.
+    /// `rowIndex` is 1-based.
+    static func openCollectionRootRowEditForm(rowIndex: Int, in app: XCUIApplication) {
+        let editBtn = app.images.matching(identifier: "SingleClickEditButton\(rowIndex)").firstMatch
+        if editBtn.waitForExistence(timeout: 1) {
+            editBtn.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    /// Open the collection nested-row edit form.
+    /// `rowIndex` is 1-based within its schema level.
+    /// `boundBy` disambiguates when L1 and L2 rows share the same index
+    /// (e.g. boundBy:0 = L1 row 1, boundBy:1 = L2 row 1 when both are visible).
+    static func openCollectionNestedRowEditForm(rowIndex: Int, boundBy boundByIndex: Int = 0, in app: XCUIApplication) {
+        let editBtn = app.images.matching(identifier: "SingleClickEditNestedButton\(rowIndex)").element(boundBy: boundByIndex)
+        if editBtn.waitForExistence(timeout: 1) {
+            editBtn.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    /// Navigate to the next row inside the row edit form (tap the `>` chevron button).
+    static func navigateToNextRowInEditForm(in app: XCUIApplication) {
+        let btn = app.buttons["LowerRowButtonIdentifier"]
+        if btn.waitForExistence(timeout: 2) {
+            btn.tap()
+            spinRunloop(0.3)
+        }
+    }
+
+    /// Navigate to the previous row inside the row edit form (tap the `<` chevron button).
+    static func navigateToPreviousRowInEditForm(in app: XCUIApplication) {
+        let btn = app.buttons["UpperRowButtonIdentifier"]
+        if btn.waitForExistence(timeout: 2) {
+            btn.tap()
+            spinRunloop(0.3)
+        }
+    }
+
+    /// Dismiss the row edit form sheet by swiping it down.
+    static func dismissRowEditForm(in app: XCUIApplication) {
+        let sheet = app.sheets.firstMatch
+        if sheet.waitForExistence(timeout: 2) {
+            sheet.swipeDown()
+            spinRunloop(0.2)
+        }
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+
+/// Shared helpers for Decorator UI tests. Reusable across field / table / collection suites.
+///
+/// The test drives every API call explicitly: build a command dict, write it to the
+/// system pasteboard, tap the hidden `decorator_command_execute` button in the app,
+/// then assert on the resulting UI. Out-of-process XCUITests cannot touch
+/// DocumentEditor directly, so the pasteboard is the sync bridge.
+enum DecoratorUITestSupport {
+
+    // MARK: - Command builders
+
+    static func addCommand(path: String, decorators: [[String: Any]]) -> [String: Any] {
+        return ["op": "add", "path": path, "decorators": decorators]
+    }
+
+    static func removeCommand(path: String, action: String) -> [String: Any] {
+        return ["op": "remove", "path": path, "action": action]
+    }
+
+    static func updateCommand(path: String, action: String, decorator: [String: Any]) -> [String: Any] {
+        return ["op": "update", "path": path, "action": action, "decorator": decorator]
+    }
+
+    /// Build a decorator dictionary.
+    static func decorator(action: String, icon: String? = nil, label: String? = nil, color: String? = nil) -> [String: Any] {
+        var d: [String: Any] = ["action": action]
+        if let icon = icon { d["icon"] = icon }
+        if let label = label { d["label"] = label }
+        if let color = color { d["color"] = color }
+        return d
+    }
+
+    // MARK: - Execution bridge
+
+    /// Ship a single command to the app: write JSON to the pasteboard, then tap the
+    /// hidden execute button so the app invokes the matching DocumentEditor API.
+    /// Type the JSON command into the bridge TextField, then tap the adjacent
+    /// button so the app invokes the matching DocumentEditor API. No pasteboard
+    /// involvement → no iOS 16+ permission prompt.
+    static func run(_ command: [String: Any], in app: XCUIApplication, file: StaticString = #file, line: UInt = #line) {
+        let data = try! JSONSerialization.data(withJSONObject: command)
+        let json = String(data: data, encoding: .utf8)!
+
+        let input = app.textFields["decorator_command_input"]
+        let button = app.buttons["decorator_command_execute"]
+        guard input.waitForExistence(timeout: 5), button.waitForExistence(timeout: 5) else {
+            XCTFail("decorator_command bridge not found — is the app running under joyfillUITestsMode?",
+                    file: file, line: line)
+            return
+        }
+        input.tap()
+        input.typeText(json)
+        button.tap()
+    }
+
+    // MARK: - Accessibility identifiers
+
+    /// Identifier for a field-level decorator button.
+    static func fieldDecoratorID(action: String) -> String {
+        return "decorator_button_\(action)"
+    }
+
+    /// Identifier for a single row-level decorator button (shown when exactly one is displayable).
+    static func rowDecoratorID(action: String) -> String {
+        return "row_decorator_\(action)"
+    }
+
+    /// Identifier for the row hamburger menu button (shown when multiple decorators exist on a row).
+    static let rowDecoratorMenuID = "row_decorator_menu"
+}

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1234,6 +1234,11 @@ public struct Schema {
         get { (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) }
         set { dictionary["rowDecorators"] = newValue?.compactMap { $0.dictionary } }
     }
+
+    public var decorate: Bool? {
+        get { dictionary["decorate"] as? Bool }
+        set { dictionary["decorate"] = newValue }
+    }
 }
 
 // MARK: - ValueElement

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -528,6 +528,11 @@ public struct JoyDocField: Equatable {
         set { dictionary["decorators"] = newValue?.compactMap { $0.dictionary } }
     }
 
+    public var decorate: Bool? {
+        get { dictionary["decorate"] as? Bool }
+        set { dictionary["decorate"] = newValue }
+    }
+
     /// Row-level decorators for table/collection fields. Rendered per-row via a kebab menu column.
     public var rowDecorators: [Decorator]? {
         get { (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) }

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -58,6 +58,32 @@ public struct Decorator: Equatable {
     }
 }
 
+// MARK: - RowDecorators
+public struct Decorators {
+    public var dictionary: [String: Any]
+
+    public init(dictionary: [String: Any] = [:]) {
+        self.dictionary = dictionary
+    }
+
+    /// Row-level decorators that apply to the entire row.
+    public var all: [Decorator] {
+        get { (dictionary["all"] as? [[String: Any]])?.compactMap(Decorator.init) ?? [] }
+        set { dictionary["all"] = newValue.map { $0.dictionary } }
+    }
+
+    /// Per-cell decorators keyed by column ID.
+    public var cells: [String: [Decorator]] {
+        get {
+            guard let raw = dictionary["cells"] as? [String: Any] else { return [:] }
+            return raw.compactMapValues { ($0 as? [[String: Any]])?.compactMap(Decorator.init) }
+        }
+        set {
+            dictionary["cells"] = newValue.mapValues { $0.map { $0.dictionary } }
+        }
+    }
+}
+
 /// Represents a Joy document.
 ///
 /// Use the `JoyDoc` struct to create and manipulate Joy documents.
@@ -1280,7 +1306,7 @@ public struct ValueElement: Codable, Equatable, Hashable, Identifiable {
 
     /// The coding keys used for encoding and decoding the value element.
     enum CodingKeys: String, CodingKey {
-        case _id, url, fileName, filePath, deleted, title, description, points, cells, metadata
+        case _id, url, fileName, filePath, deleted, title, description, points, cells, metadata, decorators
     }
 
     /// Initializes a value element with an ID, deleted flag, description, title, and points.
@@ -1462,6 +1488,22 @@ public struct ValueElement: Codable, Equatable, Hashable, Identifiable {
     public var tz: String? {
         get { (dictionary["tz"] as? ValueUnion)?.text }
         set { setValue(newValue, key: "tz") }
+    }
+
+    /// Per-row decorators: `all` for row-level, `cells` for per-cell keyed by column ID.
+    public var decorators: Decorators? {
+        get {
+            guard let valueUnion = dictionary["decorators"] as? ValueUnion,
+                  let anyDict = valueUnion.dictionary as? [String: Any] else { return nil }
+            return Decorators(dictionary: anyDict)
+        }
+        set {
+            if let decs = newValue {
+                dictionary["decorators"] = ValueUnion(anyDictionary: decs.dictionary)
+            } else {
+                dictionary.removeValue(forKey: "decorators")
+            }
+        }
     }
 }
 

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -1,6 +1,24 @@
 import SwiftUI
 import JoyfillModel
 
+private extension View {
+    func decoratorOverflowPopover<Content: View>(
+        isPresented: Binding<Bool>,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        self.popover(isPresented: isPresented) {
+            Group {
+                if #available(iOS 16.4, *) {
+                    content()
+                        .presentationCompactAdaptation(.popover)
+                } else {
+                    content()
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Decorator Icon Mapping
 
 enum DecoratorIcon {
@@ -138,6 +156,7 @@ private struct DecoratorKebabButton: View {
                 .font(.system(size: 14, weight: .bold))
                 .foregroundColor(.blue)
         }
+        .contentShape(Rectangle())
         .buttonStyle(.plain)
     }
 }
@@ -161,8 +180,9 @@ struct FieldDecoratorsView: View {
                     .frame(minHeight: 32)
                     .background(Color.blue.opacity(0.12))
                     .cornerRadius(8)
+                    .contentShape(Rectangle())
                     .accessibilityIdentifier("field_decorator_overflow_menu")
-                    .popover(isPresented: $showingOverflow) {
+                    .decoratorOverflowPopover(isPresented: $showingOverflow) {
                         decoratorPopover
                     }
             } else {
@@ -263,12 +283,8 @@ struct RowDecoratorMenuView: View {
             .frame(width: 40, height: 60)
             .contentShape(Rectangle())
             .accessibilityIdentifier("row_decorator_menu")
-            .popover(isPresented: $showingPopover) {
-                if #available(iOS 16.4, *) {
-                    popoverContent.presentationCompactAdaptation(.popover)
-                } else {
-                    popoverContent
-                }
+            .decoratorOverflowPopover(isPresented: $showingPopover) {
+                popoverContent
             }
     }
 

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -126,24 +126,83 @@ struct DecoratorButton: View {
     }
 }
 
+// MARK: - Shared Kebab Button
+
+private struct DecoratorKebabButton: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Image(systemName: "ellipsis")
+                .rotationEffect(.degrees(90))
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(.blue)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 // MARK: - Field-Level Decorators (inline next to title)
 
 struct FieldDecoratorsView: View {
     let decorators: [DecoratorLocal]
+    let visibleLimit: Int
     let onDecoratorTap: (DecoratorLocal) -> Void
+    @State private var showingOverflow = false
 
-    var displayable: [DecoratorLocal] {
-        decorators.filter { $0.isDisplayable }
-    }
+    var displayable: [DecoratorLocal] { decorators.filter { $0.isDisplayable } }
+    var exceedsLimit: Bool { displayable.count > visibleLimit }
 
     var body: some View {
         if !displayable.isEmpty {
-            HStack(spacing: 4) {
-                ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
-                    DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+            if exceedsLimit {
+                DecoratorKebabButton { showingOverflow = true }
+                    .padding(.horizontal, 10)
+                    .frame(minHeight: 32)
+                    .background(Color.blue.opacity(0.12))
+                    .cornerRadius(8)
+                    .accessibilityIdentifier("field_decorator_overflow_menu")
+                    .popover(isPresented: $showingOverflow) {
+                        decoratorPopover
+                    }
+            } else {
+                HStack(spacing: 4) {
+                    ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                        DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                    }
                 }
             }
         }
+    }
+
+    private var decoratorPopover: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(displayable.enumerated()), id: \.offset) { index, decorator in
+                let tint: Color = decorator.color.map { Color(hex: $0) } ?? .primary
+                Button {
+                    showingOverflow = false
+                    onDecoratorTap(decorator)
+                } label: {
+                    HStack(spacing: 8) {
+                        if let icon = decorator.icon, !icon.isEmpty {
+                            DecoratorIconImage(iconName: icon, size: 14)
+                                .foregroundColor(tint)
+                                .frame(width: 20)
+                        }
+                        if let label = decorator.label, !label.isEmpty {
+                            Text(label)
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundColor(tint)
+                        }
+                    }
+                    .frame(height: 27)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, index == 0 ? 12 : 4)
+                .padding(.bottom, index == displayable.count - 1 ? 12 : 4)
+            }
+        }
+        .frame(minWidth: 160)
     }
 }
 
@@ -151,52 +210,28 @@ struct FieldDecoratorsView: View {
 
 struct RowDecoratorMenuView: View {
     let decorators: [DecoratorLocal]
+    let visibleLimit: Int
     let onDecoratorTap: (DecoratorLocal) -> Void
     @State private var showingPopover = false
 
-    private var displayable: [DecoratorLocal] {
-        decorators.filter { $0.isDisplayable }
-    }
-
-    private var dominantDecorator: DecoratorLocal? {
-        displayable.first
-    }
-
-    private var dominantColor: Color {
-        if let hex = dominantDecorator?.color, !hex.isEmpty {
-            return Color(hex: hex)
-        }
-        return .secondary
-    }
+    private var displayable: [DecoratorLocal] { decorators.filter { $0.isDisplayable } }
+    private var exceedsLimit: Bool { displayable.count > visibleLimit }
 
     var body: some View {
-        if displayable.count == 1, let decorator = displayable.first {
+        if displayable.isEmpty {
+            Color.clear.frame(width: 40, height: 60)
+        } else if exceedsLimit {
+            kebabButton.frame(width: 40, height: 60)
+        } else if displayable.count == 1, let decorator = displayable.first {
             singleDecoratorButton(decorator)
-        } else if displayable.count > 1 {
-            Button {
-                showingPopover = true
-            } label: {
-                Image(systemName: "ellipsis")
-                    .rotationEffect(.degrees(90))
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(.blue)
-                    .frame(width: 40, height: 60)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("row_decorator_menu")
-            .popover(isPresented: $showingPopover) {
-                if #available(iOS 16.4, *) {
-                    popoverContent
-                        .presentationCompactAdaptation(.popover)
-                } else {
-                    popoverContent
+        } else {
+            VStack(spacing: 0) {
+                ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                    singleDecoratorButton(decorator)
+                        .frame(maxHeight: .infinity)
                 }
             }
-        } else {
-            // Empty placeholder so the column width stays consistent across rows
-            Color.clear
-                .frame(width: 40, height: 60)
+            .frame(width: 40, height: 60)
         }
     }
 
@@ -221,6 +256,20 @@ struct RowDecoratorMenuView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("row_decorator_\(decorator.action ?? "unknown")")
+    }
+
+    private var kebabButton: some View {
+        DecoratorKebabButton { showingPopover = true }
+            .frame(width: 40, height: 60)
+            .contentShape(Rectangle())
+            .accessibilityIdentifier("row_decorator_menu")
+            .popover(isPresented: $showingPopover) {
+                if #available(iOS 16.4, *) {
+                    popoverContent.presentationCompactAdaptation(.popover)
+                } else {
+                    popoverContent
+                }
+            }
     }
 
     private var popoverContent: some View {

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -122,6 +122,7 @@ struct DecoratorButton: View {
             .cornerRadius(8)
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("decorator_button_\(decorator.action ?? "unknown")")
     }
 }
 
@@ -183,6 +184,7 @@ struct RowDecoratorMenuView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("row_decorator_menu")
             .popover(isPresented: $showingPopover) {
                 if #available(iOS 16.4, *) {
                     popoverContent
@@ -218,6 +220,7 @@ struct RowDecoratorMenuView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("row_decorator_\(decorator.action ?? "unknown")")
     }
 
     private var popoverContent: some View {

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -191,6 +191,10 @@ struct RowDecoratorMenuView: View {
                     popoverContent
                 }
             }
+        } else {
+            // Empty placeholder so the column width stays consistent across rows
+            Color.clear
+                .frame(width: 40, height: 60)
         }
     }
 

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -33,10 +33,13 @@ struct FieldHeaderView: View {
 
                 Spacer()
 
-                if let decorators = fieldHeaderModel?.decorators,
-                   !decorators.isEmpty,
-                   fieldHeaderModel?.mode == .fill {
-                    FieldDecoratorsView(decorators: decorators) { decorator in
+                if let model = fieldHeaderModel,
+                   !model.decorators.isEmpty,
+                   model.mode == .fill {
+                    FieldDecoratorsView(
+                        decorators: model.decorators,
+                        visibleLimit: model.visibleLimitInFields
+                    ) { decorator in
                         onDecoratorTap?(decorator)
                     }
                 }
@@ -77,4 +80,5 @@ struct FieldHeaderModel {
     var tipVisible: Bool?
     var decorators: [DecoratorLocal] = []
     var mode: Mode = .fill
+    var visibleLimitInFields: Int
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -305,7 +305,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                         let (path, _) = viewModel.getParenthPath(rowId: firstRowId)
                         return path.isEmpty ? nil : path
                     }()
-                    FieldDecoratorsView(decorators: decorators) { decorator in
+                    FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
                             fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
                             action: decorator.action ?? "",

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -297,17 +297,15 @@ struct CollectionEditMultipleRowsSheetView: View {
             Text(col.title)
                 .font(.headline.bold())
             Spacer()
-            if viewModel.tableDataModel.mode == .fill,
-               let liveCol = viewModel.columnsMap["\(schemaKey)_\(col.id ?? "")"],
-               let decorators = liveCol.decorators, !decorators.isEmpty {
-                let locals = decorators.compactMap { $0.isDisplayable ? DecoratorLocal(from: $0) : nil }
-                if !locals.isEmpty {
+            if viewModel.tableDataModel.mode == .fill {
+                let decorators = viewModel.getCollectionCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "", schemaKey: schemaKey)
+                if !decorators.isEmpty {
                     let parentPathForSelection: String? = {
                         guard let firstRowId = viewModel.tableDataModel.selectedRows.first else { return nil }
                         let (path, _) = viewModel.getParenthPath(rowId: firstRowId)
                         return path.isEmpty ? nil : path
                     }()
-                    FieldDecoratorsView(decorators: locals) { decorator in
+                    FieldDecoratorsView(decorators: decorators) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
                             fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
                             action: decorator.action ?? "",

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -625,7 +625,7 @@ struct CollectionRowsHeaderView: View {
                 }
                 if viewModel.showRowDecorators(forSchemaKey: parentSchemaKey) {
                     let parentPathForNested = viewModel.getParenthPath(rowId: rowModel.rowID)
-                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: parentSchemaKey)) { decorator in
+                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: parentSchemaKey), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
                             fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
                             action: decorator.action ?? "",
@@ -667,7 +667,7 @@ struct CollectionRowsHeaderView: View {
                         .accessibilityIdentifier("SingleClickEditButton\(rowIndex)")
                 }
                 if viewModel.showRowDecorators(forSchemaKey: viewModel.rootSchemaKey) {
-                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: viewModel.rootSchemaKey)) { decorator in
+                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: viewModel.rootSchemaKey), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                     }
                     .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -625,7 +625,7 @@ struct CollectionRowsHeaderView: View {
                 }
                 if viewModel.showRowDecorators(forSchemaKey: parentSchemaKey) {
                     let parentPathForNested = viewModel.getParenthPath(rowId: rowModel.rowID)
-                    RowDecoratorMenuView(decorators: viewModel.tableDataModel.rowDecorators(forSchemaKey: parentSchemaKey)) { decorator in
+                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: parentSchemaKey)) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
                             fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
                             action: decorator.action ?? "",
@@ -667,7 +667,7 @@ struct CollectionRowsHeaderView: View {
                         .accessibilityIdentifier("SingleClickEditButton\(rowIndex)")
                 }
                 if viewModel.showRowDecorators(forSchemaKey: viewModel.rootSchemaKey) {
-                    RowDecoratorMenuView(decorators: viewModel.tableDataModel.rowDecorators(forSchemaKey: viewModel.rootSchemaKey)) { decorator in
+                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: viewModel.rootSchemaKey)) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                     }
                     .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -394,7 +394,7 @@ struct CollectionColumnHeaderView: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            if viewModel.showRowDecorators, !viewModel.tableDataModel.rowDecorators(forSchemaKey: schemaKey).isEmpty {
+            if viewModel.showRowDecorators(forSchemaKey: schemaKey) {
                 Image(systemName: "ellipsis")
                     .rotationEffect(.degrees(90))
                     .frame(width: 40, height: 60)
@@ -623,7 +623,7 @@ struct CollectionRowsHeaderView: View {
                         }
                         .accessibilityIdentifier("SingleClickEditNestedButton\(nastedRowIndex)")
                 }
-                if viewModel.showRowDecorators {
+                if viewModel.showRowDecorators(forSchemaKey: parentSchemaKey) {
                     let parentPathForNested = viewModel.getParenthPath(rowId: rowModel.rowID)
                     RowDecoratorMenuView(decorators: viewModel.tableDataModel.rowDecorators(forSchemaKey: parentSchemaKey)) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
@@ -666,7 +666,7 @@ struct CollectionRowsHeaderView: View {
                         }
                         .accessibilityIdentifier("SingleClickEditButton\(rowIndex)")
                 }
-                if viewModel.showRowDecorators {
+                if viewModel.showRowDecorators(forSchemaKey: viewModel.rootSchemaKey) {
                     RowDecoratorMenuView(decorators: viewModel.tableDataModel.rowDecorators(forSchemaKey: viewModel.rootSchemaKey)) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                     }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -36,6 +36,15 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         return tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey) && tableDataModel.mode == .fill
     }
 
+    func getCollectionRowDecorators(forRowID rowID: String, schemaKey: String) -> [DecoratorLocal] {
+        let rowSpecific = rowToValueElementMap[rowID]?
+            .decorators?.all
+            .filter({ $0.isDisplayable })
+            .map(DecoratorLocal.init(from:)) ?? []
+        if !rowSpecific.isEmpty { return rowSpecific }
+        return tableDataModel.rowDecorators(forSchemaKey: schemaKey)
+    }
+
     init(tableDataModel: TableDataModel) {
         self.tableDataModel = tableDataModel
         self.tableDataModel.schema.forEach { key, value in

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -32,8 +32,8 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         return tableDataModel.singleClickRowEdit && tableDataModel.mode == .fill
     }
 
-    var showRowDecorators: Bool {
-        return tableDataModel.hasAnyRowDecorators && tableDataModel.mode == .fill
+    func showRowDecorators(forSchemaKey schemaKey: String) -> Bool {
+        return tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey) && tableDataModel.mode == .fill
     }
 
     init(tableDataModel: TableDataModel) {

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -2245,6 +2245,12 @@ protocol TableDataViewModelProtocol {
     func getParenthPath(rowId: String) -> (String, String)
 }
 
+extension TableDataViewModelProtocol {
+    var decoratorConfig: DecoratorConfig {
+        tableDataModel.documentEditor?.decoratorConfig ?? DecoratorConfig()
+    }
+}
+
 extension CollectionViewModel {
     //Helper Methods for parentToChildRowMap
     func appendChild(_ childID: String, to parentRowID: String, schemaID: String) {

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -45,6 +45,21 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         return tableDataModel.rowDecorators(forSchemaKey: schemaKey)
     }
 
+    func getCollectionCellDecorators(rowIds: [String], columnId: String, schemaKey: String) -> [DecoratorLocal] {
+        let columnDecorators = columnsMap["\(schemaKey)_\(columnId)"]?
+            .decorators?
+            .filter({ $0.isDisplayable })
+            .map(DecoratorLocal.init(from:)) ?? []
+        if rowIds.count == 1, let singleID = rowIds.first {
+            let cellSpecific = rowToValueElementMap[singleID]?
+                .decorators?.cells[columnId]?
+                .filter({ $0.isDisplayable })
+                .map(DecoratorLocal.init(from:)) ?? []
+            if !cellSpecific.isEmpty { return cellSpecific }
+        }
+        return columnDecorators
+    }
+
     init(tableDataModel: TableDataModel) {
         self.tableDataModel = tableDataModel
         self.tableDataModel.schema.forEach { key, value in

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -2071,7 +2071,7 @@ extension CollectionViewModel: DocumentEditorDelegate {
 
         // Refresh the entire schema so hasAnyRowDecorators and column decorators stay in sync
         tableDataModel.schema = field.schema ?? [:]
-
+        tableDataModel.valueToValueElements = field.valueToValueElements
         // Row decorators per schema key (local DecoratorLocal cache)
         field.schema?.forEach { key, value in
             tableDataModel.setRowDecorators(value.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? [], forSchemaKey: key)
@@ -2087,6 +2087,7 @@ extension CollectionViewModel: DocumentEditorDelegate {
                 }
             }
         }
+        buildRowToValueElementMap()
     }
 
 

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -238,12 +238,10 @@ struct EditMultipleRowsSheetView: View {
             Text(viewModel.tableDataModel.getColumnTitle(columnId: col.id ?? ""))
                 .font(.headline.bold())
             Spacer()
-            if viewModel.tableDataModel.mode == .fill,
-               let decorators = col.decorators,
-               !decorators.isEmpty {
-                let locals = decorators.compactMap { $0.isDisplayable ? DecoratorLocal(from: $0) : nil }
-                if !locals.isEmpty {
-                    FieldDecoratorsView(decorators: locals) { decorator in
+            if viewModel.tableDataModel.mode == .fill {
+                let decorators = viewModel.tableDataModel.getTableCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "")
+                if !decorators.isEmpty {
+                    FieldDecoratorsView(decorators: decorators) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id)
                     }
                 }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -241,7 +241,7 @@ struct EditMultipleRowsSheetView: View {
             if viewModel.tableDataModel.mode == .fill {
                 let decorators = viewModel.tableDataModel.getTableCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "")
                 if !decorators.isEmpty {
-                    FieldDecoratorsView(decorators: decorators) { decorator in
+                    FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id)
                     }
                 }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -365,7 +365,7 @@ struct TableModalView : View {
                             .accessibilityIdentifier("SingleClickEditButton\(index)")
                     }
                     if viewModel.showRowDecorators {
-                        RowDecoratorMenuView(decorators: viewModel.tableDataModel.getTableRowDecorators(forRowID: rowModel.rowID)) { decorator in
+                        RowDecoratorMenuView(decorators: viewModel.tableDataModel.getTableRowDecorators(forRowID: rowModel.rowID), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
                             viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                         }
                         .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -365,7 +365,7 @@ struct TableModalView : View {
                             .accessibilityIdentifier("SingleClickEditButton\(index)")
                     }
                     if viewModel.showRowDecorators {
-                        RowDecoratorMenuView(decorators: viewModel.tableDataModel.rowDecorators) { decorator in
+                        RowDecoratorMenuView(decorators: viewModel.tableDataModel.getTableRowDecorators(forRowID: rowModel.rowID)) { decorator in
                             viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                         }
                         .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -649,6 +649,7 @@ extension TableViewModel: DocumentEditorDelegate {
 
         // Row + cell decorator maps
         if field.fieldType == .table {
+            tableDataModel.decorate = field.decorate ?? false
             tableDataModel.valueToValueElements = field.valueToValueElements
             refreshRowDecoratorMap()
         }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -638,19 +638,19 @@ extension TableViewModel: DocumentEditorDelegate {
     func decoratorsDidChange() {
         guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
 
-        // Row decorators
-        if field.fieldType == .table {
-            tableDataModel.valueToValueElements = field.valueToValueElements
-            refreshRowDecoratorMap()
-        }
-
-        // Column decorators
+        // Column decorators — refresh first so the row/cell maps below read fresh common column decorators
         if let freshColumns = field.tableColumns {
             for (i, col) in tableDataModel.tableColumns.enumerated() {
                 if let freshCol = freshColumns.first(where: { $0.id == col.id }) {
                     tableDataModel.tableColumns[i].decorators = freshCol.decorators
                 }
             }
+        }
+
+        // Row + cell decorator maps
+        if field.fieldType == .table {
+            tableDataModel.valueToValueElements = field.valueToValueElements
+            refreshRowDecoratorMap()
         }
     }
 

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -32,6 +32,16 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         tableDataModel.setTableRowDecorators(rowDecorators: field.rowDecorators, rows: tableDataModel.valueToValueElements ?? [])
     }
 
+    /// Seeds the row + cell decorator caches for a single newly-inserted
+    /// row so common `rowDecorators` show up immediately without rebuilding
+    /// the cache for every existing row in the table.
+    private func seedRowDecorators(for row: ValueElement) {
+        let fieldRowDecorators = tableDataModel.documentEditor?
+            .field(fieldID: tableDataModel.fieldIdentifier.fieldID)?
+            .rowDecorators
+        tableDataModel.updateTableRowDecorators(for: row, fieldRowDecorators: fieldRowDecorators)
+    }
+
     init(tableDataModel: TableDataModel) {
         self.tableDataModel = tableDataModel
         self.showRowSelector = tableDataModel.mode == .fill
@@ -195,6 +205,8 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
             Log("Could not find index of last selected row", type: .error)
             return nil
         }
+
+        seedRowDecorators(for: targetRows.0)
         updateRow(valueElement: targetRows.0, at: lastRowIndex+1)
         tableDataModel.emptySelection()
         return targetRows.0.id
@@ -316,7 +328,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
             shouldSendEvent: shouldSendEvent
         ) {
             tableDataModel.valueToValueElements = result.0
-            refreshRowDecoratorMap()
+            seedRowDecorators(for: result.1)
             updateRow(valueElement: result.1, at: tableDataModel.rowOrder.count)
         } else {
             Log("Row data is nil", type: .error)
@@ -330,7 +342,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         
         if let result = tableDataModel.documentEditor?.insertRow(at: index, id: id, cellValues: cellValues, metadata: metadata, fieldIdentifier: tableDataModel.fieldIdentifier, shouldSendEvent: shouldSendEvent) {
             tableDataModel.valueToValueElements = result.0
-            refreshRowDecoratorMap()
+            seedRowDecorators(for: result.1)
             updateRow(valueElement: result.1, at: index)
         } else {
             Log("Row data is nil", type: .error)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -27,6 +27,11 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         return tableDataModel.decorate && tableDataModel.mode == .fill
     }
 
+    private func refreshRowDecoratorMap() {
+        guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
+        tableDataModel.setTableRowDecorators(rowDecorators: field.rowDecorators, rows: tableDataModel.valueToValueElements ?? [])
+    }
+
     init(tableDataModel: TableDataModel) {
         self.tableDataModel = tableDataModel
         self.showRowSelector = tableDataModel.mode == .fill
@@ -311,6 +316,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
             shouldSendEvent: shouldSendEvent
         ) {
             tableDataModel.valueToValueElements = result.0
+            refreshRowDecoratorMap()
             updateRow(valueElement: result.1, at: tableDataModel.rowOrder.count)
         } else {
             Log("Row data is nil", type: .error)
@@ -324,6 +330,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         
         if let result = tableDataModel.documentEditor?.insertRow(at: index, id: id, cellValues: cellValues, metadata: metadata, fieldIdentifier: tableDataModel.fieldIdentifier, shouldSendEvent: shouldSendEvent) {
             tableDataModel.valueToValueElements = result.0
+            refreshRowDecoratorMap()
             updateRow(valueElement: result.1, at: index)
         } else {
             Log("Row data is nil", type: .error)
@@ -633,7 +640,8 @@ extension TableViewModel: DocumentEditorDelegate {
 
         // Row decorators
         if field.fieldType == .table {
-//            tableDataModel.rowDecorators = field.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+            tableDataModel.valueToValueElements = field.valueToValueElements
+            refreshRowDecoratorMap()
         }
 
         // Column decorators

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -24,7 +24,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
     }
 
     var showRowDecorators: Bool {
-        return !tableDataModel.rowDecorators.isEmpty && tableDataModel.mode == .fill
+        return tableDataModel.decorate && tableDataModel.mode == .fill
     }
 
     init(tableDataModel: TableDataModel) {
@@ -633,7 +633,7 @@ extension TableViewModel: DocumentEditorDelegate {
 
         // Row decorators
         if field.fieldType == .table {
-            tableDataModel.rowDecorators = field.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
+//            tableDataModel.rowDecorators = field.rowDecorators?.filter { $0.isDisplayable }.map(DecoratorLocal.init(from:)) ?? []
         }
 
         // Column decorators

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -204,6 +204,10 @@ private extension DocumentEditor {
         case .rowSelf:
             schemaKey = target.hops.last?.schemaKey
         default:
+            // .field / .commonColumn / .cell / .rowScopedColumn — none reserve
+            // the row-decorator column. Cell and row-scoped-column decorators
+            // render within the cell body (next to the column title), so they
+            // intentionally do not flip `decorate` on.
             return
         }
 
@@ -242,6 +246,9 @@ private extension DocumentEditor {
         case .rowSelf:
             schemaKey = target.hops.last?.schemaKey
         default:
+            // .field / .commonColumn / .cell / .rowScopedColumn — none drive
+            // the row-decorator column, so removing one never flips `decorate`
+            // off. Cell decorators in particular render within the cell body.
             return
         }
 
@@ -566,7 +573,7 @@ private extension DocumentEditor {
                   let children = row.childrens?[sk] else { return nil }
             currentRows = children.valueToValueElements ?? []
         }
-        return nil
+        return nil // unreachable: loop always returns; required to satisfy the compiler.
     }
 
     /// Recursively rewrites the row tree to apply the terminator's new decorator list at the deepest hop.

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -4,13 +4,16 @@ public extension DocumentEditor {
 
     // MARK: - Path-Based API
     //
-    // path = "pageId/fieldPositionId"              → field decorators
-    // path = "pageId/fieldPositionId/rows"         → common row decorators   (table: field.rowDecorators)
-    // path = "pageId/fieldPositionId/{rowId}"      → row-specific decorators (table: ValueElement.decorators.all)
-    // path = "pageId/fieldPositionId/{rowId}/colId" → column decorators
+    // path = "pageId/fieldPositionId"                    → field decorators
+    // path = "pageId/fieldPositionId/rows"               → common row decorators    (table: field.rowDecorators)
+    // path = "pageId/fieldPositionId/{rowId}"            → row-specific decorators  (table: ValueElement.decorators.all)
+    // path = "pageId/fieldPositionId/columns/{colId}"    → common column decorators (table: tableColumn.decorators)
+    // path = "pageId/fieldPositionId/{rowId}/{colId}"    → cell-specific decorators (table: ValueElement.decorators.cells[colId])
     //
     // Collection fields: the 3rd segment is always a real rowId (used to resolve the schemaKey).
-    // Table fields: "rows" keyword → common; any valid rowId → row-specific (with copy-on-write from common).
+    //   "rows" / "columns" keywords are table-only for now.
+    // Table fields: "rows" keyword → common rows; "columns" keyword → common columns;
+    //   any valid rowId → row-specific / cell-specific (with copy-on-write from common).
     //
     // Note: Path segments are parsed with empty-component filtering;
     // consecutive or trailing slashes are treated as single separators.
@@ -43,11 +46,14 @@ public extension DocumentEditor {
             }
         }
         var list = fetchDecorators(for: target)
-        // Copy-on-write: if adding to a row-specific target with no existing row-specific
-        // decorators, seed the list with the common row decorators first so that row
-        // diverges from common while keeping all previously-visible decorators.
+        // Copy-on-write: if adding to a row-specific / cell-specific target with no existing
+        // decorators on that scope, seed the list with the matching common decorators first so
+        // the row/cell diverges from common while keeping all previously-visible decorators.
         if case .rowSpecific(let fID, _) = target, list.isEmpty {
             list = rowDecoratorsForPath(fieldID: fID, schemaKey: nil)
+        }
+        if case .cellSpecific(let fID, _, let colID) = target, list.isEmpty {
+            list = columnDecoratorsForPath(fieldID: fID, columnID: colID, schemaKey: nil)
         }
         let existingActions = Set(list.compactMap { $0.action })
         let newActions = decorators.compactMap { $0.action }
@@ -132,6 +138,7 @@ private extension DocumentEditor {
         case .row(let fieldID, _): return fieldID
         case .rowSpecific(let fieldID, _): return fieldID
         case .column(let fieldID, _, _): return fieldID
+        case .cellSpecific(let fieldID, _, _): return fieldID
         }
     }
 
@@ -176,7 +183,7 @@ private extension DocumentEditor {
             field.decorate = true
             commitDecoratorChange(field: field, fieldID: fieldID)
 
-        case .field, .column:
+        case .field, .column, .cellSpecific:
             break
         }
     }
@@ -268,6 +275,7 @@ private extension DocumentEditor {
         case row(fieldID: String, schemaKey: String?)          // common row decorators
         case rowSpecific(fieldID: String, rowID: String)       // row-specific decorators (table only)
         case column(fieldID: String, columnID: String, schemaKey: String?)
+        case cellSpecific(fieldID: String, rowID: String, columnID: String) // cell-specific decorators (table only)
     }
 
     /// Parses the path and maps it to the correct decorator scope.
@@ -284,17 +292,33 @@ private extension DocumentEditor {
               let field = fieldMap[fieldID] else { return nil }
 
         if let columnId = parsed.columnId {
-            guard let rowId = parsed.rowId else { return nil }
-            guard rowExistsInField(fieldID: fieldID, rowId: rowId) else { return nil }
-            // 4 segments → column decorators; rowId resolves the schema for collection fields
-            let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
-            guard columnExistsInField(field, columnId: columnId, schemaKey: schemaKey) else { return nil }
-            return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
+            guard let rowSegment = parsed.rowId else { return nil }
+            if field.fieldType == .table {
+                if rowSegment == "columns" {
+                    // "columns/{colId}" → common column decorators
+                    guard columnExistsInField(field, columnId: columnId, schemaKey: nil) else { return nil }
+                    return .column(fieldID: fieldID, columnID: columnId, schemaKey: nil)
+                }
+                // "{rowId}/{colId}" → cell-specific decorators
+                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
+                guard columnExistsInField(field, columnId: columnId, schemaKey: nil) else { return nil }
+                return .cellSpecific(fieldID: fieldID, rowID: rowSegment, columnID: columnId)
+            } else {
+                // Collection: rowId resolves the schema for the column
+                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
+                let schemaKey = resolvedSchemaKey(forRowID: rowSegment, inFieldID: fieldID)
+                guard columnExistsInField(field, columnId: columnId, schemaKey: schemaKey) else { return nil }
+                return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
+            }
         } else if let rowSegment = parsed.rowId {
             if field.fieldType == .table {
                 if rowSegment == "rows" {
                     // "rows" keyword → common row decorators on the field
                     return .row(fieldID: fieldID, schemaKey: nil)
+                }
+                if rowSegment == "columns" {
+                    // "columns" without a columnID is an invalid path — decorators live per column
+                    return nil
                 }
                 // Actual rowId → row-specific decorators
                 guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
@@ -382,6 +406,26 @@ private extension DocumentEditor {
         commitDecoratorChange(field: field, fieldID: fieldID)
     }
 
+    // MARK: Cell-specific decorator read/write (table only)
+
+    func cellSpecificDecoratorsForPath(fieldID: String, rowID: String, columnID: String) -> [Decorator] {
+        guard let field = fieldMap[fieldID] else { return [] }
+        return field.valueToValueElements?.first(where: { $0.id == rowID })?.decorators?.cells[columnID] ?? []
+    }
+
+    func setCellSpecificDecoratorsForPath(_ decorators: [Decorator], fieldID: String, rowID: String, columnID: String) {
+        guard var field = fieldMap[fieldID],
+              var rows = field.valueToValueElements,
+              let index = rows.firstIndex(where: { $0.id == rowID }) else { return }
+        var decs = rows[index].decorators ?? Decorators()
+        var cells = decs.cells
+        cells[columnID] = decorators
+        decs.cells = cells
+        rows[index].decorators = decs
+        field.value = ValueUnion.valueElementArray(rows)
+        commitDecoratorChange(field: field, fieldID: fieldID)
+    }
+
     // MARK: Row decorator read/write (path-based, independent of the public API)
 
     /// Reads row decorators directly from the field model.
@@ -425,6 +469,8 @@ private extension DocumentEditor {
             return rowSpecificDecoratorsForPath(fieldID: fieldID, rowID: rowID)
         case .column(let fieldID, let columnID, let schemaKey):
             return columnDecoratorsForPath(fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
+        case .cellSpecific(let fieldID, let rowID, let columnID):
+            return cellSpecificDecoratorsForPath(fieldID: fieldID, rowID: rowID, columnID: columnID)
         }
     }
 
@@ -439,6 +485,8 @@ private extension DocumentEditor {
             setRowSpecificDecoratorsForPath(decorators, fieldID: fieldID, rowID: rowID)
         case .column(let fieldID, let columnID, let schemaKey):
             setColumnDecoratorsForPath(decorators, fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
+        case .cellSpecific(let fieldID, let rowID, let columnID):
+            setCellSpecificDecoratorsForPath(decorators, fieldID: fieldID, rowID: rowID, columnID: columnID)
         }
     }
 }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -81,8 +81,11 @@ public extension DocumentEditor {
         }
 
         list.append(contentsOf: decorators)
-        ensureDecorateEnabled(for: target)
-        applyDecorators(list, for: target)
+
+        guard var field = fieldMap[target.fieldID] else { return }
+        applyDecorators(list, for: target, in: &field)
+        ensureDecorateEnabled(for: target, in: &field)
+        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
     /// Removes the decorator whose `action` matches at the given path.
@@ -98,7 +101,11 @@ public extension DocumentEditor {
             return
         }
         list.remove(at: index)
-        applyDecorators(list, for: target)
+
+        guard var field = fieldMap[target.fieldID] else { return }
+        applyDecorators(list, for: target, in: &field)
+        ensureDecorateDisabledIfEmpty(for: target, in: &field)
+        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
     /// Replaces the decorator whose `action` matches with the new decorator at the given path.
@@ -126,7 +133,11 @@ public extension DocumentEditor {
             return
         }
         list[index] = decorator
-        applyDecorators(list, for: target)
+
+        guard var field = fieldMap[target.fieldID] else { return }
+        applyDecorators(list, for: target, in: &field)
+        ensureDecorateDisabledIfEmpty(for: target, in: &field)
+        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 }
 
@@ -197,7 +208,8 @@ private extension DocumentEditor {
 
     /// Sets `decorate = true` on the field (table) or schema entry (collection) when
     /// row-level decorators are added, so the decorator column shows automatically.
-    func ensureDecorateEnabled(for target: DecoratorTarget) {
+    /// Mutates `field` in place; the caller commits.
+    func ensureDecorateEnabled(for target: DecoratorTarget, in field: inout JoyDocField) {
         let schemaKey: String?
         switch target.terminator {
         case .commonRows(let sk):
@@ -207,7 +219,6 @@ private extension DocumentEditor {
         default:
             return
         }
-        guard var field = fieldMap[target.fieldID] else { return }
 
         if let sk = schemaKey {
             guard var schema = field.schema, var entry = schema[sk] else { return }
@@ -219,13 +230,92 @@ private extension DocumentEditor {
             guard field.decorate != true else { return }
             field.decorate = true
         }
-        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
     func commitDecoratorChange(field: JoyDocField, fieldID: String) {
         updateField(field: field)
         refreshField(fieldId: fieldID)
         valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
+    }
+
+    /// Mirror of `ensureDecorateEnabled`. Flips `decorate` to `false` on the target's
+    /// scope only when no displayable row decorators remain anywhere in that scope —
+    /// neither common row decorators nor row-specific decorators on any row.
+    ///
+    /// Scope:
+    /// - Table fields: the entire field (checks `field.rowDecorators` + every row's `decorators.all`).
+    /// - Collection fields: the specific schema key (checks `schema[sk].rowDecorators` +
+    ///   every row belonging to that schema, including nested occurrences).
+    /// Mutates `field` in place; the caller commits.
+    func ensureDecorateDisabledIfEmpty(for target: DecoratorTarget, in field: inout JoyDocField) {
+        let schemaKey: String?
+        switch target.terminator {
+        case .commonRows(let sk):
+            schemaKey = sk
+        case .rowSelf:
+            schemaKey = target.hops.last?.schemaKey
+        default:
+            return
+        }
+
+        // 1. Any displayable common row decorators at this scope?
+        let commonDecs: [Decorator]
+        if let sk = schemaKey {
+            commonDecs = field.schema?[sk]?.rowDecorators ?? []
+        } else {
+            commonDecs = field.rowDecorators ?? []
+        }
+        if commonDecs.contains(where: { $0.isDisplayable }) { return }
+
+        // 2. Any displayable row-specific decorator on any row in this scope?
+        let rows = rowsInScope(field: field, schemaKey: schemaKey)
+        let anyRowSpecific = rows.contains { row in
+            (row.decorators?.all ?? []).contains(where: { $0.isDisplayable })
+        }
+        if anyRowSpecific { return }
+
+        // 3. Scope is empty — flip decorate off.
+        if let sk = schemaKey {
+            guard var schema = field.schema, var entry = schema[sk], entry.decorate == true else { return }
+            entry.decorate = false
+            schema[sk] = entry
+            field.schema = schema
+        } else {
+            guard field.decorate == true else { return }
+            field.decorate = false
+        }
+    }
+
+    /// Returns every row that belongs to `schemaKey` within `field`.
+    /// - Table fields or `schemaKey == nil`: top-level rows.
+    /// - Collection root schema: top-level rows.
+    /// - Collection nested schema: walks the entire row tree collecting rows stored under
+    ///   any `row.childrens[schemaKey]` (supports the same schema appearing at multiple depths).
+    func rowsInScope(field: JoyDocField, schemaKey: String?) -> [ValueElement] {
+        let top = field.valueToValueElements ?? []
+        guard field.fieldType == .collection, let sk = schemaKey else {
+            return top
+        }
+        let rootKey = field.schema?.first(where: { $0.value.root == true })?.key
+        if sk == rootKey {
+            return top
+        }
+        var collected: [ValueElement] = []
+        func walk(_ rows: [ValueElement]) {
+            for row in rows {
+                guard let childrens = row.childrens else { continue }
+                if let match = childrens[sk] {
+                    let matchRows = match.valueToValueElements ?? []
+                    collected.append(contentsOf: matchRows)
+                    walk(matchRows)
+                }
+                for (key, children) in childrens where key != sk {
+                    walk(children.valueToValueElements ?? [])
+                }
+            }
+        }
+        walk(top)
+        return collected
     }
 
     // MARK: COW seed
@@ -428,9 +518,9 @@ private extension DocumentEditor {
         }
     }
 
-    func applyDecorators(_ decorators: [Decorator], for target: DecoratorTarget) {
-        guard var field = fieldMap[target.fieldID] else { return }
-
+    /// Writes `decorators` into the correct slot on `field` based on `target.terminator`.
+    /// Mutates `field` in place; the caller commits.
+    func applyDecorators(_ decorators: [Decorator], for target: DecoratorTarget, in field: inout JoyDocField) {
         switch target.terminator {
         case .field:
             field.decorators = decorators
@@ -468,8 +558,6 @@ private extension DocumentEditor {
             rewriteRows(&rows, hops: target.hops, depth: 0, terminator: target.terminator, newList: decorators)
             field.value = ValueUnion.valueElementArray(rows)
         }
-
-        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
     // MARK: Row tree walking

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -408,6 +408,9 @@ private extension DocumentEditor {
                 let hopSchema: String?
                 if hasPendingSchema {
                     hopSchema = pendingSchema
+                    if hops.isEmpty, hopSchema != rootSchemaKey {
+                        return nil
+                    }
                 } else if hops.isEmpty {
                     hopSchema = rootSchemaKey  // nil for table
                 } else {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -3,6 +3,12 @@ import JoyfillModel
 public extension DocumentEditor {
 
     // MARK: - Decorator API (path-based)
+    //
+    // Note: Path segments are parsed with empty-component filtering;
+    // consecutive or trailing slashes are treated as single separators.
+    //
+    // All methods in this section must be called on the main thread,
+    // consistent with the DocumentEditor threading model.
 
     /// Returns decorators at `path`, or `[]` if the path doesn't resolve / the
     /// scope is empty. Does not trigger copy-on-write seeding.

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -4,22 +4,34 @@ public extension DocumentEditor {
 
     // MARK: - Path-Based API
     //
-    // path = "pageId/fieldPositionId"                    → field decorators
-    // path = "pageId/fieldPositionId/rows"               → common row decorators    (table: field.rowDecorators)
-    // path = "pageId/fieldPositionId/{rowId}"            → row-specific decorators  (table: ValueElement.decorators.all)
-    // path = "pageId/fieldPositionId/columns/{colId}"    → common column decorators (table: tableColumn.decorators)
-    // path = "pageId/fieldPositionId/{rowId}/{colId}"    → cell-specific decorators (table: ValueElement.decorators.cells[colId])
+    // Grammar (segments are "/"-separated; empty segments are ignored):
     //
-    // Collection fields: the 3rd segment is always a real rowId (used to resolve the schemaKey).
-    //   "rows" / "columns" keywords are table-only for now.
-    // Table fields: "rows" keyword → common rows; "columns" keyword → common columns;
-    //   any valid rowId → row-specific / cell-specific (with copy-on-write from common).
+    //   path := page-id "/" field-position-id [ rest ]
+    //   rest := "rows"                                  → common rows of root schema (or table)
+    //         | "columns/" col                          → common column of root schema (or table)
+    //         | "schemas/" sk "/rows"                   → common rows of schema sk
+    //         | "schemas/" sk "/columns/" col           → common column of schema sk
+    //         | "schemas/" sk "/" row rowRest           → a row inside schema sk
+    //         | row rowRest                             → a row at root schema
+    //   rowRest := ε                                     → that row's dedicated decorators
+    //            | col                                   → cell (row × col)
+    //            | "columns/" col                        → row-scoped column  (aliases cell storage)
+    //            | "schemas/" sk "/" row rowRest         → descend into child schema
     //
-    // Note: Path segments are parsed with empty-component filtering;
-    // consecutive or trailing slashes are treated as single separators.
+    // Tables cannot use "schemas/..." — they have no schema tree.
     //
-    // All methods in this section must be called on the main thread,
-    // consistent with the DocumentEditor threading model.
+    // Storage map:
+    //   field                            → field.decorators
+    //   commonRows(sk?)                  → sk?  ? field.schema[sk].rowDecorators : field.rowDecorators
+    //   commonColumn(sk?, col)           → sk?  ? field.schema[sk].tableColumns[col].decorators : field.tableColumns[col].decorators
+    //   rowSelf                          → ValueElement.decorators.all           (at the end of the hop chain)
+    //   cell(col) / rowScopedColumn(col) → ValueElement.decorators.cells[col]    (aliased storage)
+    //
+    // Copy-on-write: adding to rowSelf / cell / rowScopedColumn when the scope is empty
+    // seeds from the matching common scope first so the specific scope diverges without
+    // losing previously-visible decorators.
+    //
+    // All methods must be called on the main thread.
 
     /// Returns all decorators at the given path.
     func getDecorators(path: String) -> [Decorator] {
@@ -38,44 +50,39 @@ public extension DocumentEditor {
             return
         }
         guard licenseAllowsDecoratorWrite(for: target, path: path) else { return }
-        
+
         for decorator in decorators {
             if let error = validateDecorator(decorator) {
                 events?.onError(error: .decoratorError(error: DecoratorError(message: error)))
                 return
             }
         }
+
         var list = fetchDecorators(for: target)
-        // Copy-on-write: if adding to a row-specific / cell-specific target with no existing
-        // decorators on that scope, seed the list with the matching common decorators first so
-        // the row/cell diverges from common while keeping all previously-visible decorators.
-        if case .rowSpecific(let fID, _) = target, list.isEmpty {
-            list = rowDecoratorsForPath(fieldID: fID, schemaKey: nil)
+        // Copy-on-write seed for specific scopes
+        if list.isEmpty, let seed = commonSeed(for: target) {
+            list = seed
         }
-        if case .cellSpecific(let fID, _, let colID) = target, list.isEmpty {
-            list = columnDecoratorsForPath(fieldID: fID, columnID: colID, schemaKey: nil)
-        }
+
         let existingActions = Set(list.compactMap { $0.action })
         let newActions = decorators.compactMap { $0.action }
 
-        // Check duplicates within incoming batch
         if Set(newActions).count != newActions.count {
             events?.onError(error: .decoratorError(error: DecoratorError(
                 message: "Duplicate decorators found in the incoming batch at path '\(path)'"
             )))
             return
         }
-
-        // Check duplicates against existing decorators
         if let duplicate = newActions.first(where: { existingActions.contains($0) }) {
             events?.onError(error: .decoratorError(error: DecoratorError(
                 message: "Decorator with action '\(duplicate)' already exists at path '\(path)'"
             )))
             return
         }
+
         list.append(contentsOf: decorators)
-        applyDecorators(list, for: target)
         ensureDecorateEnabled(for: target)
+        applyDecorators(list, for: target)
     }
 
     /// Removes the decorator whose `action` matches at the given path.
@@ -110,8 +117,6 @@ public extension DocumentEditor {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to update decorator with action: '\(action)'")))
             return
         }
-        // If the new decorator's action differs from the target action, ensure it
-        // doesn't collide with a different existing entry (would create duplicates).
         if let newAction = decorator.action,
            newAction != action,
            list.contains(where: { $0.action == newAction }) {
@@ -125,28 +130,42 @@ public extension DocumentEditor {
     }
 }
 
+// MARK: - Internal target model
+
+private extension DocumentEditor {
+
+    /// A resolved decorator location: a chain of hops through the row/schema tree, plus a terminator.
+    struct DecoratorTarget {
+        let fieldID: String
+        let hops: [Hop]
+        let terminator: Terminator
+
+        struct Hop {
+            /// Schema key the row lives in. Table fields: always nil.
+            /// Collection fields: root hop = root schema key; nested hops = the preceding `schemas/sk` key.
+            let schemaKey: String?
+            let rowID: String
+        }
+
+        enum Terminator {
+            case field
+            case commonRows(schemaKey: String?)                       // nil → table root
+            case commonColumn(schemaKey: String?, columnID: String)
+            case rowSelf                                              // hops.last is the row
+            case cell(columnID: String)
+            case rowScopedColumn(columnID: String)                    // aliased to cell storage
+        }
+    }
+}
+
 // MARK: - Private helpers
 
 private extension DocumentEditor {
 
     // MARK: License gating
 
-    /// Returns the fieldID associated with a decorator target.
-    func fieldID(for target: DecoratorTarget) -> String {
-        switch target {
-        case .field(let fieldID): return fieldID
-        case .row(let fieldID, _): return fieldID
-        case .rowSpecific(let fieldID, _): return fieldID
-        case .column(let fieldID, _, _): return fieldID
-        case .cellSpecific(let fieldID, _, _): return fieldID
-        }
-    }
-
-    /// Blocks writes to collection-field decorators when the collection feature
-    /// is not enabled by the license. Emits a decoratorError and returns false.
     func licenseAllowsDecoratorWrite(for target: DecoratorTarget, path: String) -> Bool {
-        let fieldID = self.fieldID(for: target)
-        guard let field = fieldMap[fieldID] else { return true }
+        guard let field = fieldMap[target.fieldID] else { return true }
         if field.fieldType == .collection && !isCollectionFieldEnabled {
             events?.onError(error: .decoratorError(error: DecoratorError(
                 message: "Collection field decorators are not available without a valid license (path '\(path)')"
@@ -156,48 +175,8 @@ private extension DocumentEditor {
         return true
     }
 
-    // MARK: Decorate flag
-
-    /// Sets `decorate = true` on the field (table) or schema entry (collection) when
-    /// row decorators are added, so the decorator column is shown automatically.
-    func ensureDecorateEnabled(for target: DecoratorTarget) {
-        switch target {
-        case .row(let fieldID, let schemaKey):
-            guard var field = fieldMap[fieldID] else { return }
-            if let schemaKey = schemaKey {
-                // Collection: set decorate on the specific schema entry
-                guard var schema = field.schema, var entry = schema[schemaKey] else { return }
-                guard entry.decorate != true else { return }
-                entry.decorate = true
-                schema[schemaKey] = entry
-                field.schema = schema
-            } else {
-                // Table: set decorate on the field
-                guard field.decorate != true else { return }
-                field.decorate = true
-            }
-            commitDecoratorChange(field: field, fieldID: fieldID)
-
-        case .rowSpecific(let fieldID, _):
-            guard var field = fieldMap[fieldID], field.decorate != true else { return }
-            field.decorate = true
-            commitDecoratorChange(field: field, fieldID: fieldID)
-
-        case .field, .column, .cellSpecific:
-            break
-        }
-    }
-
-    /// Persists a field mutation and notifies the view layer that decorators changed.
-    func commitDecoratorChange(field: JoyDocField, fieldID: String) {
-        updateField(field: field)
-        refreshField(fieldId: fieldID)
-        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
-    }
-
     // MARK: Decorator validation
 
-    /// Validates decorator properties. Returns an error message if invalid, nil if valid.
     func validateDecorator(_ decorator: Decorator) -> String? {
         if let action = decorator.action, action.isEmpty {
             return "Invalid decorator property: 'action' must not be empty"
@@ -214,279 +193,341 @@ private extension DocumentEditor {
         return nil
     }
 
-    // MARK: Field Decorators
+    // MARK: Decorate flag
 
-    func decorators(forFieldID fieldID: String) -> [Decorator] {
-        fieldMap[fieldID]?.decorators ?? []
+    /// Sets `decorate = true` on the field (table) or schema entry (collection) when
+    /// row-level decorators are added, so the decorator column shows automatically.
+    func ensureDecorateEnabled(for target: DecoratorTarget) {
+        let schemaKey: String?
+        switch target.terminator {
+        case .commonRows(let sk):
+            schemaKey = sk
+        case .rowSelf:
+            schemaKey = target.hops.last?.schemaKey
+        default:
+            return
+        }
+        guard var field = fieldMap[target.fieldID] else { return }
+
+        if let sk = schemaKey {
+            guard var schema = field.schema, var entry = schema[sk] else { return }
+            guard entry.decorate != true else { return }
+            entry.decorate = true
+            schema[sk] = entry
+            field.schema = schema
+        } else {
+            guard field.decorate != true else { return }
+            field.decorate = true
+        }
+        commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
-    func setDecorators(_ decorators: [Decorator], forFieldID fieldID: String) {
-        guard var field = fieldMap[fieldID] else { return }
-        field.decorators = decorators
+    func commitDecoratorChange(field: JoyDocField, fieldID: String) {
         updateField(field: field)
         refreshField(fieldId: fieldID)
+        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
     }
 
-    // MARK: Column Decorators
-    //
-    // - Table fields:      columns live on field.tableColumns      → schemaKey is nil
-    // - Collection fields: columns live on field.schema[key].tableColumns → schemaKey is non-nil
+    // MARK: COW seed
 
-    func columnDecoratorsForPath(fieldID: String, columnID: String, schemaKey: String?) -> [Decorator] {
-        guard let field = fieldMap[fieldID] else { return [] }
-        let columns: [FieldTableColumn]?
-        if field.fieldType == .collection {
-            guard let schemaKey = schemaKey else { return [] }
-            columns = field.schema?[schemaKey]?.tableColumns
-        } else {
-            columns = field.tableColumns
+    /// Returns the common-scope decorators to seed a specific scope with, if any.
+    func commonSeed(for target: DecoratorTarget) -> [Decorator]? {
+        let seedTerminator: DecoratorTarget.Terminator
+        switch target.terminator {
+        case .rowSelf:
+            seedTerminator = .commonRows(schemaKey: target.hops.last?.schemaKey)
+        case .cell(let col), .rowScopedColumn(let col):
+            seedTerminator = .commonColumn(schemaKey: target.hops.last?.schemaKey, columnID: col)
+        default:
+            return nil
         }
-        return columns?.first(where: { $0.id == columnID })?.decorators ?? []
+        let seedTarget = DecoratorTarget(fieldID: target.fieldID, hops: [], terminator: seedTerminator)
+        return fetchDecorators(for: seedTarget)
     }
 
-    func setColumnDecoratorsForPath(_ decorators: [Decorator], fieldID: String, columnID: String, schemaKey: String?) {
-        guard var field = fieldMap[fieldID] else { return }
-        if field.fieldType == .collection {
-            // Collection field: update column inside the schema entry
-            guard let schemaKey = schemaKey,
-                  var schema    = field.schema,
-                  var entry     = schema[schemaKey],
-                  var columns   = entry.tableColumns,
-                  let colIndex  = columns.firstIndex(where: { $0.id == columnID }) else { return }
-            columns[colIndex].decorators = decorators
-            entry.tableColumns  = columns
-            schema[schemaKey]   = entry
-            field.schema        = schema
-        } else {
-            // Table field: update column directly on the field
-            guard var columns  = field.tableColumns,
-                  let colIndex = columns.firstIndex(where: { $0.id == columnID }) else { return }
-            columns[colIndex].decorators = decorators
-            field.tableColumns = columns
-        }
-        commitDecoratorChange(field: field, fieldID: fieldID)
-    }
+    // MARK: Path parsing
 
-    // MARK: Path resolution
-
-    /// Resolved decorator scope from a path string.
-    enum DecoratorTarget {
-        case field(fieldID: String)
-        case row(fieldID: String, schemaKey: String?)          // common row decorators
-        case rowSpecific(fieldID: String, rowID: String)       // row-specific decorators (table only)
-        case column(fieldID: String, columnID: String, schemaKey: String?)
-        case cellSpecific(fieldID: String, rowID: String, columnID: String) // cell-specific decorators (table only)
-    }
-
-    /// Parses the path and maps it to the correct decorator scope.
-    /// The rowId segment resolves the schemaKey for both row and column paths on
-    /// collection fields. Table fields always resolve to schemaKey = nil.
+    /// Parses the path string into a DecoratorTarget, validating each segment along the way.
     func resolveDecoratorTarget(path: String) -> DecoratorTarget? {
-        let parsed = DocumentEditor.parsePath(path)
+        let segments = path
+            .split(separator: "/")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
 
-        guard let pageId = parsed.pageId,
-              let fieldPositionId = parsed.fieldPositionId,
-              let page = pagesForCurrentView.first(where: { $0.id == pageId }),
+        guard segments.count >= 2 else { return nil }
+        let pageId = segments[0]
+        let fieldPositionId = segments[1]
+
+        guard let page = pagesForCurrentView.first(where: { $0.id == pageId }),
               let position = page.fieldPositions?.first(where: { $0.id == fieldPositionId }),
               let fieldID = position.field,
               let field = fieldMap[fieldID] else { return nil }
 
-        if let columnId = parsed.columnId {
-            guard let rowSegment = parsed.rowId else { return nil }
-            if field.fieldType == .table {
-                if rowSegment == "columns" {
-                    // "columns/{colId}" → common column decorators
-                    guard columnExistsInField(field, columnId: columnId, schemaKey: nil) else { return nil }
-                    return .column(fieldID: fieldID, columnID: columnId, schemaKey: nil)
+        let isCollection = field.fieldType == .collection
+        let rootSchemaKey: String? = isCollection
+            ? field.schema?.first(where: { $0.value.root == true })?.key
+            : nil
+
+        var hops: [DecoratorTarget.Hop] = []
+        var pendingSchema: String? = nil      // last `schemas/sk` consumed, pending binding
+        var hasPendingSchema = false
+        var cursor = 2
+
+        while cursor < segments.count {
+            let tok = segments[cursor]
+
+            switch tok {
+            case "schemas":
+                if !isCollection { return nil }
+                cursor += 1
+                guard cursor < segments.count else { return nil }
+                pendingSchema = segments[cursor]
+                hasPendingSchema = true
+                cursor += 1
+                guard cursor < segments.count else { return nil } // must be followed by rows / columns / row-id
+
+            case "rows":
+                cursor += 1
+                guard cursor == segments.count else { return nil }
+                let sk: String?
+                if hasPendingSchema {
+                    sk = pendingSchema
+                } else if !hops.isEmpty {
+                    // fp/row-id/rows is not defined in the spec
+                    return nil
+                } else {
+                    sk = rootSchemaKey
                 }
-                // "{rowId}/{colId}" → cell-specific decorators
-                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
-                guard columnExistsInField(field, columnId: columnId, schemaKey: nil) else { return nil }
-                return .cellSpecific(fieldID: fieldID, rowID: rowSegment, columnID: columnId)
-            } else {
-                // Collection: rowId resolves the schema for the column
-                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
-                let schemaKey = resolvedSchemaKey(forRowID: rowSegment, inFieldID: fieldID)
-                guard columnExistsInField(field, columnId: columnId, schemaKey: schemaKey) else { return nil }
-                return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
-            }
-        } else if let rowSegment = parsed.rowId {
-            if field.fieldType == .table {
-                if rowSegment == "rows" {
-                    // "rows" keyword → common row decorators on the field
-                    return .row(fieldID: fieldID, schemaKey: nil)
+                if let sk = sk, field.schema?[sk] == nil { return nil }
+                return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .commonRows(schemaKey: sk))
+
+            case "columns":
+                cursor += 1
+                guard cursor < segments.count else { return nil }
+                let col = segments[cursor]
+                cursor += 1
+                guard cursor == segments.count else { return nil }
+
+                let contextSk: String?
+                let isRowScoped: Bool
+                if hasPendingSchema {
+                    contextSk = pendingSchema
+                    isRowScoped = false
+                } else if let lastHop = hops.last {
+                    contextSk = lastHop.schemaKey
+                    isRowScoped = true
+                } else {
+                    contextSk = rootSchemaKey
+                    isRowScoped = false
                 }
-                if rowSegment == "columns" {
-                    // "columns" without a columnID is an invalid path — decorators live per column
+
+                guard columnExists(in: field, columnID: col, schemaKey: contextSk) else { return nil }
+
+                if isRowScoped {
+                    return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .rowScopedColumn(columnID: col))
+                }
+                return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .commonColumn(schemaKey: contextSk, columnID: col))
+
+            default:
+                // row-id
+                let rowID = tok
+                cursor += 1
+
+                let hopSchema: String?
+                if hasPendingSchema {
+                    hopSchema = pendingSchema
+                } else if hops.isEmpty {
+                    hopSchema = rootSchemaKey  // nil for table
+                } else {
+                    // collection requires schemas/sk between consecutive rows; tables don't nest
                     return nil
                 }
-                // Actual rowId → row-specific decorators
-                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
-                return .rowSpecific(fieldID: fieldID, rowID: rowSegment)
-            } else {
-                // Collection: rowId always resolves to schema-level row decorators
-                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
-                let schemaKey = resolvedSchemaKey(forRowID: rowSegment, inFieldID: fieldID)
-                return .row(fieldID: fieldID, schemaKey: schemaKey)
-            }
-        } else {
-            // 2 segments → field decorators
-            return .field(fieldID: fieldID)
-        }
-    }
+                hops.append(.init(schemaKey: hopSchema, rowID: rowID))
+                pendingSchema = nil
+                hasPendingSchema = false
 
-    // MARK: Schema key resolution
+                guard rowExistsInField(fieldID: fieldID, rowId: rowID) else { return nil }
 
-    /// Returns the schemaKey the given rowId belongs to.
-    ///
-    /// - Table fields always return nil (row decorators live at field level).
-    /// - Collection fields: root-level rows map to the schema entry where
-    ///   `root == true`; nested rows return the key found in their parent's
-    ///   `childrens` map.
-    func resolvedSchemaKey(forRowID rowID: String, inFieldID fieldID: String) -> String? {
-        guard let field = fieldMap[fieldID] else { return nil }
-
-        // Table fields store row decorators at the field level, no schemaKey needed
-        if field.fieldType == .table { return nil }
-
-        let rootRows = field.valueToValueElements ?? []
-
-        // Root schema = the schema entry flagged with root == true
-        let rootSchemaKey = field.schema?.first { $0.value.root == true }?.key
-
-        // Check root-level rows first
-        if rootRows.contains(where: { $0.id == rowID }) {
-            return rootSchemaKey
-        }
-
-        // Recursively search nested children
-        for row in rootRows {
-            if let found = schemaKey(forRowID: rowID, in: row) {
-                return found
-            }
-        }
-
-        return nil
-    }
-
-    /// Recursively walks a ValueElement's `childrens` map to find which
-    /// schemaKey contains the given rowId.
-    func schemaKey(forRowID rowID: String, in element: ValueElement) -> String? {
-        guard let childrens = element.childrens else { return nil }
-        for (schemaKey, children) in childrens {
-            let childRows = children.valueToValueElements ?? []
-            if childRows.contains(where: { $0.id == rowID }) {
-                return schemaKey
-            }
-            // Go one level deeper
-            for child in childRows {
-                if let found = self.schemaKey(forRowID: rowID, in: child) {
-                    return found
+                if cursor == segments.count {
+                    return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .rowSelf)
                 }
+
+                let next = segments[cursor]
+                if next == "schemas" {
+                    continue // outer loop handles
+                }
+                if next == "columns" {
+                    cursor += 1
+                    guard cursor < segments.count else { return nil }
+                    let col = segments[cursor]
+                    cursor += 1
+                    guard cursor == segments.count else { return nil }
+                    guard columnExists(in: field, columnID: col, schemaKey: hopSchema) else { return nil }
+                    return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .rowScopedColumn(columnID: col))
+                }
+                if next == "rows" {
+                    // fp/.../row-id/rows not defined
+                    return nil
+                }
+                // Bare column id → cell
+                let col = next
+                cursor += 1
+                guard cursor == segments.count else { return nil }
+                guard columnExists(in: field, columnID: col, schemaKey: hopSchema) else { return nil }
+                return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .cell(columnID: col))
             }
+        }
+
+        // No rest → field-level
+        if hasPendingSchema { return nil }
+        return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .field)
+    }
+
+    // MARK: Column existence
+
+    func columnExists(in field: JoyDocField, columnID: String, schemaKey: String?) -> Bool {
+        let cols: [FieldTableColumn]?
+        if let sk = schemaKey {
+            cols = field.schema?[sk]?.tableColumns
+        } else {
+            cols = field.tableColumns
+        }
+        return (cols ?? []).contains(where: { $0.id == columnID })
+    }
+
+    // MARK: Fetch / apply
+
+    func fetchDecorators(for target: DecoratorTarget) -> [Decorator] {
+        guard let field = fieldMap[target.fieldID] else { return [] }
+        switch target.terminator {
+        case .field:
+            return field.decorators ?? []
+
+        case .commonRows(let sk):
+            if let sk = sk {
+                return field.schema?[sk]?.rowDecorators ?? []
+            }
+            return field.rowDecorators ?? []
+
+        case .commonColumn(let sk, let col):
+            let cols: [FieldTableColumn]?
+            if let sk = sk {
+                cols = field.schema?[sk]?.tableColumns
+            } else {
+                cols = field.tableColumns
+            }
+            return cols?.first(where: { $0.id == col })?.decorators ?? []
+
+        case .rowSelf:
+            guard let element = valueElement(at: target.hops, in: field) else { return [] }
+            return element.decorators?.all ?? []
+
+        case .cell(let col), .rowScopedColumn(let col):
+            guard let element = valueElement(at: target.hops, in: field) else { return [] }
+            return element.decorators?.cells[col] ?? []
+        }
+    }
+
+    func applyDecorators(_ decorators: [Decorator], for target: DecoratorTarget) {
+        guard var field = fieldMap[target.fieldID] else { return }
+
+        switch target.terminator {
+        case .field:
+            field.decorators = decorators
+
+        case .commonRows(let sk):
+            if let sk = sk {
+                guard var schema = field.schema, var entry = schema[sk] else { return }
+                entry.rowDecorators = decorators
+                schema[sk] = entry
+                field.schema = schema
+            } else {
+                field.rowDecorators = decorators
+            }
+
+        case .commonColumn(let sk, let col):
+            if let sk = sk {
+                guard var schema = field.schema,
+                      var entry = schema[sk],
+                      var cols = entry.tableColumns,
+                      let i = cols.firstIndex(where: { $0.id == col }) else { return }
+                cols[i].decorators = decorators
+                entry.tableColumns = cols
+                schema[sk] = entry
+                field.schema = schema
+            } else {
+                guard var cols = field.tableColumns,
+                      let i = cols.firstIndex(where: { $0.id == col }) else { return }
+                cols[i].decorators = decorators
+                field.tableColumns = cols
+            }
+
+        case .rowSelf, .cell, .rowScopedColumn:
+            guard !target.hops.isEmpty else { return }
+            var rows = field.valueToValueElements ?? []
+            rewriteRows(&rows, hops: target.hops, depth: 0, terminator: target.terminator, newList: decorators)
+            field.value = ValueUnion.valueElementArray(rows)
+        }
+
+        commitDecoratorChange(field: field, fieldID: target.fieldID)
+    }
+
+    // MARK: Row tree walking
+
+    /// Walks the hop chain and returns the ValueElement at the end (last hop's row).
+    func valueElement(at hops: [DecoratorTarget.Hop], in field: JoyDocField) -> ValueElement? {
+        guard !hops.isEmpty else { return nil }
+        var currentRows: [ValueElement] = field.valueToValueElements ?? []
+        for (i, hop) in hops.enumerated() {
+            guard let row = currentRows.first(where: { $0.id == hop.rowID }) else { return nil }
+            if i == hops.count - 1 { return row }
+            // Descend into child schema specified by NEXT hop's schemaKey
+            let nextHop = hops[i + 1]
+            guard let sk = nextHop.schemaKey,
+                  let children = row.childrens?[sk] else { return nil }
+            currentRows = children.valueToValueElements ?? []
         }
         return nil
     }
 
-    // MARK: Row-specific decorator read/write (table only)
+    /// Recursively rewrites the row tree to apply the terminator's new decorator list at the deepest hop.
+    func rewriteRows(
+        _ rows: inout [ValueElement],
+        hops: [DecoratorTarget.Hop],
+        depth: Int,
+        terminator: DecoratorTarget.Terminator,
+        newList: [Decorator]
+    ) {
+        let hop = hops[depth]
+        guard let idx = rows.firstIndex(where: { $0.id == hop.rowID }) else { return }
+        var row = rows[idx]
 
-    func rowSpecificDecoratorsForPath(fieldID: String, rowID: String) -> [Decorator] {
-        guard let field = fieldMap[fieldID] else { return [] }
-        return field.valueToValueElements?.first(where: { $0.id == rowID })?.decorators?.all ?? []
-    }
-
-    func setRowSpecificDecoratorsForPath(_ decorators: [Decorator], fieldID: String, rowID: String) {
-        guard var field = fieldMap[fieldID],
-              var rows = field.valueToValueElements,
-              let index = rows.firstIndex(where: { $0.id == rowID }) else { return }
-        var decs = rows[index].decorators ?? Decorators()
-        decs.all = decorators
-        rows[index].decorators = decs
-        field.value = ValueUnion.valueElementArray(rows)
-        commitDecoratorChange(field: field, fieldID: fieldID)
-    }
-
-    // MARK: Cell-specific decorator read/write (table only)
-
-    func cellSpecificDecoratorsForPath(fieldID: String, rowID: String, columnID: String) -> [Decorator] {
-        guard let field = fieldMap[fieldID] else { return [] }
-        return field.valueToValueElements?.first(where: { $0.id == rowID })?.decorators?.cells[columnID] ?? []
-    }
-
-    func setCellSpecificDecoratorsForPath(_ decorators: [Decorator], fieldID: String, rowID: String, columnID: String) {
-        guard var field = fieldMap[fieldID],
-              var rows = field.valueToValueElements,
-              let index = rows.firstIndex(where: { $0.id == rowID }) else { return }
-        var decs = rows[index].decorators ?? Decorators()
-        var cells = decs.cells
-        cells[columnID] = decorators
-        decs.cells = cells
-        rows[index].decorators = decs
-        field.value = ValueUnion.valueElementArray(rows)
-        commitDecoratorChange(field: field, fieldID: fieldID)
-    }
-
-    // MARK: Row decorator read/write (path-based, independent of the public API)
-
-    /// Reads row decorators directly from the field model.
-    /// - nil schemaKey → table field, reads `field.rowDecorators`
-    /// - non-nil schemaKey → collection field, reads `field.schema[schemaKey].rowDecorators`
-    func rowDecoratorsForPath(fieldID: String, schemaKey: String?) -> [Decorator] {
-        guard let field = fieldMap[fieldID] else { return [] }
-        if field.fieldType == .collection {
-            guard let schemaKey = schemaKey else { return [] }
-            return field.schema?[schemaKey]?.rowDecorators ?? []
+        if depth == hops.count - 1 {
+            var decs = row.decorators ?? Decorators()
+            switch terminator {
+            case .rowSelf:
+                decs.all = newList
+            case .cell(let col), .rowScopedColumn(let col):
+                var cells = decs.cells
+                cells[col] = newList
+                decs.cells = cells
+            default:
+                return
+            }
+            row.decorators = decs
+            rows[idx] = row
+            return
         }
-        return field.rowDecorators ?? []
-    }
 
-    /// Writes row decorators directly to the field model.
-    func setRowDecoratorsForPath(_ decorators: [Decorator], fieldID: String, schemaKey: String?) {
-        guard var field = fieldMap[fieldID] else { return }
-        if field.fieldType == .collection {
-            guard var schema = field.schema,
-                  let schemaKey = schemaKey,
-                  var entry  = schema[schemaKey] else { return }
-            entry.rowDecorators = decorators
-            schema[schemaKey]   = entry
-            field.schema        = schema
-        } else {
-            field.rowDecorators = decorators
-        }
-        commitDecoratorChange(field: field, fieldID: fieldID)
-    }
-
-    // MARK: Generic fetch / apply routers
-
-    /// Returns the current decorator list for a resolved target.
-    func fetchDecorators(for target: DecoratorTarget) -> [Decorator] {
-        switch target {
-        case .field(let fieldID):
-            return decorators(forFieldID: fieldID)
-        case .row(let fieldID, let schemaKey):
-            return rowDecoratorsForPath(fieldID: fieldID, schemaKey: schemaKey)
-        case .rowSpecific(let fieldID, let rowID):
-            return rowSpecificDecoratorsForPath(fieldID: fieldID, rowID: rowID)
-        case .column(let fieldID, let columnID, let schemaKey):
-            return columnDecoratorsForPath(fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
-        case .cellSpecific(let fieldID, let rowID, let columnID):
-            return cellSpecificDecoratorsForPath(fieldID: fieldID, rowID: rowID, columnID: columnID)
-        }
-    }
-
-    /// Persists an updated decorator list for a resolved target.
-    func applyDecorators(_ decorators: [Decorator], for target: DecoratorTarget) {
-        switch target {
-        case .field(let fieldID):
-            setDecorators(decorators, forFieldID: fieldID)
-        case .row(let fieldID, let schemaKey):
-            setRowDecoratorsForPath(decorators, fieldID: fieldID, schemaKey: schemaKey)
-        case .rowSpecific(let fieldID, let rowID):
-            setRowSpecificDecoratorsForPath(decorators, fieldID: fieldID, rowID: rowID)
-        case .column(let fieldID, let columnID, let schemaKey):
-            setColumnDecoratorsForPath(decorators, fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
-        case .cellSpecific(let fieldID, let rowID, let columnID):
-            setCellSpecificDecoratorsForPath(decorators, fieldID: fieldID, rowID: rowID, columnID: columnID)
-        }
+        let nextHop = hops[depth + 1]
+        guard let sk = nextHop.schemaKey else { return }
+        var childrens = row.childrens ?? [:]
+        guard var children = childrens[sk] else { return }
+        var childRows = children.valueToValueElements ?? []
+        rewriteRows(&childRows, hops: hops, depth: depth + 1, terminator: terminator, newList: newList)
+        children.value = ValueUnion.valueElementArray(childRows)
+        childrens[sk] = children
+        row.childrens = childrens
+        rows[idx] = row
     }
 }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -4,9 +4,13 @@ public extension DocumentEditor {
 
     // MARK: - Path-Based API
     //
-    // path = "pageId/fieldPositionId"             → field decorators
-    // path = "pageId/fieldPositionId/rowId"        → row decorators
-    // path = "pageId/fieldPositionId/rowId/colId"  → column decorators
+    // path = "pageId/fieldPositionId"              → field decorators
+    // path = "pageId/fieldPositionId/rows"         → common row decorators   (table: field.rowDecorators)
+    // path = "pageId/fieldPositionId/{rowId}"      → row-specific decorators (table: ValueElement.decorators.all)
+    // path = "pageId/fieldPositionId/{rowId}/colId" → column decorators
+    //
+    // Collection fields: the 3rd segment is always a real rowId (used to resolve the schemaKey).
+    // Table fields: "rows" keyword → common; any valid rowId → row-specific (with copy-on-write from common).
     //
     // Note: Path segments are parsed with empty-component filtering;
     // consecutive or trailing slashes are treated as single separators.
@@ -39,6 +43,12 @@ public extension DocumentEditor {
             }
         }
         var list = fetchDecorators(for: target)
+        // Copy-on-write: if adding to a row-specific target with no existing row-specific
+        // decorators, seed the list with the common row decorators first so that row
+        // diverges from common while keeping all previously-visible decorators.
+        if case .rowSpecific(let fID, _) = target, list.isEmpty {
+            list = rowDecoratorsForPath(fieldID: fID, schemaKey: nil)
+        }
         let existingActions = Set(list.compactMap { $0.action })
         let newActions = decorators.compactMap { $0.action }
 
@@ -59,6 +69,7 @@ public extension DocumentEditor {
         }
         list.append(contentsOf: decorators)
         applyDecorators(list, for: target)
+        ensureDecorateEnabled(for: target)
     }
 
     /// Removes the decorator whose `action` matches at the given path.
@@ -119,6 +130,7 @@ private extension DocumentEditor {
         switch target {
         case .field(let fieldID): return fieldID
         case .row(let fieldID, _): return fieldID
+        case .rowSpecific(let fieldID, _): return fieldID
         case .column(let fieldID, _, _): return fieldID
         }
     }
@@ -135,6 +147,45 @@ private extension DocumentEditor {
             return false
         }
         return true
+    }
+
+    // MARK: Decorate flag
+
+    /// Sets `decorate = true` on the field (table) or schema entry (collection) when
+    /// row decorators are added, so the decorator column is shown automatically.
+    func ensureDecorateEnabled(for target: DecoratorTarget) {
+        switch target {
+        case .row(let fieldID, let schemaKey):
+            guard var field = fieldMap[fieldID] else { return }
+            if let schemaKey = schemaKey {
+                // Collection: set decorate on the specific schema entry
+                guard var schema = field.schema, var entry = schema[schemaKey] else { return }
+                guard entry.decorate != true else { return }
+                entry.decorate = true
+                schema[schemaKey] = entry
+                field.schema = schema
+            } else {
+                // Table: set decorate on the field
+                guard field.decorate != true else { return }
+                field.decorate = true
+            }
+            commitDecoratorChange(field: field, fieldID: fieldID)
+
+        case .rowSpecific(let fieldID, _):
+            guard var field = fieldMap[fieldID], field.decorate != true else { return }
+            field.decorate = true
+            commitDecoratorChange(field: field, fieldID: fieldID)
+
+        case .field, .column:
+            break
+        }
+    }
+
+    /// Persists a field mutation and notifies the view layer that decorators changed.
+    func commitDecoratorChange(field: JoyDocField, fieldID: String) {
+        updateField(field: field)
+        refreshField(fieldId: fieldID)
+        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
     }
 
     // MARK: Decorator validation
@@ -206,9 +257,7 @@ private extension DocumentEditor {
             columns[colIndex].decorators = decorators
             field.tableColumns = columns
         }
-        updateField(field: field)
-        refreshField(fieldId: fieldID)
-        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
+        commitDecoratorChange(field: field, fieldID: fieldID)
     }
 
     // MARK: Path resolution
@@ -216,7 +265,8 @@ private extension DocumentEditor {
     /// Resolved decorator scope from a path string.
     enum DecoratorTarget {
         case field(fieldID: String)
-        case row(fieldID: String, schemaKey: String?)
+        case row(fieldID: String, schemaKey: String?)          // common row decorators
+        case rowSpecific(fieldID: String, rowID: String)       // row-specific decorators (table only)
         case column(fieldID: String, columnID: String, schemaKey: String?)
     }
 
@@ -240,11 +290,21 @@ private extension DocumentEditor {
             let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
             guard columnExistsInField(field, columnId: columnId, schemaKey: schemaKey) else { return nil }
             return .column(fieldID: fieldID, columnID: columnId, schemaKey: schemaKey)
-        } else if let rowId = parsed.rowId {
-            guard rowExistsInField(fieldID: fieldID, rowId: rowId) else { return nil }
-            // 3 segments → row decorators; resolve schemaKey from the rowId
-            let schemaKey = resolvedSchemaKey(forRowID: rowId, inFieldID: fieldID)
-            return .row(fieldID: fieldID, schemaKey: schemaKey)
+        } else if let rowSegment = parsed.rowId {
+            if field.fieldType == .table {
+                if rowSegment == "rows" {
+                    // "rows" keyword → common row decorators on the field
+                    return .row(fieldID: fieldID, schemaKey: nil)
+                }
+                // Actual rowId → row-specific decorators
+                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
+                return .rowSpecific(fieldID: fieldID, rowID: rowSegment)
+            } else {
+                // Collection: rowId always resolves to schema-level row decorators
+                guard rowExistsInField(fieldID: fieldID, rowId: rowSegment) else { return nil }
+                let schemaKey = resolvedSchemaKey(forRowID: rowSegment, inFieldID: fieldID)
+                return .row(fieldID: fieldID, schemaKey: schemaKey)
+            }
         } else {
             // 2 segments → field decorators
             return .field(fieldID: fieldID)
@@ -304,6 +364,24 @@ private extension DocumentEditor {
         return nil
     }
 
+    // MARK: Row-specific decorator read/write (table only)
+
+    func rowSpecificDecoratorsForPath(fieldID: String, rowID: String) -> [Decorator] {
+        guard let field = fieldMap[fieldID] else { return [] }
+        return field.valueToValueElements?.first(where: { $0.id == rowID })?.decorators?.all ?? []
+    }
+
+    func setRowSpecificDecoratorsForPath(_ decorators: [Decorator], fieldID: String, rowID: String) {
+        guard var field = fieldMap[fieldID],
+              var rows = field.valueToValueElements,
+              let index = rows.firstIndex(where: { $0.id == rowID }) else { return }
+        var decs = rows[index].decorators ?? Decorators()
+        decs.all = decorators
+        rows[index].decorators = decs
+        field.value = ValueUnion.valueElementArray(rows)
+        commitDecoratorChange(field: field, fieldID: fieldID)
+    }
+
     // MARK: Row decorator read/write (path-based, independent of the public API)
 
     /// Reads row decorators directly from the field model.
@@ -331,9 +409,7 @@ private extension DocumentEditor {
         } else {
             field.rowDecorators = decorators
         }
-        updateField(field: field)
-        refreshField(fieldId: fieldID)
-        valueDelegate(for: fieldID, fieldType: field.fieldType)?.decoratorsDidChange()
+        commitDecoratorChange(field: field, fieldID: fieldID)
     }
 
     // MARK: Generic fetch / apply routers
@@ -345,6 +421,8 @@ private extension DocumentEditor {
             return decorators(forFieldID: fieldID)
         case .row(let fieldID, let schemaKey):
             return rowDecoratorsForPath(fieldID: fieldID, schemaKey: schemaKey)
+        case .rowSpecific(let fieldID, let rowID):
+            return rowSpecificDecoratorsForPath(fieldID: fieldID, rowID: rowID)
         case .column(let fieldID, let columnID, let schemaKey):
             return columnDecoratorsForPath(fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
         }
@@ -357,6 +435,8 @@ private extension DocumentEditor {
             setDecorators(decorators, forFieldID: fieldID)
         case .row(let fieldID, let schemaKey):
             setRowDecoratorsForPath(decorators, fieldID: fieldID, schemaKey: schemaKey)
+        case .rowSpecific(let fieldID, let rowID):
+            setRowSpecificDecoratorsForPath(decorators, fieldID: fieldID, rowID: rowID)
         case .column(let fieldID, let columnID, let schemaKey):
             setColumnDecoratorsForPath(decorators, fieldID: fieldID, columnID: columnID, schemaKey: schemaKey)
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -417,7 +417,7 @@ private extension DocumentEditor {
                 pendingSchema = nil
                 hasPendingSchema = false
 
-                guard rowExistsInField(fieldID: fieldID, rowId: rowID) else { return nil }
+                guard valueElement(at: hops, in: field) != nil else { return nil }
 
                 if cursor == segments.count {
                     return DecoratorTarget(fieldID: fieldID, hops: hops, terminator: .rowSelf)

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -275,18 +275,19 @@ private extension DocumentEditor {
     func rowsInScope(field: JoyDocField, schemaKey: String?) -> [ValueElement] {
         let top = field.valueToValueElements ?? []
         guard field.fieldType == .collection, let sk = schemaKey else {
-            return top
+            return top.filter { !($0.deleted ?? false) }
         }
         let rootKey = field.schema?.first(where: { $0.value.root == true })?.key
         if sk == rootKey {
-            return top
+            return top.filter { !($0.deleted ?? false) }
         }
         var collected: [ValueElement] = []
         func walk(_ rows: [ValueElement]) {
             for row in rows {
+                if row.deleted == true { continue }
                 guard let childrens = row.childrens else { continue }
                 if let match = childrens[sk] {
-                    let matchRows = match.valueToValueElements ?? []
+                    let matchRows = (match.valueToValueElements ?? []).filter { !($0.deleted ?? false) }
                     collected.append(contentsOf: matchRows)
                     walk(matchRows)
                 }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -600,3 +600,18 @@ private extension DocumentEditor {
         rows[idx] = row
     }
 }
+
+public struct DecoratorConfig {
+    /// Maximum number of field-level decorators (`field.decorators`) shown
+    /// inline next to the field title before the rest move into a kebab menu.
+    public var visibleLimitInFields: Int
+
+    /// Maximum number of row decorators (merged common + row-self) shown
+    /// inline on a row before the rest move into a kebab menu.
+    public var visibleLimitInRows: Int
+
+    public init(visibleLimitInFields: Int = 2, visibleLimitInRows: Int = 1) {
+        self.visibleLimitInFields = max(0, visibleLimitInFields)
+        self.visibleLimitInRows = max(0, visibleLimitInRows)
+    }
+}

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -2,38 +2,10 @@ import JoyfillModel
 
 public extension DocumentEditor {
 
-    // MARK: - Path-Based API
-    //
-    // Grammar (segments are "/"-separated; empty segments are ignored):
-    //
-    //   path := page-id "/" field-position-id [ rest ]
-    //   rest := "rows"                                  → common rows of root schema (or table)
-    //         | "columns/" col                          → common column of root schema (or table)
-    //         | "schemas/" sk "/rows"                   → common rows of schema sk
-    //         | "schemas/" sk "/columns/" col           → common column of schema sk
-    //         | "schemas/" sk "/" row rowRest           → a row inside schema sk
-    //         | row rowRest                             → a row at root schema
-    //   rowRest := ε                                     → that row's dedicated decorators
-    //            | col                                   → cell (row × col)
-    //            | "columns/" col                        → row-scoped column  (aliases cell storage)
-    //            | "schemas/" sk "/" row rowRest         → descend into child schema
-    //
-    // Tables cannot use "schemas/..." — they have no schema tree.
-    //
-    // Storage map:
-    //   field                            → field.decorators
-    //   commonRows(sk?)                  → sk?  ? field.schema[sk].rowDecorators : field.rowDecorators
-    //   commonColumn(sk?, col)           → sk?  ? field.schema[sk].tableColumns[col].decorators : field.tableColumns[col].decorators
-    //   rowSelf                          → ValueElement.decorators.all           (at the end of the hop chain)
-    //   cell(col) / rowScopedColumn(col) → ValueElement.decorators.cells[col]    (aliased storage)
-    //
-    // Copy-on-write: adding to rowSelf / cell / rowScopedColumn when the scope is empty
-    // seeds from the matching common scope first so the specific scope diverges without
-    // losing previously-visible decorators.
-    //
-    // All methods must be called on the main thread.
+    // MARK: - Decorator API (path-based)
 
-    /// Returns all decorators at the given path.
+    /// Returns decorators at `path`, or `[]` if the path doesn't resolve / the
+    /// scope is empty. Does not trigger copy-on-write seeding.
     func getDecorators(path: String) -> [Decorator] {
         guard let target = resolveDecoratorTarget(path: path) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
@@ -42,7 +14,10 @@ public extension DocumentEditor {
         return fetchDecorators(for: target)
     }
 
-    /// Appends one or more decorators at the given path.
+    /// Appends decorators at `path`. Each needs a non-empty `action` unique
+    /// within the batch and against entries already there; `color` if set must
+    /// be `#RRGGBB`. Row-scope adds flip `decorate` on; specific-row adds on
+    /// an empty scope seed from the common scope first.
     func addDecorators(path: String, decorators: [Decorator]) {
         guard !decorators.isEmpty else { return }
         guard let target = resolveDecoratorTarget(path: path) else {
@@ -88,7 +63,10 @@ public extension DocumentEditor {
         commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
-    /// Removes the decorator whose `action` matches at the given path.
+    /// Removes the decorator with matching `action` at `path`. If the enclosing
+    /// scope (table field / schema entry) has no displayable decorator left
+    /// after the removal — neither common `rowDecorators` nor any row's
+    /// `decorators.all` — `decorate` is flipped off.
     func removeDecorator(path: String, action: String) {
         guard let target = resolveDecoratorTarget(path: path) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))
@@ -108,7 +86,10 @@ public extension DocumentEditor {
         commitDecoratorChange(field: field, fieldID: target.fieldID)
     }
 
-    /// Replaces the decorator whose `action` matches with the new decorator at the given path.
+    /// Replaces the decorator with matching `action` at `path`. Rename is
+    /// allowed if the new action is unused. An update that strips both icon
+    /// and label makes it non-displayable; if that empties the scope,
+    /// `decorate` flips off (same as `removeDecorator`).
     func updateDecorator(path: String, action: String, decorator: Decorator) {
         guard let target = resolveDecoratorTarget(path: path) else {
             events?.onError(error: .decoratorError(error: DecoratorError(message: "Failed to resolve path '\(path)'")))

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -552,7 +552,7 @@ private extension DocumentEditor {
         guard !hops.isEmpty else { return nil }
         var currentRows: [ValueElement] = field.valueToValueElements ?? []
         for (i, hop) in hops.enumerated() {
-            guard let row = currentRows.first(where: { $0.id == hop.rowID }) else { return nil }
+            guard let row = currentRows.first(where: { $0.id == hop.rowID && !($0.deleted ?? false) }) else { return nil }
             if i == hops.count - 1 { return row }
             // Descend into child schema specified by NEXT hop's schemaKey
             let nextHop = hops[i + 1]
@@ -572,7 +572,7 @@ private extension DocumentEditor {
         newList: [Decorator]
     ) {
         let hop = hops[depth]
-        guard let idx = rows.firstIndex(where: { $0.id == hop.rowID }) else { return }
+        guard let idx = rows.firstIndex(where: { $0.id == hop.rowID && !($0.deleted ?? false) }) else { return }
         var row = rows[idx]
 
         if depth == hops.count - 1 {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -74,7 +74,7 @@ public class DocumentEditor: ObservableObject {
     private var fieldPositionMap = [String: FieldPosition]()
     private var fieldIndexMap = [String: String]()
     public var events: FormChangeEvent?
-    let backgroundQueue = DispatchQueue(label: "documentEditor.background", qos: .userInitiated)
+    private(set) public var decoratorConfig: DecoratorConfig
     
     private var validationHandler: ValidationHandler!
     var conditionalLogicHandler: ConditionalLogicHandler!
@@ -89,7 +89,8 @@ public class DocumentEditor: ObservableObject {
                 isPageDeleteEnabled: Bool = false,
                 validateSchema: Bool = true,
                 license: String? = nil,
-                singleClickRowEdit: Bool = false) {
+                singleClickRowEdit: Bool = false,
+                decoratorConfig: DecoratorConfig = DecoratorConfig()) {
         // Perform schema validation first
         if validateSchema {
             // Check for schema validation errors
@@ -106,6 +107,7 @@ public class DocumentEditor: ObservableObject {
                 self.singleClickRowEdit = singleClickRowEdit
                 self.currentPageID = ""
                 self.events = events
+                self.decoratorConfig = decoratorConfig
                 
                 // Trigger onError callback if events handler is available
                 events?.onError(error: .schemaValidationError(error: schemaError))
@@ -124,6 +126,7 @@ public class DocumentEditor: ObservableObject {
         self.events = events
         // Set feature flags from license
         self.isCollectionFieldEnabled = LicenseValidator.isCollectionEnabled(licenseToken: license)
+        self.decoratorConfig = decoratorConfig
         updateFieldMap()
         updateFieldPositionMap()
         self.conditionalLogicHandler = ConditionalLogicHandler(documentEditor: self)
@@ -654,7 +657,7 @@ extension DocumentEditor {
         let fieldEditMode: Mode = ((fieldData?.disabled == true) || (mode == .readonly) ? .readonly : .fill)
         let decorators = fieldData?.decorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
         
-        var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode) : nil
+        var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields) : nil
         
         switch fieldPosition.type {
         case .text:
@@ -826,7 +829,7 @@ extension DocumentEditor {
             let fieldEditMode: Mode = ((fieldData?.disabled == true) || (mode == .readonly) ? .readonly : .fill)
             let decorators = fieldData?.decorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
             
-            var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode) : nil
+            var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields) : nil
             
             dataModelType = getFieldModel(fieldPosition: fieldPosition, fieldIdentifier: fieldIdentifier)
             fieldListModels.append(FieldListModel(fieldIdentifier: fieldIdentifier, fieldEditMode: fieldEditMode, model: dataModelType))

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -408,6 +408,10 @@ struct TableDataModel {
     
     mutating func setTableRowDecorators(rowDecorators: [Decorator]?, rows: [ValueElement]) {
         guard fieldType == .table else { return }
+        tableRowDecorators.removeAll()
+        tableCellDecorators.removeAll()
+        tableCommonCellDecorators.removeAll()
+
         let nonDeleteRows = rows.filter { !($0.deleted ?? false) }
         for row in nonDeleteRows {
             updateTableRowDecorators(for: row, fieldRowDecorators: rowDecorators)

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -146,6 +146,7 @@ struct TableDataModel {
     let mode: Mode
     let documentEditor: DocumentEditor?
     let fieldIdentifier: FieldIdentifier
+    let decorate: Bool
     let title: String?
     let fieldType: FieldTypes
     var fieldRequired: Bool = false
@@ -158,7 +159,9 @@ struct TableDataModel {
     let fieldPositionTableColumns: [TableColumn]?
     var columnIdToColumnMap: [String: CellDataModel] = [:]
     var schemaChainMap: [String: [String]] = [:]
-    var rowDecorators: [DecoratorLocal] = []
+    var tableRowDecorators: [String: [DecoratorLocal]] = [:] // Both Row specific and common row decorators are combined
+    var tableCellDecorators: [String: [DecoratorLocal]] = [:] // Both Cell specific and common column decorators are combined
+    var tableCommonCellDecorators: [String: [DecoratorLocal]] = [:] // columnId
     private(set) var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
     var selectedRows = [String]()
     var cellModels = [RowDataModel]()
@@ -205,12 +208,12 @@ struct TableDataModel {
         self.documentEditor = documentEditor
         self.title = fieldData.title
         self.fieldIdentifier = fieldIdentifier
+        self.decorate = fieldData.decorate ?? false
         self.rowOrder = fieldData.rowOrder ?? []
         self.valueToValueElements = fieldData.valueToValueElements
         self.fieldPositionTableColumns = fieldPosition.tableColumns
         self.fieldType = fieldData.fieldType
         self.singleClickRowEdit = documentEditor.singleClickRowEdit
-        self.rowDecorators = fieldData.fieldType == .table ? (fieldData.rowDecorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []) : []
         self.cleanUpRowOrder()
         if fieldData.fieldType == .collection {
             self.schema = fieldData.schema ?? [:]
@@ -246,6 +249,7 @@ struct TableDataModel {
         setupColumns()
         filterRowsIfNeeded()
         self.id = fieldIdentifier.fieldID + ":" + filterModels.map { $0.colID }.sorted().joined(separator: ",")
+        self.setTableRowDecorators(rowDecorators: fieldData.rowDecorators, rows: valueToValueElements ?? [])
     }
     
     mutating func buildFullSchemaChainMap() {
@@ -370,11 +374,58 @@ struct TableDataModel {
     private func isRootSchema(_ schemaKey: String) -> Bool {
         return schema[schemaKey]?.root == true
     }
-
+    
+    func getTableRowDecorators(forRowID id: String) -> [DecoratorLocal] {
+        return tableRowDecorators[id] ?? []
+    }
+    
+    func getTableCellDecorators(rowIds: [String], columnId: String) -> [DecoratorLocal] {
+        if rowIds.isEmpty { return [] }
+        if rowIds.count == 1, let singleID = rowIds.first {
+            let key = "\(singleID)/\(columnId)"
+            return tableCellDecorators[key] ?? []
+        } else {
+            return tableCommonCellDecorators[columnId] ?? []
+        }
+    }
+    
+    fileprivate mutating func setTableCellDecorators(_ row: ValueElement, _ id: String) {
+        for column in tableColumns {
+            guard let columnID = column.id else { continue }
+            let cellCommonDecorators = column.decorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
+            let cellSpecificDecorators = row.decorators?.cells[columnID]?
+                .filter({ $0.isDisplayable })
+                .map(DecoratorLocal.init(from:)) ?? []
+            self.tableCommonCellDecorators[columnID] = cellCommonDecorators
+            let key = "\(id)/\(columnID)"
+            if cellSpecificDecorators.isEmpty {
+                self.tableCellDecorators[key] = cellCommonDecorators
+            } else {
+                self.tableCellDecorators[key] = cellSpecificDecorators
+            }
+        }
+    }
+    
+    mutating func setTableRowDecorators(rowDecorators: [Decorator]?, rows: [ValueElement]) {
+        guard fieldType == .table else { return }
+        let nonDeleteRows = rows.filter { !($0.deleted ?? false) }
+        for row in nonDeleteRows {
+            guard let id = row.id else { continue }
+            let rowCommonDecorators = rowDecorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
+            let rowSpecificDecorators = row.decorators?.all.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
+            if rowSpecificDecorators.isEmpty {
+                self.tableRowDecorators[id] = rowCommonDecorators
+            } else {
+                self.tableRowDecorators[id] = rowSpecificDecorators
+            }
+            self.setTableCellDecorators(row, id)
+        }
+    }
+    
     /// Row decorators for the given schema. Table: always returns field-level rowDecorators. Collection: returns cached decorators per schema key (built in init).
     func rowDecorators(forSchemaKey schemaKey: String) -> [DecoratorLocal] {
         if fieldType == .table {
-            return rowDecorators
+            return []
         }
         return rowDecoratorsBySchemaKey[schemaKey] ?? []
     }
@@ -389,7 +440,7 @@ struct TableDataModel {
     /// True if any row decorators should be shown. Table: field has rowDecorators. Collection: any schema has rowDecorators.
     var hasAnyRowDecorators: Bool {
         if fieldType == .table {
-            return !rowDecorators.isEmpty
+            return true
         }
         return schema.values.contains { !(($0.rowDecorators ?? []).filter { $0.isDisplayable }).isEmpty }
     }

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -410,16 +410,20 @@ struct TableDataModel {
         guard fieldType == .table else { return }
         let nonDeleteRows = rows.filter { !($0.deleted ?? false) }
         for row in nonDeleteRows {
-            guard let id = row.id else { continue }
-            let rowCommonDecorators = rowDecorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
-            let rowSpecificDecorators = row.decorators?.all.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
-            if rowSpecificDecorators.isEmpty {
-                self.tableRowDecorators[id] = rowCommonDecorators
-            } else {
-                self.tableRowDecorators[id] = rowSpecificDecorators
-            }
-            self.setTableCellDecorators(row, id)
+            updateTableRowDecorators(for: row, fieldRowDecorators: rowDecorators)
         }
+    }
+
+    mutating func updateTableRowDecorators(for row: ValueElement, fieldRowDecorators: [Decorator]?) {
+        guard fieldType == .table, let id = row.id, !(row.deleted ?? false) else { return }
+        let rowCommonDecorators = fieldRowDecorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
+        let rowSpecificDecorators = row.decorators?.all.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
+        if rowSpecificDecorators.isEmpty {
+            self.tableRowDecorators[id] = rowCommonDecorators
+        } else {
+            self.tableRowDecorators[id] = rowSpecificDecorators
+        }
+        self.setTableCellDecorators(row, id)
     }
     
     /// Row decorators for the given schema. Table: always returns field-level rowDecorators. Collection: returns cached decorators per schema key (built in init).

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -146,7 +146,7 @@ struct TableDataModel {
     let mode: Mode
     let documentEditor: DocumentEditor?
     let fieldIdentifier: FieldIdentifier
-    let decorate: Bool
+    var decorate: Bool
     let title: String?
     let fieldType: FieldTypes
     var fieldRequired: Bool = false

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -162,7 +162,7 @@ struct TableDataModel {
     var tableRowDecorators: [String: [DecoratorLocal]] = [:] // Both Row specific and common row decorators are combined
     var tableCellDecorators: [String: [DecoratorLocal]] = [:] // Both Cell specific and common column decorators are combined
     var tableCommonCellDecorators: [String: [DecoratorLocal]] = [:] // columnId
-    private(set) var rowDecoratorsBySchemaKey: [String: [DecoratorLocal]] = [:]
+    private(set) var commonRowDecorators: [String: [DecoratorLocal]] = [:]
     var selectedRows = [String]()
     var cellModels = [RowDataModel]()
     var filteredcellModels = [RowDataModel]()
@@ -427,22 +427,15 @@ struct TableDataModel {
         if fieldType == .table {
             return []
         }
-        return rowDecoratorsBySchemaKey[schemaKey] ?? []
+        return commonRowDecorators[schemaKey] ?? []
     }
 
     mutating func setRowDecorators(_ decorators: [DecoratorLocal], forSchemaKey schemaKey: String) {
-        rowDecoratorsBySchemaKey[schemaKey] = decorators
+        commonRowDecorators[schemaKey] = decorators
     }
 
     func hasAnyRowDecorators(schemaKey: String) -> Bool {
-        return !rowDecorators(forSchemaKey: schemaKey).isEmpty
-    }
-    /// True if any row decorators should be shown. Table: field has rowDecorators. Collection: any schema has rowDecorators.
-    var hasAnyRowDecorators: Bool {
-        if fieldType == .table {
-            return true
-        }
-        return schema.values.contains { !(($0.rowDecorators ?? []).filter { $0.isDisplayable }).isEmpty }
+        return schema[schemaKey]?.decorate == true
     }
 
     func rowMatchesFilter(_ row: RowDataModel, filters: [FilterModel]) -> Bool {


### PR DESCRIPTION
## 1. Context

Decorator API lets callers attach visual indicators (icon/label/color) to fields, rows, columns, and cells via a path string, with a one-shot `decorate` flag on the field/schema that tells the renderer whether to reserve the decorator column. Covers both table and collection fields; collection uses the schema tree (`schemas/{sk}/...`) to address nested scopes.

A new `DecoratorConfig` lets hosts cap how many decorators render inline before the rest collapse into a kebab menu — separate limits for fields/columns vs. rows.

## 2. What changed

- **Public API surface** (`DocumentEditor+Decorators.swift`): `getDecorators`, `addDecorators`, `removeDecorator`, `updateDecorator`, all keyed by a `page-id/field-position-id/...` path.
- **Path grammar**: `/rows`, `/columns/{col}`, `/{rowID}`, `/{rowID}/{col}`, `/{rowID}/columns/{col}`, `/schemas/{sk}/...` (collection only). `rowScopedColumn` aliases `cell` storage.
- **Model** (`JoyfillModel`): `Decorator`, `Decorators` (all/cells), `rowDecorators` on field + schema entry, per-column `decorators`, `decorate` flag on field + schema entry.
- **Rendering**: table + collection read `decorate` to decide whether to render the decorator column; per-row decorators fall back to the common `rowDecorators` list when a row has none.
- **decorate flag auto-toggle**: add flips it on (`ensureDecorateEnabled`); remove/update flips it off when the scope has no displayable decorators left (`ensureDecorateDisabledIfEmpty` — new, this PR's bug fix).
- **Single-commit write path**: `applyDecorators` / `ensureDecorateEnabled` / `ensureDecorateDisabledIfEmpty` now take `inout JoyDocField` and mutate without persisting; the three public APIs commit once at the end via `commitDecoratorChange`.
- **DecoratorConfig + kebab overflow UI**: new `DecoratorConfig(visibleLimitInFields: Int = 2, visibleLimitInRows: Int = 1)` passed at editor init. When a field/column scope exceeds `visibleLimitInFields` (default 2) or a row exceeds `visibleLimitInRows` (default 1), only a kebab icon renders; tap shows the full set in a popover. Field/column kebabs get a light blue background to match `DecoratorButton` styling; row kebabs render plain. Negative values clamp to 0.

## 3. Decisions

- **Path grammar over nested structs**: keeps the SDK call site a single string argument, matches how host apps already identify fields by page + position, and lets us extend to new terminators without API changes.
- **Copy-on-write seed for specific scopes**: when a row-self/cell scope is first written to, we seed from the matching common scope so the specific scope can diverge without silently losing previously-visible decorators.
- **`decorate` as a derived flag, not caller-managed**: hosts shouldn't need to track how many decorators they've added — if anything displayable exists in scope, the flag is on; otherwise off. `isDisplayable = hasIcon || hasLabel`, so updates that strip both icon and label also flip the flag off.
- **Single commit per API call**: previously `add`/`remove`/`update` could emit two `updateField` writes, two `refreshField` rebuilds, two `decoratorsDidChange` notifications, and two `onChange` events per user action. Collapsed to one. See the last commit for the refactor.
- **Kebab-only over inline + kebab combo**: when over the limit we show only the kebab (not "first N inline plus a kebab for the rest") to keep header/row layout predictable across field counts. The popover then shows everything.
- **Defaults of 2 / 1**: matches the existing visual density — a field title row comfortably fits two decorator chips, a table row fits one before crowding the cell content. Hosts that want everything inline can pass `Int.max`; hosts that want everything in the kebab can pass `0`.
- **Old "one-way latch" tests removed**: two tests in `DecoratorDeepPathTests.swift` asserted decorate stays `true` after the last decorator is removed — that encoded the bug being fixed. Replaced with inverted assertions in `DecoratorPublicAPITests.swift`.

## 4. Screenshot / video

N/A — pure API + behavioral change. User-facing effects:
- The decorator column disappears when all decorators are removed (previously it stayed visible but empty).
- A kebab menu replaces the inline chips when a scope exceeds its configured limit.

## 5. Public API / docs

- **New public API** on `DocumentEditor`: `getDecorators(path:)`, `addDecorators(path:decorators:)`, `removeDecorator(path:action:)`, `updateDecorator(path:action:decorator:)`.
- **New public model types**: `Decorator`, `Decorators`, `JoyfillError.decoratorError`.
- **New public config type**: `DecoratorConfig(visibleLimitInFields:visibleLimitInRows:)`, exposed on `DocumentEditor` as a read-only `decoratorConfig` property; passed at init via `DocumentEditor(... decoratorConfig:)`.
- **Public docs**: path grammar + storage map are documented inline at the top of `DocumentEditor+Decorators.swift`. External SDK docs will need entries for the decorator path grammar, the auto-toggle contract, and the new `DecoratorConfig` limits — **docs update required** before release.

## 6. Tests

Covered in this branch — no follow-up test work pending.

- `DecoratorPublicAPITests` — add/remove/update happy paths, duplicate-action rejection, path resolution, field-map reflection, **and the 14 new decorate-flag cases** (table, collection root, nested schema, scope isolation, updateDecorator → non-displayable).
- `DecoratorDeepPathTests` — long paths, schema descent, multi-level nesting.
- `DecoratorCOWTests` — specific-scope seeding from common scope.
- `DecoratorLiveUpdateTests` — post-mutation field state.
- `DecoratorPathResolutionTests` — path grammar edge cases.
- `DecoratorErrorHandlingTests` — invalid paths, license gating, validation errors.
- `DecoratorAPIDemoView` (example app) — UI sandbox with steppers for `visibleLimitInFields` / `visibleLimitInRows` and an Update button that rebuilds the editor with the new config while preserving the current document state.

## 7. Notes for reviewer

- All four public APIs are main-thread-only — call out in docs.
- Collection-field writes are license-gated; without a valid license the editor emits `decoratorError` and rejects the write. Same gating lives on `licenseAllowsDecoratorWrite`.
- Helpers `applyDecorators` / `ensureDecorateEnabled` / `ensureDecorateDisabledIfEmpty` intentionally take `inout JoyDocField` and do **not** commit — only the top-level public methods own the persist + notify path. If you add a new decorator mutation, follow the same pattern: mutate in place, then one `commitDecoratorChange` at the end.
- `DecoratorConfig` is currently set once at editor init; live reconfiguration requires rebuilding the `DocumentEditor` (the demo's Update button shows the pattern — reuses `editor.document` so user edits survive). If we need live reconfig later, the config can be promoted to a settable property and a `decoratorsDidChange`-style refresh added.
- `DecoratorDeepPathTests.swift` has a breadcrumb comment where the two obsolete "one-way latch" tests used to live, pointing to their replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)