### PR TITLE
NO-2108: Scale row decorator column width and render inline horizontally

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
@@ -130,6 +130,16 @@
               "field" : "699dc392acb30df81f5a694a",
               "type" : "image",
               "displayType" : "original"
+            },
+            {
+              "_id" : "6a1f0c00a1b2c3d4e5f60718",
+              "x" : 0,
+              "height" : 8,
+              "y" : 170,
+              "width" : 4,
+              "field" : "6a1f0c00a1b2c3d4e5f60719",
+              "type" : "text",
+              "displayType" : "original"
             }
           ],
           "hidden" : false,
@@ -795,6 +805,15 @@
       "title" : "Multiple Choice",
       "_id" : "69709dc240f1e385f35abd36",
       "multi" : true
+    },
+    {
+      "title" : "Extra Text",
+      "identifier" : "field_6a1f0c00a1b2c3d4e5f60719",
+      "value" : "",
+      "type" : "text",
+      "file" : "691f3762c80bfb0005c57b48",
+      "_id" : "6a1f0c00a1b2c3d4e5f60719",
+      "hidden" : false
     }
   ]
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorUITestSupport.swift
@@ -63,8 +63,9 @@ enum DecoratorUITestSupport {
     }
 
     /// Identifier for a single row-level decorator button (shown when exactly one is displayable).
+    /// Row and field buttons currently share the same DecoratorButton identifier format.
     static func rowDecoratorID(action: String) -> String {
-        return "row_decorator_\(action)"
+        return "decorator_button_\(action)"
     }
 
     /// Identifier for the row hamburger menu button (shown when multiple decorators exist on a row).

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -242,11 +242,8 @@ struct RowDecoratorMenuView: View {
     let onDecoratorTap: (DecoratorLocal) -> Void
     @State private var showingPopover = false
 
-    private static let inlineMax = 3
     private var displayable: [DecoratorLocal] { decorators.filter { $0.isDisplayable } }
     private var exceedsLimit: Bool { displayable.count > visibleLimit }
-    private var inlineVisible: [DecoratorLocal] { Array(displayable.prefix(Self.inlineMax)) }
-    private var hasInlineOverflow: Bool { displayable.count > Self.inlineMax }
 
     var body: some View {
         if displayable.isEmpty {

--- a/Sources/JoyfillUI/View/DecoratorView.swift
+++ b/Sources/JoyfillUI/View/DecoratorView.swift
@@ -254,43 +254,18 @@ struct RowDecoratorMenuView: View {
         } else if exceedsLimit {
             kebabButton.frame(width: 40, height: 60)
         } else {
-            VStack(spacing: 0) {
-                ForEach(Array(inlineVisible.enumerated()), id: \.offset) { _, decorator in
-                    singleDecoratorButton(decorator)
-                        .frame(maxHeight: .infinity)
-                }
-                if hasInlineOverflow {
-                    Text("•••")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+            GeometryReader { geometry in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 4) {
+                        ForEach(Array(displayable.enumerated()), id: \.offset) { _, decorator in
+                            DecoratorButton(decorator: decorator, onTap: onDecoratorTap)
+                        }
+                    }
+                    .frame(minWidth: geometry.size.width, alignment: .center)
                 }
             }
-            .frame(width: 40, height: 60)
+            .frame(height: 32)
         }
-    }
-
-    private func singleDecoratorButton(_ decorator: DecoratorLocal) -> some View {
-        let tint: Color = decorator.color.map { Color(hex: $0) } ?? .secondary
-        return Button {
-            onDecoratorTap(decorator)
-        } label: {
-            HStack(spacing: 4) {
-                if let icon = decorator.icon, !icon.isEmpty {
-                    DecoratorIconImage(iconName: icon, size: 14)
-                }
-                if let label = decorator.label, !label.isEmpty {
-                    Text(label)
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(1)
-                }
-            }
-            .foregroundColor(tint)
-            .frame(width: 40)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("row_decorator_\(decorator.action ?? "unknown")")
     }
 
     private var kebabButton: some View {

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -397,7 +397,7 @@ struct CollectionColumnHeaderView: View {
             if viewModel.showRowDecorators(forSchemaKey: schemaKey) {
                 Image(systemName: "ellipsis")
                     .rotationEffect(.degrees(90))
-                    .frame(width: 40, height: 60)
+                    .frame(width: viewModel.decoratorsCellWidth(), height: 60)
                     .foregroundColor(Color.gray.opacity(0.4))
                     .border(Color.tableCellBorderColor)
                     .background(colorScheme == .dark ? Color(UIColor.systemGray6) : Color.tableColumnBgColor)
@@ -625,7 +625,10 @@ struct CollectionRowsHeaderView: View {
                 }
                 if viewModel.showRowDecorators(forSchemaKey: parentSchemaKey) {
                     let parentPathForNested = viewModel.getParenthPath(rowId: rowModel.rowID)
-                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: parentSchemaKey), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
+                    RowDecoratorMenuView(
+                        decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: parentSchemaKey),
+                        visibleLimit: viewModel.decoratorConfig.visibleLimitInRows
+                    ) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
                             fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
                             action: decorator.action ?? "",
@@ -633,6 +636,8 @@ struct CollectionRowsHeaderView: View {
                             parentPath: parentPathForNested.0
                         )
                     }
+                    .padding(.all, 4)
+                    .frame(width: viewModel.decoratorsCellWidth(), height: 60)
                     .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))
                     .border(Color.tableCellBorderColor)
                 }
@@ -667,9 +672,14 @@ struct CollectionRowsHeaderView: View {
                         .accessibilityIdentifier("SingleClickEditButton\(rowIndex)")
                 }
                 if viewModel.showRowDecorators(forSchemaKey: viewModel.rootSchemaKey) {
-                    RowDecoratorMenuView(decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: viewModel.rootSchemaKey), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
+                    RowDecoratorMenuView(
+                        decorators: viewModel.getCollectionRowDecorators(forRowID: rowModel.rowID, schemaKey: viewModel.rootSchemaKey),
+                        visibleLimit: viewModel.decoratorConfig.visibleLimitInRows
+                    ) { decorator in
                         viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
                     }
+                    .padding(.all, 4)
+                    .frame(width: viewModel.decoratorsCellWidth(), height: 60)
                     .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))
                     .border(Color.tableCellBorderColor)
                 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -503,7 +503,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
     
     func rowWidth(_ tableColumns: [FieldTableColumn], _ level: Int, _ schemaKey: String, tableDataModel: TableDataModel) -> CGFloat {
-        return Utility.getWidthForExpanderRow(columns: tableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey)) + Utility.getTotalTableScrollWidth(level: level)
+        return Utility.getWidthForExpanderRow(columns: tableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey), rowDecoratorsCellWidth: decoratorsCellWidth()) + Utility.getTotalTableScrollWidth(level: level)
     }
     
     func getCollectionWidth(tableDataModel: TableDataModel) -> CGFloat {
@@ -788,7 +788,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                                                    rowType: .tableExpander(schemaValue: (childSchemaKey, childSchema),
                                                                            level: level,
                                                                            parentID: parentID,
-                                                                           rowWidth: Utility.getWidthForExpanderRow(columns: filteredTableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: childSchemaKey))),
+                                                                           rowWidth: Utility.getWidthForExpanderRow(columns: filteredTableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: childSchemaKey), rowDecoratorsCellWidth: decoratorsCellWidth())),
                                                    isExpanded: true, // Mark as expanded since we're showing content
                                                    rowWidth: rowWidth(filteredTableColumns, level, childSchemaKey, tableDataModel: tableDataModel))
                     cellModels.append(expanderRow)
