### PR TITLE
NO-2075: Fix trailing alignment for field decorators in horizontal scroll

### DIFF
--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -186,13 +186,17 @@ struct FieldDecoratorsView: View {
                         decoratorPopover
                     }
             } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 4) {
-                        ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
-                            DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                GeometryReader { geometry in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 4) {
+                            ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                                DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                            }
                         }
+                        .frame(minWidth: geometry.size.width, alignment: .trailing)
                     }
                 }
+                .frame(height: 32)
             }
         }
     }


### PR DESCRIPTION
## Context

Field decorators are shown inline (up to 3) on the trailing edge of form field rows. When fewer decorators than the max fit in the available space, they were left-aligned instead of right/trailing-aligned — inconsistent with the intended layout where decorators hug the right side of the row.

## What Changed

**`Sources/JoyfillUI/View/DecoratorView.swift`** — `FieldDecoratorsView`

Wrapped the `ScrollView` in a `GeometryReader` and applied `.frame(minWidth: geometry.size.width, alignment: .trailing)` to the inner `HStack`. This ensures the content is always pinned to the trailing edge while still allowing horizontal scrolling when decorators overflow.

```swift
// Before
ScrollView(.horizontal, showsIndicators: false) {
    HStack(spacing: 4) { ... }
}

// After
GeometryReader { geometry in
    ScrollView(.horizontal, showsIndicators: false) {
        HStack(spacing: 4) { ... }
            .frame(minWidth: geometry.size.width, alignment: .trailing)
    }
}
.frame(height: 32)
```

The explicit `.frame(height: 32)` on the `GeometryReader` is required because `GeometryReader` expands to fill all available height by default — without it the row height would grow unexpectedly.

## Decision Notes

- Used `GeometryReader` + `minWidth` rather than `Spacer()` because a `Spacer` inside a `ScrollView` doesn't push content to the trailing edge — it just adds empty scrollable space.
- `alignment: .trailing` on the frame handles the short-content case; the `minWidth` ensures the scroll still works when content is wider than the container.

## Screenshot / Video

> Please attach a screen recording showing decorators aligned to the trailing edge before and after the fix. (No Xcode Simulator access in this session.)

## Public API Changes

None. This is a purely internal layout fix — no public structs, properties, or methods were modified. No doc updates needed.

## Test Coverage

No automated snapshot/UI tests added in this PR. The layout regression can be verified visually by running the demo app with 1–3 decorators on a field in a horizontally-scrollable row. Test cases to cover formally in a follow-up if needed:
- 1 decorator → trailing-aligned, no scroll
- 3 decorators → trailing-aligned, no scroll
- 3+ decorators → overflow kebab shown (unchanged path)

## Reviewer Notes

- Only `FieldDecoratorsView` (the ≤3 decorators path) was touched; the overflow/kebab path is unchanged.
- The fix is self-contained in 8 lines; no logic changes, purely layout.