### PR TITLE
NO-2075 Filter duplicate decorators and cap inline row decorators at 3

### DIFF
--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -58,6 +58,17 @@ public struct Decorator: Equatable {
     }
 }
 
+extension Array where Element == Decorator {
+    /// Returns the first decorator per action, preserving order. Decorators without an action are always kept.
+    func deduplicatedByAction() -> [Decorator] {
+        var seen = Set<String>()
+        return filter { dec in
+            guard let action = dec.action, !action.isEmpty else { return true }
+            return seen.insert(action).inserted
+        }
+    }
+}
+
 // MARK: - RowDecorators
 public struct Decorators {
     public var dictionary: [String: Any]
@@ -68,7 +79,10 @@ public struct Decorators {
 
     /// Row-level decorators that apply to the entire row.
     public var all: [Decorator] {
-        get { (dictionary["all"] as? [[String: Any]])?.compactMap(Decorator.init) ?? [] }
+        get {
+            let raw = (dictionary["all"] as? [[String: Any]])?.compactMap(Decorator.init) ?? []
+            return raw.deduplicatedByAction()
+        }
         set { dictionary["all"] = newValue.map { $0.dictionary } }
     }
 
@@ -76,7 +90,10 @@ public struct Decorators {
     public var cells: [String: [Decorator]] {
         get {
             guard let raw = dictionary["cells"] as? [String: Any] else { return [:] }
-            return raw.compactMapValues { ($0 as? [[String: Any]])?.compactMap(Decorator.init) }
+            return raw.compactMapValues { value -> [Decorator]? in
+                guard let list = (value as? [[String: Any]])?.compactMap(Decorator.init) else { return nil }
+                return list.deduplicatedByAction()
+            }
         }
         set {
             dictionary["cells"] = newValue.mapValues { $0.map { $0.dictionary } }
@@ -524,7 +541,10 @@ public struct JoyDocField: Equatable {
     
     /// Decorators attached to this field. Rendered inline next to the field title.
     public var decorators: [Decorator]? {
-        get { (dictionary["decorators"] as? [[String: Any]])?.compactMap(Decorator.init) }
+        get {
+            guard let raw = (dictionary["decorators"] as? [[String: Any]])?.compactMap(Decorator.init) else { return nil }
+            return raw.deduplicatedByAction()
+        }
         set { dictionary["decorators"] = newValue?.compactMap { $0.dictionary } }
     }
 
@@ -535,7 +555,10 @@ public struct JoyDocField: Equatable {
 
     /// Row-level decorators for table/collection fields. Rendered per-row via a kebab menu column.
     public var rowDecorators: [Decorator]? {
-        get { (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) }
+        get {
+            guard let raw = (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) else { return nil }
+            return raw.deduplicatedByAction()
+        }
         set { dictionary["rowDecorators"] = newValue?.compactMap { $0.dictionary } }
     }
 
@@ -1164,7 +1187,10 @@ public struct FieldTableColumn {
 
     /// Decorators attached to this column. Rendered in the column header area.
     public var decorators: [Decorator]? {
-        get { (dictionary["decorators"] as? [[String: Any]])?.compactMap(Decorator.init) }
+        get {
+            guard let raw = (dictionary["decorators"] as? [[String: Any]])?.compactMap(Decorator.init) else { return nil }
+            return raw.deduplicatedByAction()
+        }
         set { dictionary["decorators"] = newValue?.compactMap { $0.dictionary } }
     }
 
@@ -1231,7 +1257,10 @@ public struct Schema {
 
     /// Row-level decorators for this collection schema. Rendered per-row via kebab menu (collection only; table uses field-level rowDecorators).
     public var rowDecorators: [Decorator]? {
-        get { (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) }
+        get {
+            guard let raw = (dictionary["rowDecorators"] as? [[String: Any]])?.compactMap(Decorator.init) else { return nil }
+            return raw.deduplicatedByAction()
+        }
         set { dictionary["rowDecorators"] = newValue?.compactMap { $0.dictionary } }
     }
 

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -186,9 +186,11 @@ struct FieldDecoratorsView: View {
                         decoratorPopover
                     }
             } else {
-                HStack(spacing: 4) {
-                    ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
-                        DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 4) {
+                        ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                            DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                        }
                     }
                 }
             }

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -238,21 +238,28 @@ struct RowDecoratorMenuView: View {
     let onDecoratorTap: (DecoratorLocal) -> Void
     @State private var showingPopover = false
 
+    private static let inlineMax = 3
     private var displayable: [DecoratorLocal] { decorators.filter { $0.isDisplayable } }
     private var exceedsLimit: Bool { displayable.count > visibleLimit }
+    private var inlineVisible: [DecoratorLocal] { Array(displayable.prefix(Self.inlineMax)) }
+    private var hasInlineOverflow: Bool { displayable.count > Self.inlineMax }
 
     var body: some View {
         if displayable.isEmpty {
             Color.clear.frame(width: 40, height: 60)
         } else if exceedsLimit {
             kebabButton.frame(width: 40, height: 60)
-        } else if displayable.count == 1, let decorator = displayable.first {
-            singleDecoratorButton(decorator)
         } else {
             VStack(spacing: 0) {
-                ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                ForEach(Array(inlineVisible.enumerated()), id: \.offset) { _, decorator in
                     singleDecoratorButton(decorator)
                         .frame(maxHeight: .infinity)
+                }
+                if hasInlineOverflow {
+                    Text("•••")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             .frame(width: 40, height: 60)
@@ -275,7 +282,7 @@ struct RowDecoratorMenuView: View {
                 }
             }
             .foregroundColor(tint)
-            .frame(width: 40, height: 60)
+            .frame(width: 40)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -198,30 +198,32 @@ struct FieldDecoratorsView: View {
     }
 
     private var decoratorPopover: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(displayable.enumerated()), id: \.offset) { index, decorator in
-                let tint: Color = decorator.color.map { Color(hex: $0) } ?? .primary
-                Button {
-                    showingOverflow = false
-                    onDecoratorTap(decorator)
-                } label: {
-                    HStack(spacing: 8) {
-                        if let icon = decorator.icon, !icon.isEmpty {
-                            DecoratorIconImage(iconName: icon, size: 14)
-                                .foregroundColor(tint)
-                                .frame(width: 20)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(displayable.enumerated()), id: \.offset) { index, decorator in
+                    let tint: Color = decorator.color.map { Color(hex: $0) } ?? .primary
+                    Button {
+                        showingOverflow = false
+                        onDecoratorTap(decorator)
+                    } label: {
+                        HStack(spacing: 8) {
+                            if let icon = decorator.icon, !icon.isEmpty {
+                                DecoratorIconImage(iconName: icon, size: 14)
+                                    .foregroundColor(tint)
+                                    .frame(width: 20)
+                            }
+                            if let label = decorator.label, !label.isEmpty {
+                                Text(label)
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundColor(tint)
+                            }
                         }
-                        if let label = decorator.label, !label.isEmpty {
-                            Text(label)
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(tint)
-                        }
+                        .frame(height: 27)
                     }
-                    .frame(height: 27)
+                    .padding(.horizontal, 16)
+                    .padding(.top, index == 0 ? 12 : 4)
+                    .padding(.bottom, index == displayable.count - 1 ? 12 : 4)
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, index == 0 ? 12 : 4)
-                .padding(.bottom, index == displayable.count - 1 ? 12 : 4)
             }
         }
         .frame(minWidth: 160)
@@ -291,33 +293,35 @@ struct RowDecoratorMenuView: View {
     }
 
     private var popoverContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(displayable.enumerated()), id: \.offset) { index, decorator in
-                let tint: Color = decorator.color.map { Color(hex: $0) } ?? .primary
-
-                Button {
-                    showingPopover = false
-                    onDecoratorTap(decorator)
-                } label: {
-                    HStack(spacing: 8) {
-                        if let icon = decorator.icon, !icon.isEmpty {
-                            DecoratorIconImage(iconName: icon, size: 14)
-                                .foregroundColor(tint)
-                                .frame(width: 20)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(displayable.enumerated()), id: \.offset) { index, decorator in
+                    let tint: Color = decorator.color.map { Color(hex: $0) } ?? .primary
+                    
+                    Button {
+                        showingPopover = false
+                        onDecoratorTap(decorator)
+                    } label: {
+                        HStack(spacing: 8) {
+                            if let icon = decorator.icon, !icon.isEmpty {
+                                DecoratorIconImage(iconName: icon, size: 14)
+                                    .foregroundColor(tint)
+                                    .frame(width: 20)
+                            }
+                            if let label = decorator.label, !label.isEmpty {
+                                Text(label)
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundColor(tint)
+                            }
                         }
-                        if let label = decorator.label, !label.isEmpty {
-                            Text(label)
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(tint)
-                        }
+                        .frame(height: 27)
                     }
-                    .frame(height: 27)
+                    .padding(.horizontal, 16)
+                    .padding(.top, index == 0 ? 12 : 4)
+                    .padding(.bottom, index == displayable.count - 1 ? 12 : 4)
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, index == 0 ? 12 : 4)
-                .padding(.bottom, index == displayable.count - 1 ? 12 : 4)
             }
+            .frame(minWidth: 160)
         }
-        .frame(minWidth: 160)
     }
 }


### PR DESCRIPTION
## 1. Context / Spec

Two decorator display issues:
- Decorator arrays decoded from JSON could contain entries with duplicate `action` values — only the first should be used.
- Row decorator columns are `40×60pt`. When `visibleLimitInRows` is set high (e.g. 200), the old code stacked all inline decorators, breaking layout. Fields and cells handle high counts with horizontal scroll; rows needed a different approach.

## 2. What Changed

**`Sources/JoyfillModel/JoyDoc.swift`**
- Added `extension Array where Element == Decorator` with `deduplicatedByAction()` — keeps the first decorator per `action`, preserving order; decorators with no action are always kept.
- Applied to all 6 decorator getters: `Decorators.all`, `Decorators.cells`, `JoyDocField.decorators`, `JoyDocField.rowDecorators`, `FieldTableColumn.decorators`, `Schema.rowDecorators`.
- Filtering is read-time only — raw JSON/dictionary is never mutated.

**`Sources/JoyfillUI/View/DecoratorView.swift`**

*`FieldDecoratorsView`*
- When `count ≤ visibleLimit`: inline decorators now render inside a `ScrollView(.horizontal)` so a high limit doesn't overflow the header.
- Popover content (for `count > visibleLimit`) wrapped in a `ScrollView` so it scrolls when item count is large.

*`RowDecoratorMenuView`*
- When `count > visibleLimit`: unchanged — shows kebab → popover (also now wrapped in `ScrollView`).
- When `count ≤ visibleLimit`: now caps inline display at **3 items** max. If there are more than 3, a non-tappable `•••` indicator fills the remaining slot. Previously it tried to stack all items, which broke at high counts.
- Removed the separate single-item branch — unified into the shared `VStack` path.
- Button label: removed hardcoded `height: 60` so items share column height correctly when stacked.

## 3. Design Decisions

- **Read-time dedup, not write-time:** Avoids silently rewriting stored data. If the source is fixed upstream the filter becomes a no-op.
- **Inline cap hardcoded at 3:** The `40×60pt` column can fit 3 small items comfortably. Making this configurable adds complexity with no practical value — anyone needing access to more items will set `visibleLimitInRows` low enough to trigger the kebab/popover.
- **`•••` is non-tappable:** It's a visual hint only. Users who need to act on hidden decorators should lower `visibleLimitInRows` to trigger the popover.
- **Plain `VStack` in popovers (not `LazyVStack`):** Deferred until there's a measured perf problem. Popovers are opened on demand so initial render cost is paid once per tap, not on scroll.

## 4. Screenshots / Video

_N/A — no visual design change to existing behaviour. To test: set `visibleLimitInRows = 10` with 5 decorators on a row → should see 3 stacked + `•••`. Set `visibleLimitInRows = 2` with 5 decorators → should see kebab._

## 5. Public API Impact

- `deduplicatedByAction()` is package-internal (`Array` extension, no `public` modifier) — not exposed.
- The 6 modified decorator getters are `public` computed properties but **signatures are unchanged** — only return value behaviour changes (duplicates stripped). No docs update needed.

## 6. Test Coverage

No new tests in this PR. Follow-up needed:
- Unit test for `deduplicatedByAction` (JSON with duplicate actions → assert first-wins).
- UI test for the 3-cap inline row behaviour.

## 7. Reviewer Notes

- `deduplicatedByAction()` lives directly below the `Decorator` struct in `JoyDoc.swift` — easy to locate.
- The `•••` overflow indicator in rows has no tap target by design. If a future spec requires tapping it, that's a separate ticket.
- Cell decorator popovers follow the same `ScrollView` wrapping pattern added here for consistency.