### PR TITLE
NO-2131: Reset duplicated mobile-view page controls + add UI tests

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -180,6 +180,9 @@
 		BA2353392FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2353372FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift */; };
 		BA23533A2FA1DFEF002D9345 /* PageDeletableCopyable.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353362FA1DFEF002D9345 /* PageDeletableCopyable.json */; };
 		BA23533B2FA1DFEF002D9345 /* PageDeletableCopyable.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353362FA1DFEF002D9345 /* PageDeletableCopyable.json */; };
+		BA2353C12FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2353C42FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift */; };
+		BA2353C22FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */; };
+		BA2353C32FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */; };
 		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
 		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
 		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
@@ -588,6 +591,8 @@
 		BA2352F12F99E9F4002D9345 /* Decorator.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Decorator.json; sourceTree = "<group>"; };
 		BA2353362FA1DFEF002D9345 /* PageDeletableCopyable.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageDeletableCopyable.json; sourceTree = "<group>"; };
 		BA2353372FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableUITests.swift; sourceTree = "<group>"; };
+		BA2353C42FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableMobileViewUITests.swift; sourceTree = "<group>"; };
+		BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageDeletableCopyableMobileView.json; sourceTree = "<group>"; };
 		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
 		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
 		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
@@ -1029,6 +1034,8 @@
 			children = (
 				BA2353362FA1DFEF002D9345 /* PageDeletableCopyable.json */,
 				BA2353372FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift */,
+				BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */,
+				BA2353C42FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift */,
 			);
 			path = PageDeletableCopyable;
 			sourceTree = "<group>";
@@ -1688,6 +1695,7 @@
 				36A5EF372E29725B0059C2A6 /* FirstPageHidden.json in Resources */,
 				E2C8BD2B2E462A8800B93B9E /* AllFieldTitleDispalayed.json in Resources */,
 				BA23533A2FA1DFEF002D9345 /* PageDeletableCopyable.json in Resources */,
+				BA2353C22FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */,
 				36A5EF382E29725B0059C2A6 /* 3000-fields.json in Resources */,
 				E29FF8692F215C9C0079A614 /* Navigation.json in Resources */,
 				36A5EF392E29725B0059C2A6 /* ErrorHandling.json in Resources */,
