### PR TITLE
NO-2115 Store blank chart points as null in JSON

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/ChartField/ChartFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChartField/ChartFieldUITestCases.swift
@@ -106,6 +106,48 @@ final class ChartFieldUITestCases: JoyfillUITestsBaseClass {
         XCTAssertEqual(verticalTF.value as? String, "one")
         XCTAssertEqual(horizontalTF.value as? String, "two")
     }
+    
+    func testChartCoordinateValuesPersistAndClearToNil() {
+        goToChartDetailField(index: 0)
+
+        let horizontalPointsValue = app.textFields.matching(identifier: "HorizontalPointsValue").element(boundBy: 0)
+        let verticalPointsValue = app.textFields.matching(identifier: "VerticalPointsValue").element(boundBy: 0)
+
+        XCTAssertTrue(horizontalPointsValue.waitForExistence(timeout: 1), "Horizontal coordinate textfield not found")
+        XCTAssertTrue(verticalPointsValue.waitForExistence(timeout: 1), "Vertical coordinate textfield not found")
+
+        horizontalPointsValue.tap()
+        horizontalPointsValue.clearText()
+        horizontalPointsValue.typeText("11")
+
+        verticalPointsValue.tap()
+        verticalPointsValue.clearText()
+        verticalPointsValue.typeText("22")
+        app.dismissKeyboardIfVisible()
+
+        goBack()
+
+        goToChartDetailField(index: 0)
+        let horizontalAfterWrite = app.textFields.matching(identifier: "HorizontalPointsValue").element(boundBy: 0)
+        let verticalAfterWrite = app.textFields.matching(identifier: "VerticalPointsValue").element(boundBy: 0)
+
+        XCTAssertEqual(horizontalAfterWrite.value as? String, "11", "Horizontal coordinate did not persist after navigation")
+        XCTAssertEqual(verticalAfterWrite.value as? String, "22", "Vertical coordinate did not persist after navigation")
+
+        horizontalAfterWrite.tap()
+        horizontalAfterWrite.clearText()
+        verticalAfterWrite.tap()
+        verticalAfterWrite.clearText()
+
+        goBack()
+
+        goToChartDetailField(index: 0)
+        let horizontalAfterClear = app.textFields.matching(identifier: "HorizontalPointsValue").element(boundBy: 0)
+        let verticalAfterClear = app.textFields.matching(identifier: "VerticalPointsValue").element(boundBy: 0)
+
+        XCTAssertNil(onChangeResultValue().valueElements?.first?.points?.first?.x, "Horizontal coordinate should be nil after clearing")
+        XCTAssertNil(onChangeResultValue().valueElements?.first?.points?.first?.y, "Vertical coordinate should be nil after clearing")
+    }
 
     func testChartFieldOnFocusAndOnBlur() {
         goToChartDetailField(index: 0)

--- a/JoyfillSwiftUIExample/JoyfillUITests/ChartField/ChartFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChartField/ChartFieldUITestCases.swift
@@ -147,6 +147,14 @@ final class ChartFieldUITestCases: JoyfillUITestsBaseClass {
 
         XCTAssertNil(onChangeResultValue().valueElements?.first?.points?.first?.x, "Horizontal coordinate should be nil after clearing")
         XCTAssertNil(onChangeResultValue().valueElements?.first?.points?.first?.y, "Vertical coordinate should be nil after clearing")
+
+        // The getter returns nil for both `.null` and "key absent". Pin down the
+        // actual contract — cleared coordinates must be omitted from the point's
+        // dictionary entirely (not stored as .null or .double(0)).
+        let clearedPoint = onChangeResultValue().valueElements?.first?.points?.first
+        XCTAssertNotNil(clearedPoint, "Point should still exist after clearing coordinates")
+        XCTAssertNil(clearedPoint?.dictionary["x"], "x key should be absent from point dictionary, not stored as null or 0")
+        XCTAssertNil(clearedPoint?.dictionary["y"], "y key should be absent from point dictionary, not stored as null or 0")
     }
 
     func testChartFieldOnFocusAndOnBlur() {

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1656,7 +1656,7 @@ public struct Point: Codable,Hashable, Equatable {
     ///   - key: The key to set the value for.
     mutating func setValue(_ value: CGFloat?, key: String) {
         guard let value = value else {
-            self.dictionary[key] = .null
+            self.dictionary[key] = nil
             return
         }
         self.dictionary[key] = .double(value)

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1594,7 +1594,10 @@ public struct Point: Codable,Hashable, Equatable {
         }
         let allKeys = container.allKeys
         for key in allKeys {
-            dictionary[key.stringValue] = try container.decodeIfPresent(ValueUnion.self, forKey: key)
+            // Use `decode` rather than `decodeIfPresent` so JSON `null` round-trips
+            // as `ValueUnion.null` instead of being silently dropped. `allKeys` only
+            // contains keys present in the payload, so `decode` cannot throw "missing key".
+            dictionary[key.stringValue] = try container.decode(ValueUnion.self, forKey: key)
         }
     }
 

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1633,8 +1633,8 @@ public struct Point: Codable,Hashable, Equatable {
     /// - Parameter id: The id of the `Point`.
     public init(id: String) {
         self.id = id
-        self.x = 0
-        self.y = 0
+        self.x = nil
+        self.y = nil
         self.label = ""
     }
 
@@ -1656,6 +1656,7 @@ public struct Point: Codable,Hashable, Equatable {
     ///   - key: The key to set the value for.
     mutating func setValue(_ value: CGFloat?, key: String) {
         guard let value = value else {
+            self.dictionary[key] = .null
             return
         }
         self.dictionary[key] = .double(value)

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -1594,10 +1594,7 @@ public struct Point: Codable,Hashable, Equatable {
         }
         let allKeys = container.allKeys
         for key in allKeys {
-            // Use `decode` rather than `decodeIfPresent` so JSON `null` round-trips
-            // as `ValueUnion.null` instead of being silently dropped. `allKeys` only
-            // contains keys present in the payload, so `decode` cannot throw "missing key".
-            dictionary[key.stringValue] = try container.decode(ValueUnion.self, forKey: key)
+            dictionary[key.stringValue] = try container.decodeIfPresent(ValueUnion.self, forKey: key)
         }
     }
 

--- a/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
+++ b/Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift
@@ -465,10 +465,11 @@ struct PointView: View {
                 HStack {
                     var xBinding : Binding<String> {
                            Binding {
+                               guard let x = point.x else { return "" }
                                let formatter = NumberFormatter()
                                formatter.numberStyle = .decimal
                                formatter.usesGroupingSeparator = false
-                               let formattedNumberString = formatter.string(from: NSNumber(value: point.x ?? 0)) ?? ""
+                               let formattedNumberString = formatter.string(from: NSNumber(value: x)) ?? ""
                                return formattedNumberString
                            } set: { newX in
                                setX(x: newX)
@@ -476,10 +477,11 @@ struct PointView: View {
                        }
                     var yBinding : Binding<String> {
                            Binding {
+                               guard let y = point.y else { return "" }
                                let formatter = NumberFormatter()
                                formatter.numberStyle = .decimal
                                formatter.usesGroupingSeparator = false
-                               let formattedNumberString = formatter.string(from: NSNumber(value: point.y ?? 0)) ?? ""
+                               let formattedNumberString = formatter.string(from: NSNumber(value: y)) ?? ""
                                return formattedNumberString
                            } set: { newY in
                                setY(y: newY)
@@ -506,7 +508,7 @@ struct PointView: View {
         formatter.usesGroupingSeparator = false
         let number = formatter.number(from: y)
         var point = self.point
-        point.y = CGFloat(number?.doubleValue ?? 0)
+        point.y = number.map { CGFloat($0.doubleValue) }
         updatePoint(point)
     }
     
@@ -516,7 +518,7 @@ struct PointView: View {
         formatter.usesGroupingSeparator = false
         let number = formatter.number(from: x)
         var point = self.point
-        point.x = CGFloat(number?.doubleValue ?? 0)
+        point.x = number.map { CGFloat($0.doubleValue) }
         updatePoint(point)
     }
 }


### PR DESCRIPTION
## Context / Spec
Spec: when a coordinate (x or y) on a chart-field point is left blank — i.e. the user has not entered any value, not even zero — the saved JSON should not encode that coordinate as `0`. Today blanks silently coerce to `0`, which is indistinguishable from a real zero and corrupts downstream charting/analytics. The fix omits the coordinate from the JSON entirely when the user hasn't entered a value.

## What Changed
Two source files plus a UI test, all scoped to chart-point handling:

- **`Sources/JoyfillModel/JoyDoc.swift`**
  - `Point.setValue(_ value: CGFloat?, key:)` now removes the key from the dictionary when `value` is `nil` (previously it was a no-op, so clearing a coordinate left the prior value in place). With the key removed, the encoder emits no field at all for that coordinate.
  - `Point.init(id:)` no longer defaults `x` and `y` to `0`; new points start with `nil` coordinates so an untouched, freshly added point serializes without `x` / `y` keys.

- **`Sources/JoyfillUI/View/Fields/ChartView/ChartDetailView.swift`**
  - `setX` / `setY` use `number.map { CGFloat($0.doubleValue) }` instead of `?? 0`, so empty / unparseable input propagates as `nil` rather than being coerced to `0`.
  - `xBinding` / `yBinding` display an empty string when the underlying value is `nil` instead of formatting `0`, so a cleared field reads as blank in the UI.

- **`JoyfillSwiftUIExample/JoyfillUITests/ChartField/ChartFieldUITestCases.swift`**
  - New `testChartCoordinateValuesPersistAndClearToNil` UI test covering write → persist round-trip and clear → key-absent propagation through `onChange`.

## Design Decisions
- **Removing the key (not storing `.null`) when the setter receives `nil`.** The encoder iterates the dictionary, so omitting the key produces no field for that coordinate in the JSON. This is symmetric with `Point.init(from:)`, which uses `decodeIfPresent` and collapses both "missing key" and JSON `null` into "key absent" — meaning encode/decode is a fixed point, and re-saved documents stay stable across round-trips. Storing `.null` would have produced an asymmetric encoder (emits `null`) vs. decoder (drops it back to absent).
- **Fix is in the model setter, not only in the UI.** Doing it in `Point.setValue` makes the invariant universal — any future caller that assigns `point.x = nil` gets the right behavior, instead of every UI site having to remember to clear the dictionary entry manually.
- **Display binding shows empty string for `nil`, not `"0"`.** Otherwise the user sees `0` even though no value is stored, which is misleading and reintroduces the original confusion.
- **No change to `Point`'s public signatures.** Only the internal behavior of `setValue(CGFloat?, key:)` and `init(id:)` changed — both still accept the same arguments and produce a valid `Point`.

## Screenshots / Video
N/A — behavioral / serialization change only; no visual layout difference. Cleared input now reads as blank instead of `0`, which matches what the user typed.

## Public API Impact
No public API surface changes. `Point.init(id:)` and `Point.x` / `Point.y` setters keep the same signatures; only their internal handling of `nil` changes (previously `nil` was silently dropped, now it removes the key from the underlying dictionary). No SDK docs need updating.

## Test Coverage
UI test added: `testChartCoordinateValuesPersistAndClearToNil` in `ChartFieldUITestCases`. It walks the full path:
1. Enter values into the horizontal / vertical point textfields, navigate away, navigate back → values persist correctly.
2. Clear both textfields, navigate away, navigate back → asserts `valueElements.first.points.first.x` and `.y` are both `nil` via the `onChange` payload, and additionally pins down the contract that the cleared coordinates are omitted from the point's dictionary entirely (not stored as `.null` or `.double(0)`).

This covers the regression directly. No additional unit tests were added.

## Reviewer Notes
- The behavior change in `Point.setValue(CGFloat?, key:)` (previously a no-op for `nil`) only has two callers — the `x` and `y` setters — so the blast radius is contained.
- Existing documents that already store explicit `0` coordinates are unaffected; only newly cleared / freshly added blank points have their keys omitted from the JSON.