@@ -974,7 +974,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                                                             rowType: .tableExpander(schemaValue: (id, schemaValue),
                                                                                     level: level,
                                                                                     parentID: (columnID: "", rowID: rowDataModel.rowID),
-                                                                                    rowWidth: Utility.getWidthForExpanderRow(columns: filteredTableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: id))),
+                                                                                    rowWidth: Utility.getWidthForExpanderRow(columns: filteredTableColumns, showSelector: showRowSelector(for: tableDataModel), showSingleClickEdit: showSingleClickEditButton(for: tableDataModel), showRowDecorators: tableDataModel.hasAnyRowDecorators(schemaKey: id), rowDecoratorsCellWidth: decoratorsCellWidth())),
                                                             rowWidth: rowWidth(filteredTableColumns, level, id, tableDataModel: tableDataModel)
                             )
                             rowDataModel.isExpanded = false
@@ -2254,6 +2254,16 @@ protocol TableDataViewModelProtocol {
 extension TableDataViewModelProtocol {
     var decoratorConfig: DecoratorConfig {
         tableDataModel.documentEditor?.decoratorConfig ?? DecoratorConfig()
+    }
+
+    func decoratorsCellWidth() -> CGFloat {
+        if decoratorConfig.visibleLimitInRows <= 1 {
+            return 40
+        } else if decoratorConfig.visibleLimitInRows == 2 {
+            return 80
+        } else {
+            return 100
+        }
     }
 }
 

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -11,6 +11,22 @@ struct TableRowView : View {
 
     var body: some View {
         LazyHStack(alignment: .top, spacing: 0) {
+            if viewModel.showRowDecorators {
+                RowDecoratorMenuView(
+                    decorators: viewModel.tableDataModel.getTableRowDecorators(forRowID: rowDataModel.rowID),
+                    visibleLimit: viewModel.decoratorConfig.visibleLimitInRows
+                ) { decorator in
+                    viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
+                        fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
+                        action: decorator.action ?? "",
+                        rowIds: [rowDataModel.rowID]
+                    )
+                }
+                .padding(.all, 4)
+                .frame(width: viewModel.decoratorsCellWidth(), height: 60)
+                .background(Color.rowSelectionBackground(isSelected: isSelected, colorScheme: colorScheme))
+                .border(Color.tableCellBorderColor)
+            }
             ForEach($rowDataModel.cells, id: \.id) { $cellModel in
                 TableViewCellBuilder(viewModel: viewModel, cellModel: $cellModel)
                     .frame(width: 200, height: 60)
@@ -194,7 +210,6 @@ struct TableModalView : View {
         var width: CGFloat = 40 // # column
         if viewModel.showRowSelector { width += 40 }
         if viewModel.showSingleClickEditButton { width += 40 }
-        if viewModel.showRowDecorators { width += 40 }
         return width
     }
 
@@ -221,13 +236,6 @@ struct TableModalView : View {
                         .border(Color.tableCellBorderColor)
                     if viewModel.showSingleClickEditButton {
                         Image(systemName: "square.and.pencil")
-                            .frame(width: 40, height: 60)
-                            .foregroundColor(Color.gray.opacity(0.4))
-                            .border(Color.tableCellBorderColor)
-                    }
-                    if viewModel.showRowDecorators {
-                        Image(systemName: "ellipsis")
-                            .rotationEffect(.degrees(90))
                             .frame(width: 40, height: 60)
                             .foregroundColor(Color.gray.opacity(0.4))
                             .border(Color.tableCellBorderColor)
@@ -283,6 +291,18 @@ struct TableModalView : View {
 
     var colsHeader: some View {
         HStack(alignment: .top, spacing: 0) {
+            if viewModel.showRowDecorators {
+                Image(systemName: "ellipsis")
+                    .rotationEffect(.degrees(90))
+                    .foregroundColor(Color.gray.opacity(0.4))
+                    .frame(width: viewModel.decoratorsCellWidth(), height: 60)
+                    .background(colorScheme == .dark ? Color(UIColor.systemGray6) : Color.tableColumnBgColor)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 0)
+                            .inset(by: 1)
+                            .stroke(Color.tableCellBorderColor, lineWidth: 1.5)
+                    )
+            }
             ForEach(Array(viewModel.tableDataModel.tableColumns.enumerated()), id: \.offset) { index, column in
                 HStack {
                     ScrollView {
@@ -363,13 +383,6 @@ struct TableModalView : View {
                                 showEditMultipleRowsSheetView = true
                             }
                             .accessibilityIdentifier("SingleClickEditButton\(index)")
-                    }
-                    if viewModel.showRowDecorators {
-                        RowDecoratorMenuView(decorators: viewModel.tableDataModel.getTableRowDecorators(forRowID: rowModel.rowID), visibleLimit: viewModel.decoratorConfig.visibleLimitInRows) { decorator in
-                            viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: [rowModel.rowID])
-                        }
-                        .background(Color.rowSelectionBackground(isSelected: isRowSelected, colorScheme: colorScheme))
-                        .border(Color.tableCellBorderColor)
                     }
                 }
             }

--- a/Sources/JoyfillUI/View/Utility.swift
+++ b/Sources/JoyfillUI/View/Utility.swift
@@ -26,7 +26,7 @@ class Utility {
         }
     }
     
-    static func getWidthForExpanderRow(columns: [FieldTableColumn], showSelector: Bool, showSingleClickEdit: Bool = false, showRowDecorators: Bool = false) -> CGFloat {
+    static func getWidthForExpanderRow(columns: [FieldTableColumn], showSelector: Bool, showSingleClickEdit: Bool = false, showRowDecorators: Bool = false, rowDecoratorsCellWidth: CGFloat = 40) -> CGFloat {
         let totalWidth = columns.reduce(0) { accumulator, column in
             // Get width based on column type and format
             let columnWidth = Utility.getCellWidth(
@@ -38,7 +38,7 @@ class Utility {
         let widthForTwoEmptyBox: CGFloat = 80
         let widthForThirdEmptyBox: CGFloat = showSelector ? 40 : 0
         let widthForEditButton: CGFloat = showSingleClickEdit ? 40 : 0
-        let widthForRowDecorators: CGFloat = showRowDecorators ? 40 : 0
+        let widthForRowDecorators: CGFloat = showRowDecorators ? rowDecoratorsCellWidth : 0
         return max(totalWidth, singleColumnWidth) + widthForTwoEmptyBox + widthForThirdEmptyBox + widthForEditButton + widthForRowDecorators
     }
     


### PR DESCRIPTION
## Context
Row decorators in tables and collections need to respect the `decoratorConfig.visibleLimitInRows` setting visually — both in how many decorators render inline before collapsing to a kebab, and in how wide the dedicated decorator column reserves for itself. Previously the column was hardcoded at 40pt regardless of how many decorators were configured to show, so anything more than one inline decorator got cramped. The inline rendering also stacked vertically with a `•••` overflow indicator, which didn't scale well with longer decorator sets.

## What changed
- **`RowDecoratorMenuView`** ([DecoratorView.swift](Sources/JoyfillUI/View/DecoratorView.swift)): below-limit rows now render decorators in a horizontal `ScrollView` of `DecoratorButton`s instead of a vertical stack with a `•••` overflow indicator. Above-limit rows still collapse to a single kebab.
- **Shared width helper** ([CollectionViewModel.swift:2259](Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift)): added `decoratorsCellWidth()` as a default implementation on `TableDataViewModelProtocol` (returns 40 / 80 / 100 for limit ≤ 1 / 2 / ≥ 3). Both `TableViewModel` and `CollectionViewModel` get it via conformance — one source of truth.
- **Table** ([TableModalView.swift](Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift)): row decorator moved out of the sticky left pane into the horizontally scrolling area. Added a decorator header cell at the start of `colsHeader` and a per-row decorator cell at the start of `TableRowView`. `leftColumnWidth` and the left header HStack no longer reserve space for it. Cleaned up the now-stale commented-out block in `rowsHeader`.
- **Collection** ([CollectionModelView.swift](Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift)): kept the decorator inside `CollectionRowsHeaderView` (collection has no sticky-pane split, so there's no reason to move it). Header cell in `CollectionColumnHeaderView` and per-row cells in both `.row` and `.nestedRow` now use `decoratorsCellWidth()` so they stay aligned.
- **Width plumbing** ([Utility.swift](Sources/JoyfillUI/View/Utility.swift)): `getWidthForExpanderRow` accepts a `rowDecoratorsCellWidth` parameter (default 40) so collection's `collectionWidth` calculation reflects the dynamic width. Threaded through three call sites in `CollectionViewModel`.

## Decisions and rationale
- **Why width 40 / 80 / 100 instead of `limit × 40`?** `visibleLimitInRows` is a *collapse threshold*, not a render count — a row with `count ≤ limit` renders all of its decorators in a horizontal scroll inside the cell. Capping the reserved width at 100 keeps the column from dominating the table when limits are configured high (e.g. 5–10), while still giving inline rows real space to breathe. 40 stays the default for the common limit-of-1 case.
- **Why option B over a per-row max-count scan?** Considered computing the max actual decorator count across all rows but rejected it on perf grounds (collection has nested schemas and frequent reflows). The chosen approach is cosmetic-loose for rows whose count exceeds the limit (kebab in a wider cell) but bounded and cheap.
- **Why move only the table's decorator and not the collection's?** Table has a sticky left pane that the decorator was trapped in; moving it into the scroll area was the user-visible goal. Collection has no sticky pane — everything already scrolls together — so the decorator stays where it was. Both use the same width helper for visual consistency.

## Screenshots / video
_TODO: attach a short clip showing the table column scrolling horizontally with the decorators, and the collection rows with the wider cell when `visibleLimitInRows = 2 or 3`._

## Public API
- No public API changes. The new `decoratorsCellWidth()` is added on the **internal** `TableDataViewModelProtocol`.
- `Utility.getWidthForExpanderRow` gained an optional parameter `rowDecoratorsCellWidth: CGFloat = 40` — internal type, default keeps any existing caller's behavior identical.
- No docs update needed.

## Tests
- No new tests in this PR. The change is purely visual/layout. Will follow up with snapshot tests in a separate PR if/when the snapshot infra lands for these views.
- Manually verified: table decorator column scrolls with data columns; collection rows align with header at limit 1, 2, and ≥3; inline horizontal scroll renders correctly for below-limit rows; kebab still appears for above-limit rows.

## Notes for reviewer
- Width formula's cap at 100 is a judgment call — happy to bump to 120 (the previous attempt) if real usage shows decorators getting clipped.
- The `inlineMax = 3` constant in `RowDecoratorMenuView` is now effectively dead (the body uses `displayable` directly). Left as-is to keep this PR scoped, but worth removing in cleanup.
- Commented-out decorator block previously in `rowsHeader` of the table is removed — no longer needed since the decorator now lives in the scrolling area.