@@ -1879,6 +1887,7 @@
 			files = (
 				BA2352F32F99E9FE002D9346 /* Decorator.json in Resources */,
 				BA23533B2FA1DFEF002D9345 /* PageDeletableCopyable.json in Resources */,
+				BA2353C32FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */,
 				E274CB532E2EA8ED00B35C09 /* ConditionalLogic_FormulaTemplate.json in Resources */,
 				369D451E2E0E51AC00677280 /* FormulaTemplate_TextField.json in Resources */,
 				362746572E24F0D0005B0FA7 /* FormulaTemplate_EqualityOperator.json in Resources */,
@@ -2021,6 +2030,7 @@
 				E274CA312E2E60A000B35C09 /* OnChangeHandlerUITests.swift in Sources */,
 				E274CA382E2E60A100B35C09 /* FocusCallbackUITests.swift in Sources */,
 				BA2353392FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift in Sources */,
+				BA2353C12FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift in Sources */,
 				E2F568A22E2A4724005216A6 /* TextFieldUITestCases.swift in Sources */,
 				E2F568BE2E2A47A1005216A6 /* SingleChoiceFieldUITestCases.swift in Sources */,
 				E2F568B92E2A4792005216A6 /* NumberFieldUITestCases.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileView.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileView.json
@@ -1,0 +1,236 @@
+{
+  "_id": "69fda955b580cf6fab953a4e",
+  "type": "template",
+  "stage": "published",
+  "identifier": "doc_pdc_mobile_001",
+  "name": "PDC Mobile",
+  "createdOn": 1758527982824,
+  "files": [
+    {
+      "_id": "file_pdc_mobile_001",
+      "metadata": {},
+      "name": "",
+      "version": 1,
+      "pages": [
+        {
+          "_id": "page_pdc_mobile_001",
+          "name": "Web Only Page",
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ],
+          "fieldPositions": [],
+          "metadata": {},
+          "hidden": false,
+          "width": 816,
+          "height": 1056,
+          "cols": 8,
+          "rowHeight": 8,
+          "layout": "grid",
+          "presentation": "normal",
+          "margin": 0,
+          "padding": 24,
+          "borderWidth": 0
+        }
+      ],
+      "pageOrder": [
+        "page_pdc_mobile_001"
+      ],
+      "views": [
+        {
+          "_id": "view_pdc_mobile_001",
+          "type": "mobile",
+          "pages": [
+            {
+              "_id": "page_pdc_mobile_001",
+              "name": "Mobile View Page",
+              "fieldPositions": [
+                {
+                  "_id": "69fda9611467c1db59e4d3e9",
+                  "type": "block",
+                  "displayType": "original",
+                  "fontSize": 28,
+                  "fontWeight": "bold",
+                  "x": 0,
+                  "y": 0,
+                  "width": 3,
+                  "height": 4,
+                  "field": "69fda96121a7adca05d300ed"
+                },
+                {
+                  "_id": "69fda96d0c839f53f00e39fc",
+                  "type": "text",
+                  "displayType": "original",
+                  "x": 0,
+                  "y": 4,
+                  "width": 4,
+                  "height": 9,
+                  "field": "69fda96d180c2668269fa855"
+                },
+                {
+                  "_id": "69fda977525cf2212e2bc466",
+                  "type": "number",
+                  "displayType": "original",
+                  "x": 0,
+                  "y": 13,
+                  "width": 4,
+                  "height": 8,
+                  "field": "69fda9770d8a0f4198bcdd6b"
+                },
+                {
+                  "_id": "69fda97ce247af94be7fac7c",
+                  "type": "date",
+                  "displayType": "original",
+                  "format": "MM/DD/YYYY hh:mma",
+                  "x": 0,
+                  "y": 21,
+                  "width": 4,
+                  "height": 7,
+                  "field": "69fda97c01d09f836499f4d0"
+                },
+                {
+                  "_id": "69fda9833003b431d0ee26b0",
+                  "type": "table",
+                  "displayType": "original",
+                  "x": 0,
+                  "y": 28,
+                  "width": 4,
+                  "height": 15,
+                  "field": "69fda9839f94ae3df377125b"
+                }
+              ],
+              "metadata": {},
+              "hidden": false,
+              "width": 375,
+              "height": 667,
+              "cols": 4,
+              "rowHeight": 8,
+              "layout": "grid",
+              "presentation": "normal",
+              "margin": 0,
+              "padding": 16,
+              "borderWidth": 0
+            }
+          ],
+          "pageOrder": [
+            "page_pdc_mobile_001"
+          ]
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "file": "file_pdc_mobile_001",
+      "_id": "69fda96121a7adca05d300ed",
+      "type": "block",
+      "title": "Heading Text",
+      "value": "Mobile View",
+      "identifier": "field_69fda96121a7adca05d300ed"
+    },
+    {
+      "file": "file_pdc_mobile_001",
+      "_id": "69fda96d180c2668269fa855",
+      "type": "text",
+      "title": "Text",
+      "identifier": "field_69fda96d180c2668269fa855",
+      "value": "Mobile View"
+    },
+    {
+      "file": "file_pdc_mobile_001",
+      "_id": "69fda9770d8a0f4198bcdd6b",
+      "type": "number",
+      "title": "Number",
+      "identifier": "field_69fda9770d8a0f4198bcdd6b",
+      "value": 999999
+    },
+    {
+      "file": "file_pdc_mobile_001",
+      "_id": "69fda97c01d09f836499f4d0",
+      "type": "date",
+      "title": "Date Time",
+      "identifier": "field_69fda97c01d09f836499f4d0",
+      "value": 1778231739198,
+      "tz": "Asia/Calcutta"
+    },
+    {
+      "file": "file_pdc_mobile_001",
+      "_id": "69fda9839f94ae3df377125b",
+      "type": "table",
+      "title": "Table",
+      "tableColumns": [
+        {
+          "_id": "69fd9b33f281c145236324f4",
+          "type": "text",
+          "title": "Text Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "69fda9839f94ae3df377125b_column_69fd9b33f281c145236324f4"
+        },
+        {
+          "_id": "69fd9b33b274a8e580fbc89f",
+          "type": "dropdown",
+          "title": "Dropdown Column",
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "69fd9b330d0e14af562203f6",
+              "value": "Yes",
+              "deleted": false
+            },
+            {
+              "_id": "69fd9b338ec7e34ced2a9ae3",
+              "value": "No",
+              "deleted": false
+            },
+            {
+              "_id": "69fd9b33a67afdc2c212156d",
+              "value": "N/A",
+              "deleted": false
+            }
+          ],
+          "identifier": "69fda9839f94ae3df377125b_column_69fd9b33b274a8e580fbc89f"
+        },
+        {
+          "_id": "69fd9b33b147eebab75f60ca",
+          "type": "text",
+          "title": "Text Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "69fda9839f94ae3df377125b_column_69fd9b33b147eebab75f60ca"
+        }
+      ],
+      "value": [
+        {
+          "_id": "69fd9b33dc3bdf3f95044b0c",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "69fd9b33d0a316b6dd9c194e",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "69fd9b33c1b3075e999de97e",
+          "deleted": false,
+          "cells": {}
+        }
+      ],
+      "identifier": "field_69fda9839f94ae3df377125b",
+      "tableColumnOrder": [
+        "69fd9b33f281c145236324f4",
+        "69fd9b33b274a8e580fbc89f",
+        "69fd9b33b147eebab75f60ca"
+      ],
+      "rowOrder": [
+        "69fd9b33dc3bdf3f95044b0c",
+        "69fd9b33d0a316b6dd9c194e",
+        "69fd9b33c1b3075e999de97e"
+      ]
+    }
+  ],
+  "deleted": false
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileView.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileView.json
@@ -45,6 +45,10 @@
             {
               "_id": "page_pdc_mobile_001",
               "name": "Mobile View Page",
+              "deletable": false,
+              "copyable": [
+                "with-values"
+              ],
               "fieldPositions": [
                 {
                   "_id": "69fda9611467c1db59e4d3e9",

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
@@ -23,46 +23,61 @@ final class PageDeletableCopyableMobileViewUITests: JoyfillUITestsBaseClass {
         pageNavigationButton.tap()
     }
 
-    private func mobileViewPageRowOrFail(file: StaticString = #filePath, line: UInt = #line) -> XCUIElement? {
+    /// Returns the mobile-view page row and its index within the current page-row query.
+    /// The fixture's mobile-view page is intentionally restrictive (deletable=false,
+    /// copyable=[with-values]) so the duplicate-reset behavior under test is observable.
+    private func mobileViewPageRowOrFail(file: StaticString = #filePath, line: UInt = #line) -> (row: XCUIElement, index: Int)? {
         let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
         XCTAssertTrue(pageRows.firstMatch.waitForExistence(timeout: 8), "Page rows should appear in the sheet.", file: file, line: line)
 
-        let row = pageRows.allElementsBoundByIndex.first { row in
-            row.label.contains("Mobile View Page") || row.staticTexts["Mobile View Page"].exists
+        let rows = pageRows.allElementsBoundByIndex
+        guard let idx = rows.firstIndex(where: { $0.label.contains("Mobile View Page") || $0.staticTexts["Mobile View Page"].exists }) else {
+            XCTFail("Mobile-view page row should be visible — confirms mobile view is active.", file: file, line: line)
+            return nil
         }
-        XCTAssertNotNil(row, "Mobile-view page row should be visible — confirms mobile view is active.", file: file, line: line)
-        return row
+        return (rows[idx], idx)
     }
 
-    /// Confirms that after duplicating the mobile-view page, the new page is rendered
-    /// with the spec defaults: `deletable=true` (delete button visible) and
-    /// `copyable=[withValues, withoutValues]` (duplicate dialog offers both modes).
+    /// Confirms that after duplicating the mobile-view page, the new page is rendered with
+    /// the spec defaults (NO-2131): `deletable=true` (delete button visible) and
+    /// `copyable=[withValues, withoutValues]` (duplicate dialog offers both modes) —
+    /// EVEN WHEN the source page is restrictive. Also asserts the source page's restrictions
+    /// are preserved (i.e. the reset doesn't mutate the source in place).
     func testDuplicateInMobileViewProducesPageWithDeletableAndFullCopyable() {
         openPageNavigationSheet()
-        guard let originalRow = mobileViewPageRowOrFail() else { return }
+        guard let original = mobileViewPageRowOrFail() else { return }
 
         let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
         let initialCount = pageRows.count
 
-        // 1. Tap the copyable (duplicate) icon on the original page.
-        let duplicateButton = originalRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
+        // Source page is restrictive in the fixture: no delete button should be visible on it.
+        let originalDeleteBefore = original.row.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier")
+        XCTAssertEqual(originalDeleteBefore.count, 0,
+                       "Source mobile-view page is restrictive (deletable=false) — no delete button expected before duplication.")
+
+        // 1. Tap the copyable (duplicate) icon on the original page. Because the source's
+        //    copyable contains only with-values, this triggers a direct duplicate (no dialog).
+        let duplicateButton = original.row.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
         XCTAssertTrue(duplicateButton.exists, "Duplicate button must exist on the mobile-view page.")
         duplicateButton.tap()
 
         XCTAssertTrue(waitUntil(5) { pageRows.count == initialCount + 1 },
                       "Page count should increase by 1 after duplication.")
 
-        // 2. Locate the duplicated row (inserted right after the original).
-        let duplicatedRow = pageRows.element(boundBy: initialCount)
-        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear after the original.")
+        // 2. Locate the duplicated row. The implementation inserts it at originalIdx + 1
+        //    (not necessarily at the end of the list), so address it by that index.
+        let duplicatedRow = pageRows.element(boundBy: original.index + 1)
+        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear right after the original.")
 
-        // 3. Duplicated page must be deletable — delete control is present.
+        // 3. Duplicated page must be deletable — delete control is present. If the alt-page
+        //    reset is removed, the duplicate would inherit deletable=false and this fails.
         let dupDelete = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier")
         XCTAssertGreaterThan(dupDelete.count, 0,
                              "Duplicated page must show delete button (deletable reset to true).")
 
         // 4. Duplicated page's copyable must include both with-values AND without-values.
-        //    Tap its duplicate button and assert the dialog presents both options.
+        //    If the reset is removed, the duplicate would inherit copyable=[with-values] only
+        //    and tapping duplicate would skip the dialog entirely — failing the wait below.
         let dupDuplicate = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
         XCTAssertTrue(dupDuplicate.exists,
                       "Duplicated page must show duplicate button (copyable reset).")
@@ -70,35 +85,45 @@ final class PageDeletableCopyableMobileViewUITests: JoyfillUITestsBaseClass {
 
         let alert = app.alerts.firstMatch
         XCTAssertTrue(alert.waitForExistence(timeout: 3), "Duplicate dialog should appear on the duplicated page.")
+        // Label-based matching is fine here: the project is not localized. If localization
+        // is introduced, switch these to accessibility identifiers on the alert buttons.
         let hasWithValues = alert.buttons["With Values"].exists || app.buttons["With Values"].exists
         let hasWithoutValues = alert.buttons["Without Values"].exists || app.buttons["Without Values"].exists
         XCTAssertTrue(hasWithValues, "Duplicated page's copyable must include with-values.")
         XCTAssertTrue(hasWithoutValues, "Duplicated page's copyable must include without-values.")
 
         if alert.buttons["Cancel"].exists { alert.buttons["Cancel"].tap() }
+
+        // 5. Inverse assertion: the source page must NOT have been mutated in place by the
+        //    duplicate flow. Its delete button should still be hidden (deletable=false).
+        let originalRowAfter = pageRows.element(boundBy: original.index)
+        let originalDeleteAfter = originalRowAfter.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier")
+        XCTAssertEqual(originalDeleteAfter.count, 0,
+                       "Source page's deletable=false must be preserved after duplication.")
     }
 
     /// Duplicates the mobile-view page, then taps delete on the duplicate and confirms
-    /// the page is removed.
+    /// the page is removed. Exercises the deletable reset: without it, the duplicate
+    /// would inherit deletable=false from the (restrictive) source and have no delete button.
     func testDeleteDuplicatedPageInMobileViewRemovesIt() {
         openPageNavigationSheet()
-        guard let originalRow = mobileViewPageRowOrFail() else { return }
+        guard let original = mobileViewPageRowOrFail() else { return }
 
         let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
         let initialCount = pageRows.count
 
-        let duplicateButton = originalRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
+        let duplicateButton = original.row.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
         XCTAssertTrue(duplicateButton.exists, "Duplicate button must exist on the mobile-view page.")
         duplicateButton.tap()
 
         XCTAssertTrue(waitUntil(5) { pageRows.count == initialCount + 1 },
                       "Page count should increase by 1 after duplication.")
 
-        let duplicatedRow = pageRows.element(boundBy: initialCount)
-        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear after the original.")
+        let duplicatedRow = pageRows.element(boundBy: original.index + 1)
+        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear right after the original.")
 
         let deleteButton = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier").firstMatch
-        XCTAssertTrue(deleteButton.exists, "Delete button must be visible on the duplicated row.")
+        XCTAssertTrue(deleteButton.exists, "Delete button must be visible on the duplicated row (deletable reset to true).")
         deleteButton.tap()
 
         let confirmDelete = app.alerts.buttons["Delete"]

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
@@ -74,6 +74,8 @@ final class PageDeletableCopyableMobileViewUITests: JoyfillUITestsBaseClass {
         let hasWithoutValues = alert.buttons["Without Values"].exists || app.buttons["Without Values"].exists
         XCTAssertTrue(hasWithValues, "Duplicated page's copyable must include with-values.")
         XCTAssertTrue(hasWithoutValues, "Duplicated page's copyable must include without-values.")
+
+        if alert.buttons["Cancel"].exists { alert.buttons["Cancel"].tap() }
     }
 
     /// Duplicates the mobile-view page, then taps delete on the duplicate and confirms

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
@@ -1,0 +1,121 @@
+//
+//  PageDeletableCopyableMobileViewUITests.swift
+//  JoyfillExample
+//
+
+import XCTest
+
+final class PageDeletableCopyableMobileViewUITests: JoyfillUITestsBaseClass {
+    override func getJSONFileNameForTest() -> String {
+        return "PageDeletableCopyableMobileView"
+    }
+
+    override func getGotoLaunchArguments() -> [(String, String?)] {
+        return [
+            ("--page-delete-enabled", "true"),
+            ("--page-duplicate-enabled", "true"),
+        ]
+    }
+
+    private func openPageNavigationSheet() {
+        let pageNavigationButton = app.buttons["PageNavigationIdentifier"]
+        XCTAssertTrue(pageNavigationButton.waitForExistence(timeout: 5), "Page navigation button should exist.")
+        pageNavigationButton.tap()
+    }
+
+    private func mobileViewPageRowOrFail(file: StaticString = #filePath, line: UInt = #line) -> XCUIElement? {
+        let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        XCTAssertTrue(pageRows.firstMatch.waitForExistence(timeout: 8), "Page rows should appear in the sheet.", file: file, line: line)
+
+        let row = pageRows.allElementsBoundByIndex.first { row in
+            row.label.contains("Mobile View Page") || row.staticTexts["Mobile View Page"].exists
+        }
+        XCTAssertNotNil(row, "Mobile-view page row should be visible — confirms mobile view is active.", file: file, line: line)
+        return row
+    }
+
+    private func tapDuplicateMode(_ title: String, file: StaticString = #filePath, line: UInt = #line) {
+        let alert = app.alerts.firstMatch
+        XCTAssertTrue(alert.waitForExistence(timeout: 3), "Duplicate mode dialog should appear.", file: file, line: line)
+        if alert.buttons[title].exists {
+            alert.buttons[title].tap()
+        } else if app.buttons[title].exists {
+            app.buttons[title].tap()
+        } else {
+            XCTFail("Could not find duplicate mode button '\(title)'.", file: file, line: line)
+        }
+    }
+
+    /// Confirms that after duplicating the mobile-view page, the new page is rendered
+    /// with the spec defaults: `deletable=true` (delete button visible) and
+    /// `copyable=[withValues, withoutValues]` (duplicate dialog offers both modes).
+    func testDuplicateInMobileViewProducesPageWithDeletableAndFullCopyable() {
+        openPageNavigationSheet()
+        guard let originalRow = mobileViewPageRowOrFail() else { return }
+
+        let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        let initialCount = pageRows.count
+
+        // 1. Tap the copyable (duplicate) icon on the original page.
+        let duplicateButton = originalRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
+        XCTAssertTrue(duplicateButton.exists, "Duplicate button must exist on the mobile-view page.")
+        duplicateButton.tap()
+
+        XCTAssertTrue(waitUntil(5) { pageRows.count == initialCount + 1 },
+                      "Page count should increase by 1 after duplication.")
+
+        // 2. Locate the duplicated row (inserted right after the original).
+        let duplicatedRow = pageRows.element(boundBy: initialCount)
+        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear after the original.")
+
+        // 3. Duplicated page must be deletable — delete control is present.
+        let dupDelete = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier")
+        XCTAssertGreaterThan(dupDelete.count, 0,
+                             "Duplicated page must show delete button (deletable reset to true).")
+
+        // 4. Duplicated page's copyable must include both with-values AND without-values.
+        //    Tap its duplicate button and assert the dialog presents both options.
+        let dupDuplicate = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
+        XCTAssertTrue(dupDuplicate.exists,
+                      "Duplicated page must show duplicate button (copyable reset).")
+        dupDuplicate.tap()
+
+        let alert = app.alerts.firstMatch
+        XCTAssertTrue(alert.waitForExistence(timeout: 3), "Duplicate dialog should appear on the duplicated page.")
+        let hasWithValues = alert.buttons["With Values"].exists || app.buttons["With Values"].exists
+        let hasWithoutValues = alert.buttons["Without Values"].exists || app.buttons["Without Values"].exists
+        XCTAssertTrue(hasWithValues, "Duplicated page's copyable must include with-values.")
+        XCTAssertTrue(hasWithoutValues, "Duplicated page's copyable must include without-values.")
+    }
+
+    /// Duplicates the mobile-view page, then taps delete on the duplicate and confirms
+    /// the page is removed.
+    func testDeleteDuplicatedPageInMobileViewRemovesIt() {
+        openPageNavigationSheet()
+        guard let originalRow = mobileViewPageRowOrFail() else { return }
+
+        let pageRows = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        let initialCount = pageRows.count
+
+        let duplicateButton = originalRow.descendants(matching: .button).matching(identifier: "PageDuplicateIdentifier").firstMatch
+        XCTAssertTrue(duplicateButton.exists, "Duplicate button must exist on the mobile-view page.")
+        duplicateButton.tap()
+
+        XCTAssertTrue(waitUntil(5) { pageRows.count == initialCount + 1 },
+                      "Page count should increase by 1 after duplication.")
+
+        let duplicatedRow = pageRows.element(boundBy: initialCount)
+        XCTAssertTrue(duplicatedRow.waitForExistence(timeout: 3), "Duplicated row should appear after the original.")
+
+        let deleteButton = duplicatedRow.descendants(matching: .button).matching(identifier: "PageDeleteIdentifier").firstMatch
+        XCTAssertTrue(deleteButton.exists, "Delete button must be visible on the duplicated row.")
+        deleteButton.tap()
+
+        let confirmDelete = app.alerts.buttons["Delete"]
+        XCTAssertTrue(confirmDelete.waitForExistence(timeout: 3), "Delete confirmation dialog should appear.")
+        confirmDelete.tap()
+
+        XCTAssertTrue(waitUntil(5) { pageRows.count == initialCount },
+                      "Page count should return to \(initialCount) after deleting the duplicate.")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift
@@ -34,18 +34,6 @@ final class PageDeletableCopyableMobileViewUITests: JoyfillUITestsBaseClass {
         return row
     }
 
-    private func tapDuplicateMode(_ title: String, file: StaticString = #filePath, line: UInt = #line) {
-        let alert = app.alerts.firstMatch
-        XCTAssertTrue(alert.waitForExistence(timeout: 3), "Duplicate mode dialog should appear.", file: file, line: line)
-        if alert.buttons[title].exists {
-            alert.buttons[title].tap()
-        } else if app.buttons[title].exists {
-            app.buttons[title].tap()
-        } else {
-            XCTFail("Could not find duplicate mode button '\(title)'.", file: file, line: line)
-        }
-    }
-
     /// Confirms that after duplicating the mobile-view page, the new page is rendered
     /// with the spec defaults: `deletable=true` (delete button visible) and
     /// `copyable=[withValues, withoutValues]` (duplicate dialog offers both modes).

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -1062,6 +1062,8 @@ extension DocumentEditor {
                 var originalAltPage = altView.pages![originalAlternatePageIndex]
                 let originalAltPageID = originalAltPage.id
                 originalAltPage.id = duplicatedPage.id
+                originalAltPage.deletable = true
+                originalAltPage.copyable = [.withValues, .withoutValues]
                 
                 var alternateFieldMapping: [String: String] = [:]
                 var alternateNewFields: [JoyDocField] = []


### PR DESCRIPTION
## Context / Spec
This PR addresses `NO-2131` by aligning duplicated **mobile-view** pages with expected default controls after duplication. In mobile view, a duplicated page should remain manageable and re-duplicable with both duplicate modes available.

## What Changed (Files / Code)
- `Sources/JoyfillUI/ViewModels/DocumentEditor.swift`
  - In `duplicatePage(...)`, when duplicating an alternate (mobile) page, the duplicated alternate page is now explicitly reset to:
    - `deletable = true`
    - `copyable = [.withValues, .withoutValues]`
- `JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileViewUITests.swift`
  - Added UI coverage for mobile-view duplication behavior and post-duplication delete behavior.
- `JoyfillSwiftUIExample/JoyfillUITests/PageDeletableCopyable/PageDeletableCopyableMobileView.json`
  - Added dedicated fixture used by mobile-view UI tests.
- `JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj`
  - Registered the new fixture and new UI test file in the test target/resources.

## Key Implementation Decision
We reset `deletable` and `copyable` on the duplicated alternate page at duplication time rather than inheriting potentially restrictive source values. This guarantees duplicated mobile-view pages have predictable, spec-aligned controls regardless of original-page state.

## Screenshot / Video
No screenshot/video attached for this PR since the change is primarily behavior + automated UI test coverage in the page navigation sheet. Happy to attach a short recording if reviewers want visual confirmation.

## Public API / Docs Impact
- Public API changes: **None**
- Documentation updates needed: **No**

## Test Coverage
- Added UI tests:
  - `testDuplicateInMobileViewProducesPageWithDeletableAndFullCopyable`
  - `testDeleteDuplicatedPageInMobileViewRemovesIt`
- Coverage note: This PR covers the mobile-view duplicate/delete flows described above.

## Reviewer Notes
- Focus review on `duplicatePage(...)` alternate-page behavior in `DocumentEditor` and the new mobile-view UI test expectations.
- Change is intentionally small and scoped to `NO-2131` behavior.
