### PR TITLE
NO-2127: Show decorators, tooltip, and required indicator on readonly forms and when title is hidden

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
@@ -29,6 +29,9 @@ private let cL2ColBarcode    = "69e8827e72fb2149cfd944a4"
 
 // Text field
 private let fpTextField = "6970918d350238d0738dd5c9"
+private let fpNumberField = "69709192a4e9c0c281851275"
+private let fpDateField = "6970919451f1adb30fcff9ea"
+private let fpDropdownField = "6970919a6ce635a6b14913ed"
 
 // MARK: - Decorator base (disables animations for all decorator tests)
 
@@ -779,5 +782,99 @@ final class DecoratorCollectionAPIUITests: DecoratorAPIUITestsBase {
         S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
         XCTAssertTrue(waitUntil(2) { !flag.exists })
         S.dismissRowEditForm(in: app)
+    }
+}
+
+// MARK: - Readonly Decorator Coverage
+
+final class DecoratorReadonlyAPIUITests: DecoratorAPIUITestsBase {
+
+    override func getJSONFileNameForTest() -> String { "Decorator" }
+
+    override func getGotoLaunchArguments() -> [(String, String?)] {
+        return [("--disable-animations", nil), ("--mode", "readonly")]
+    }
+
+    private func slightSwipeUp() {
+        let start = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.72))
+        let end = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.58))
+        start.press(forDuration: 0.01, thenDragTo: end)
+    }
+
+    private func addTapAndAssertFocus(path: String, action: String) {
+        typealias S = DecoratorUITestSupport
+        let button = app.buttons[S.fieldDecoratorID(action: action)]
+
+        S.run(S.addCommand(path: path,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+
+        XCTAssertTrue(waitUntil(3) { button.exists && button.isHittable })
+        button.tap()
+
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        })
+
+        S.run(S.removeCommand(path: path, action: action), in: app)
+    }
+
+    func testReadonly_TextDecorator_Tappable() {
+        addTapAndAssertFocus(path: "\(pageID)/\(fpTextField)", action: "ro_text")
+    }
+
+    func testReadonly_NumberDecorator_Tappable() {
+        addTapAndAssertFocus(path: "\(pageID)/\(fpNumberField)", action: "ro_number")
+    }
+
+    func testReadonly_DateDecorator_Tappable() {
+        addTapAndAssertFocus(path: "\(pageID)/\(fpDateField)", action: "ro_date")
+    }
+
+    func testReadonly_DropdownDecorator_Tappable() {
+        slightSwipeUp()
+        addTapAndAssertFocus(path: "\(pageID)/\(fpDropdownField)", action: "ro_dropdown")
+    }
+
+    func testReadonly_TableRowDecorator_Tappable() {
+        typealias S = DecoratorUITestSupport
+        let action = "ro_table_row"
+        let rowsPath = "\(pageID)/\(fpTable)/rows"
+
+        S.openTableDetailView(in: app)
+        let rowButton = app.buttons.matching(identifier: S.rowDecoratorID(action: action)).element(boundBy: 0)
+
+        S.run(S.addCommand(path: rowsPath,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(waitUntil(3) { rowButton.exists && rowButton.isHittable })
+
+        rowButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        })
+
+        S.run(S.removeCommand(path: rowsPath, action: action), in: app)
+    }
+
+    func testReadonly_CollectionRowDecorator_Tappable() {
+        typealias S = DecoratorUITestSupport
+        let action = "ro_collection_row"
+        let rootRowsPath = "\(pageID)/\(fpCollection)/rows"
+
+        S.openCollectionDetailView(in: app)
+        let rowButton = app.buttons.matching(identifier: S.rowDecoratorID(action: action)).element(boundBy: 0)
+
+        S.run(S.addCommand(path: rootRowsPath,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+        XCTAssertTrue(waitUntil(3) { rowButton.exists && rowButton.isHittable })
+
+        rowButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        })
+
+        S.run(S.removeCommand(path: rootRowsPath, action: action), in: app)
     }
 }

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -20,53 +20,53 @@ struct FieldHeaderView: View {
     }
     
     var body: some View {
-        if let title = fieldHeaderModel?.title {
-            HStack(alignment: .center, spacing: 4) {
+        HStack(alignment: .center, spacing: 4) {
+            if let title = fieldHeaderModel?.title {
                 Text("\(title)")
                     .font(.headline.bold())
-                
-                if fieldHeaderModel?.required == true {
-                    Image(systemName: "asterisk")
-                        .foregroundColor(isFilled ? .gray : .red)
-                        .imageScale(.small)
+            }
+            
+            if fieldHeaderModel?.required == true {
+                Image(systemName: "asterisk")
+                    .foregroundColor(isFilled ? .gray : .red)
+                    .imageScale(.small)
+            }
+            
+            Spacer()
+            
+            if let model = fieldHeaderModel,
+               !model.decorators.isEmpty {
+                FieldDecoratorsView(
+                    decorators: model.decorators,
+                    visibleLimit: model.visibleLimitInFields
+                ) { decorator in
+                    onDecoratorTap?(decorator)
                 }
-
-                Spacer()
-
-                if let model = fieldHeaderModel,
-                   !model.decorators.isEmpty {
-                    FieldDecoratorsView(
-                        decorators: model.decorators,
-                        visibleLimit: model.visibleLimitInFields
-                    ) { decorator in
-                        onDecoratorTap?(decorator)
-                    }
-                    // Re-enable the header even when the parent field is .disabled() —
-                    // decorators must stay interactive on readonly forms.
-                    .environment(\.isEnabled, true)
-                }
-                let tipDescription = fieldHeaderModel?.tipDescription ?? ""
-                let tipTitle = fieldHeaderModel?.tipTitle ?? ""
-                if let tipVisible = fieldHeaderModel?.tipVisible {
-                    if tipVisible == true && !(tipDescription.isEmpty && tipTitle.isEmpty) {
-                        Button(action: {
-                            if let tipTitle = fieldHeaderModel?.tipTitle,
-                               let tipDescription = fieldHeaderModel?.tipDescription {
-                                alertMessage = tipTitle
-                                alertDescription = tipDescription
-                                showAlert = true
-                            }
-                        }, label: {
-                            Image(systemName: "i.circle")
-                        })
-                        .accessibilityIdentifier("ToolTipIdentifier")
-                        .alert(isPresented: $showAlert) {
-                            Alert(
-                                title: Text(alertMessage ?? ""),
-                                message: Text(alertDescription ?? ""),
-                                dismissButton: .default(Text("Dismiss"))
-                            )
+                // Re-enable the header even when the parent field is .disabled() —
+                // decorators must stay interactive on readonly forms.
+                .environment(\.isEnabled, true)
+            }
+            let tipDescription = fieldHeaderModel?.tipDescription ?? ""
+            let tipTitle = fieldHeaderModel?.tipTitle ?? ""
+            if let tipVisible = fieldHeaderModel?.tipVisible {
+                if tipVisible == true && !(tipDescription.isEmpty && tipTitle.isEmpty) {
+                    Button(action: {
+                        if let tipTitle = fieldHeaderModel?.tipTitle,
+                           let tipDescription = fieldHeaderModel?.tipDescription {
+                            alertMessage = tipTitle
+                            alertDescription = tipDescription
+                            showAlert = true
                         }
+                    }, label: {
+                        Image(systemName: "i.circle")
+                    })
+                    .accessibilityIdentifier("ToolTipIdentifier")
+                    .alert(isPresented: $showAlert) {
+                        Alert(
+                            title: Text(alertMessage ?? ""),
+                            message: Text(alertDescription ?? ""),
+                            dismissButton: .default(Text("Dismiss"))
+                        )
                     }
                 }
             }

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -42,6 +42,7 @@ struct FieldHeaderView: View {
                 ) { decorator in
                     onDecoratorTap?(decorator)
                 }
+                .padding(.bottom, fieldHeaderModel?.title == nil ? 12 : 0)
                 // Re-enable the header even when the parent field is .disabled() —
                 // decorators must stay interactive on readonly forms.
                 .environment(\.isEnabled, true)

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -42,7 +42,7 @@ struct FieldHeaderView: View {
                 ) { decorator in
                     onDecoratorTap?(decorator)
                 }
-                .padding(.bottom, fieldHeaderModel?.title == nil ? 12 : 0)
+                .padding(.bottom, fieldHeaderModel?.title == nil ? 8 : 0)
                 // Re-enable the header even when the parent field is .disabled() —
                 // decorators must stay interactive on readonly forms.
                 .environment(\.isEnabled, true)

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -34,8 +34,7 @@ struct FieldHeaderView: View {
                 Spacer()
 
                 if let model = fieldHeaderModel,
-                   !model.decorators.isEmpty,
-                   model.mode == .fill {
+                   !model.decorators.isEmpty {
                     FieldDecoratorsView(
                         decorators: model.decorators,
                         visibleLimit: model.visibleLimitInFields

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -67,6 +67,9 @@ struct FieldHeaderView: View {
                     }
                 }
             }
+            // Re-enable the header even when the parent field is .disabled() —
+            // decorators and tooltip must stay interactive on readonly forms.
+            .environment(\.isEnabled, true)
         }
     }
 }

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -41,6 +41,9 @@ struct FieldHeaderView: View {
                     ) { decorator in
                         onDecoratorTap?(decorator)
                     }
+                    // Re-enable the header even when the parent field is .disabled() —
+                    // decorators must stay interactive on readonly forms.
+                    .environment(\.isEnabled, true)
                 }
                 let tipDescription = fieldHeaderModel?.tipDescription ?? ""
                 let tipTitle = fieldHeaderModel?.tipTitle ?? ""
@@ -67,9 +70,6 @@ struct FieldHeaderView: View {
                     }
                 }
             }
-            // Re-enable the header even when the parent field is .disabled() —
-            // decorators and tooltip must stay interactive on readonly forms.
-            .environment(\.isEnabled, true)
         }
     }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -294,26 +294,27 @@ struct CollectionEditMultipleRowsSheetView: View {
                     .foregroundColor(.red)
                     .imageScale(.small)
             }
+            
             Text(col.title)
                 .font(.headline.bold())
+            
             Spacer()
-            if viewModel.tableDataModel.mode == .fill {
-                let decorators = viewModel.getCollectionCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "", schemaKey: schemaKey)
-                if !decorators.isEmpty {
-                    let parentPathForSelection: String? = {
-                        guard let firstRowId = viewModel.tableDataModel.selectedRows.first else { return nil }
-                        let (path, _) = viewModel.getParenthPath(rowId: firstRowId)
-                        return path.isEmpty ? nil : path
-                    }()
-                    FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
-                        viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
-                            fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
-                            action: decorator.action ?? "",
-                            rowIds: viewModel.tableDataModel.selectedRows,
-                            columnId: col.id,
-                            parentPath: parentPathForSelection
-                        )
-                    }
+            
+            let decorators = viewModel.getCollectionCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "", schemaKey: schemaKey)
+            if !decorators.isEmpty {
+                let parentPathForSelection: String? = {
+                    guard let firstRowId = viewModel.tableDataModel.selectedRows.first else { return nil }
+                    let (path, _) = viewModel.getParenthPath(rowId: firstRowId)
+                    return path.isEmpty ? nil : path
+                }()
+                FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
+                    viewModel.tableDataModel.documentEditor?.reportDecoratorAction(
+                        fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
+                        action: decorator.action ?? "",
+                        rowIds: viewModel.tableDataModel.selectedRows,
+                        columnId: col.id,
+                        parentPath: parentPathForSelection
+                    )
                 }
             }
         }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -36,7 +36,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
 
     func showRowDecorators(forSchemaKey schemaKey: String) -> Bool {
-        return tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey) && tableDataModel.mode == .fill
+        return tableDataModel.hasAnyRowDecorators(schemaKey: schemaKey)
     }
 
     func getCollectionRowDecorators(forRowID rowID: String, schemaKey: String) -> [DecoratorLocal] {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -237,13 +237,13 @@ struct EditMultipleRowsSheetView: View {
         HStack(alignment: .center, spacing: 4) {
             Text(viewModel.tableDataModel.getColumnTitle(columnId: col.id ?? ""))
                 .font(.headline.bold())
+            
             Spacer()
-            if viewModel.tableDataModel.mode == .fill {
-                let decorators = viewModel.tableDataModel.getTableCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "")
-                if !decorators.isEmpty {
-                    FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
-                        viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id)
-                    }
+            
+            let decorators = viewModel.tableDataModel.getTableCellDecorators(rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id ?? "")
+            if !decorators.isEmpty {
+                FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
+                    viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id)
                 }
             }
         }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -24,7 +24,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
     }
 
     var showRowDecorators: Bool {
-        return tableDataModel.decorate && tableDataModel.mode == .fill
+        return tableDataModel.decorate
     }
 
     private func refreshRowDecoratorMap() {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -657,7 +657,9 @@ extension DocumentEditor {
         let fieldEditMode: Mode = ((fieldData?.disabled == true) || (mode == .readonly) ? .readonly : .fill)
         let decorators = fieldData?.decorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
         
-        var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields) : nil
+        let showTitle = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none")
+        
+        var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
         
         switch fieldPosition.type {
         case .text:
@@ -829,7 +831,9 @@ extension DocumentEditor {
             let fieldEditMode: Mode = ((fieldData?.disabled == true) || (mode == .readonly) ? .readonly : .fill)
             let decorators = fieldData?.decorators?.filter({ $0.isDisplayable }).map(DecoratorLocal.init(from:)) ?? []
             
-            var fieldHeaderModel = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none") ? FieldHeaderModel(title: fieldData?.title, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields) : nil
+            let showTitle = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none")
+            
+            var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
             
             dataModelType = getFieldModel(fieldPosition: fieldPosition, fieldIdentifier: fieldIdentifier)
             fieldListModels.append(FieldListModel(fieldIdentifier: fieldIdentifier, fieldEditMode: fieldEditMode, model: dataModelType))


### PR DESCRIPTION
## 1. Context
On readonly forms (`mode == .readonly` or `field.disabled == true`), the field header was being disabled wholesale by SwiftUI's `.disabled()` propagation, which made decorators non-tappable and hid them in table/collection bulk-edit sheets. Additionally, when `titleDisplay == "none"`, the entire `FieldHeaderView` was skipped, so decorators, the required asterisk, and the tooltip button never rendered even though they should still be visible/interactive.

## 2. What changed
- **[FieldHeaderView.swift](Sources/JoyfillUI/View/FieldHeaderView.swift)** — Always render the header `HStack`; title is now an optional child instead of gating the whole view. Decorators, required asterisk, and tooltip render regardless of title visibility. Added `.environment(\.isEnabled, true)` on `FieldDecoratorsView` so decorators stay tappable even when the parent field is `.disabled()`. Removed the `model.mode == .fill` guard around decorators.
- **[DocumentEditor.swift](Sources/JoyfillUI/ViewModels/DocumentEditor.swift)** — Always build a `FieldHeaderModel`; when `titleDisplay == "none"`, pass `title: nil` instead of skipping the model entirely so decorators/tooltip/required still surface.
- **[TableModalTopNavigationView.swift](Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift)** & **[CollectionModalTopNavigationView.swift](Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift)** — Removed `mode == .fill` gating in the bulk-edit sheet so decorators show on readonly tables/collections.
- **[TableViewModel.swift](Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift)** & **[CollectionViewModel.swift](Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift)** — `showRowDecorators` no longer requires `.fill` mode.

## 3. Why it's done this way
- Used `.environment(\.isEnabled, true)` rather than restructuring the `.disabled()` chain at every call site — this is a localized override scoped to decorator buttons inside the header, keeps the rest of the readonly behavior (inputs disabled) intact, and avoids touching the public field-rendering API.
- Kept building `FieldHeaderModel` unconditionally and made `title` optional, instead of introducing a separate "header-without-title" code path. Smaller diff, single source of truth for header content.
- Mode (`.fill`/`.readonly`) is still tracked on the model; only the rendering gates were removed, so future consumers that need mode-aware behavior aren't blocked.

## 4. Screenshot / video
N/A — behavioral fix; visually the header now appears in readonly mode and when titles are hidden, with decorators tappable. Happy to attach a clip if needed.

## 5. Public API
No public API changes. `FieldHeaderModel.title` was already `String?`; existing initializers and call sites are unchanged. No docs update required.

## 6. Tests
- Added [DecoratorAPIUITests.swift](JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift) covering decorator tap interactions in readonly mode.
- Existing decorator/header UI tests continue to pass.
- Manual verification on readonly forms, `titleDisplay == "none"` fields, and table/collection bulk-edit sheets.

## 7. Notes for reviewer
- The `.environment(\.isEnabled, true)` override is intentionally narrow — only on the `FieldDecoratorsView` inside the header. If you'd prefer a different mechanism (e.g., lifting the `.disabled()` boundary), happy to discuss.
- Decorator visibility is now driven purely by `decorators.isEmpty` and `isDisplayable` — `mode` is no longer a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)