### PR TITLE
NO-2120 Update schema for chart x/y nullability and image multi flag

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -12,7 +12,7 @@ import Joyfill
 
 final class SchemaValidationTests: XCTestCase {
     /// The schema version expected in `SchemaValidationError.details`.
-    private let expectedSchemaVersion = "1.0.0"
+    private let expectedSchemaVersion = "1.0.1"
     private let sdkVersion = "3.0.0-rc17"
     
     func documentEditor(document: JoyDoc) -> DocumentEditor {

--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -341,6 +341,39 @@ final class SchemaValidationTests: XCTestCase {
             XCTAssertEqual(expectedSchemaVersion, err?.details.schemaVersion)
         }
     }
+
+    // MARK: - Schema 1.0.1 relaxations
+
+    // ChartPoint: x/y are now optional and may be null. Only _id is required.
+    func testChartPoint_WithNullOrMissingCoordinates_ShouldValidate() {
+        let cases: [(String, [String: Any])] = [
+            ("null x and y",     ["_id": "p1", "x": NSNull(), "y": NSNull()]),
+            ("missing x and y",  ["_id": "p2"]),
+            ("null x only",      ["_id": "p3", "x": NSNull(), "y": 5]),
+            ("missing y only",   ["_id": "p4", "x": 1])
+        ]
+        for (label, point) in cases {
+            var docDict = minimalValidDocumentDictionary()
+            let chartField: [String: Any] = [
+                "_id": "chart1",
+                "type": "chart",
+                "file": "file1",
+                "xTitle": "X", "yTitle": "Y",
+                "xMin": 0, "xMax": 100,
+                "yMin": 0, "yMax": 100,
+                "value": [
+                    [
+                        "_id": "series1",
+                        "points": [point]
+                    ]
+                ]
+            ]
+            docDict["fields"] = [chartField]
+            let doc = JoyDoc(dictionary: docDict)
+            let err = JoyfillSchemaManager().validateSchema(document: doc)
+            XCTAssertNil(err, "ChartPoint with \(label) should validate against the relaxed schema")
+        }
+    }
 }
 
 private class MockFormChangeEvent: FormChangeEvent {

--- a/Sources/JoyfillUI/View/joyfill-schema.swift
+++ b/Sources/JoyfillUI/View/joyfill-schema.swift
@@ -1877,6 +1877,9 @@ public var joyfillSchema = """
             "type": "string",
             "minLength": 1
           },
+          "multi": {
+            "type": "boolean"
+          },
           "type": {
             "type": "string",
             "const": "image"
@@ -2257,16 +2260,14 @@ public var joyfillSchema = """
             "type": "string"
           },
           "y": {
-            "type": "number"
+            "type": ["number", "null"]
           },
           "x": {
-            "type": "number"
+            "type": ["number", "null"]
           }
         },
         "required": [
-          "_id",
-          "y",
-          "x"
+          "_id"
         ]
       },
       "CollectionField": {

--- a/Sources/JoyfillUI/View/joyfill-schema.swift
+++ b/Sources/JoyfillUI/View/joyfill-schema.swift
@@ -2594,7 +2594,7 @@ public var joyfillSchema = """
         ]
       }
     },
-    "$joyfillSchemaVersion": "1.0.0"
+    "$joyfillSchemaVersion": "1.0.1"
   }
 
 """


### PR DESCRIPTION
## 1. Context / Spec
The bundled `joyfill-schema.swift` was out of sync with the latest backend schema for chart points and image columns. Chart points need to support sparse data (missing or null x/y), and image columns (image-type cells in table/collection fields) need a `multi` flag to indicate multi-image support. Bumping the embedded schema version to reflect the change.

## 2. What Changed
**File:** `Sources/JoyfillUI/View/joyfill-schema.swift`

- **Chart point** (`x`, `y`):
  - Type changed from `"number"` to `["number", "null"]`
  - Removed from `required` array — only `_id` is now required
- **ImageColumn** (image-type column in table/collection):
  - Added optional `multi: boolean` property
- **Schema version**:
  - `$joyfillSchemaVersion` bumped `1.0.0` → `1.0.1`

**File:** `JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift`

- Updated `expectedSchemaVersion` constant from `"1.0.0"` to `"1.0.1"` to match the bumped schema (resolves 49 test failures in the `SchemaValidationTests` suite — all of them were asserting against this single constant).

## 3. Design Decisions
- Used JSON Schema's union type `["number", "null"]` rather than dropping the type constraint, so non-null values are still validated as numbers.
- Kept `_id` required on chart points to preserve point identity even when coordinates are absent.
- `multi` is optional (not in `required`) on `ImageColumn` to remain backwards-compatible with existing column definitions.
- Bumped version to **1.0.1** (patch) because all changes are backwards-compatible relaxations: relaxing `required` and adding optional fields. `JoyfillSchemaManager.validateVersion` only compares major versions, so this bump flows through without code changes and old documents continue to validate.

## 4. Screenshots / Video
N/A — schema-only change, no UI impact.

## 5. Public API Impact
No public Swift API changes. `joyfillSchema` is a `public var` string constant; its value is updated but the symbol/signature is unchanged. Swift models already support the new shapes — `Point.x`/`Point.y` are already `CGFloat?`, and `multi: Bool?` already exists on the column-data types in `JoyDoc.swift`. No docs update required.

## 6. Test Coverage
- Existing `SchemaValidationTests` suite (49 tests) continues to pass after the version-constant update; nothing in those tests depends on chart x/y being required or on `ImageColumn` lacking `multi`, so the relaxations don't break them.
- No new positive-coverage tests added for the relaxed shapes (chart point with `x: null` / missing `x`/`y`, ImageColumn with `multi: true`). Can be added as a follow-up if desired.

## 7. Reviewer Notes
- Diff is small and localized; please verify the schema delta matches the canonical backend schema source.
- The `null` allowance on `x`/`y` means downstream chart rendering must already tolerate missing coordinates — verified that current consumers (`ChartDetailView`, formula context in `JoyfillDocContext`) treat them as optional, and no force-unwraps exist in `ChartView/`.
- Version bump is **patch-level** (1.0.0 → 1.0.1); no migration or consumer impact expected.
- The fallback `documentVersion ?? "1.0.0"` in `JoyfillSchemaManager.swift:69` is intentional ("treat undefined as v1.x.x") and was deliberately left as-is — major-version comparison makes the literal irrelevant.