### PR TITLE
NO-2140 Include deleted row data in rowDelete change logs

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
@@ -1103,6 +1103,72 @@ extension DocumentEditorChangeHandlerTests {
         }
     }
 
+    // Duplicate rowIDs in the input must produce a single rowDelete event (the second occurrence
+    // can't find the already-removed row and is filtered out before emit).
+    func testBulkDeleteNestedCollectionItemsWithDuplicateRowIDs() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"
+        let nestedKey = "67ddc5c9910a394a1324bfbe"
+        let duplicatedRowID = "67ddd18bc3a74e6b350987f9"
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        _ = documentEditor.deleteNestedRows(rowIDs: [duplicatedRowID, duplicatedRowID],
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        let deleteEvents = captured.filter { $0.target == "field.value.rowDelete" }
+        XCTAssertEqual(deleteEvents.count, 1, "Duplicate rowIDs must collapse into a single rowDelete event")
+        XCTAssertEqual(deleteEvents.first?.change?["rowId"] as? String, duplicatedRowID)
+    }
+
+    // The embedded row payload in a nested rowDelete change must carry "deleted": true,
+    // matching the top-level deleteRows path. The snapshot is mutated via setDeleted() on the
+    // removed copy in deleteNestedRows; the underlying data is untouched (already removed).
+    func testDeleteNestedCollectionItemPayloadMarksDeletedTrue() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"
+        let nestedKey = "67ddc5c9910a394a1324bfbe"
+        let rowToDelete = "67ddd18bc3a74e6b350987f9"
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        _ = documentEditor.deleteNestedRows(rowIDs: [rowToDelete],
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        let deleteEvents = captured.filter { $0.target == "field.value.rowDelete" }
+        XCTAssertEqual(deleteEvents.count, 1)
+        let row = deleteEvents.first?.change?["row"] as? [String: Any]
+        XCTAssertEqual(row?["deleted"] as? Bool, true, "Embedded row payload must record deleted: true")
+    }
+
     // Deleting an L1 row that owns L2 grandchildren must surface the full subtree in the
     // rowDelete change-log payload. The previous test only covers leaf deletion.
     func testDeleteNestedCollectionItemPayloadIncludesSubtree() {

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
@@ -981,7 +981,58 @@ extension DocumentEditorChangeHandlerTests {
         
         XCTAssertEqual(updatedNestedRows.filter { !($0.deleted ?? false) }.count, initialNestedRows.count - 1)
     }
-    
+
+    // Deleting an L1 row that owns L2 grandchildren must surface the full subtree in the
+    // rowDelete change-log payload. The previous test only covers leaf deletion.
+    func testDeleteNestedCollectionItemPayloadIncludesSubtree() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"          // root row owning the L1 schema
+        let nestedKey = "67ddc5c9910a394a1324bfbe"            // L1 schema key
+        let rowToDelete = "67ddd191ab6a428ea69c77ad"          // L1 row with three L2 grandchildren
+        let grandchildSchemaKey = "67ddc5f5c2477e8457956fb4"  // L2 schema key under the deleted row
+        let expectedGrandchildIDs: Set<String> = [
+            "67ddd1a5e6d0d62d55a7aaad",
+            "67ddd1a656a259a9b6ab1263",
+            "67ddd1a779642224075bf23c"
+        ]
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        _ = documentEditor.deleteNestedRows(rowIDs: [rowToDelete],
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        let deleteEvents = captured.filter { $0.target == "field.value.rowDelete" }
+        XCTAssertEqual(deleteEvents.count, 1, "Expected exactly one rowDelete change")
+
+        guard let change = deleteEvents.first?.change,
+              let row = change["row"] as? [String: Any] else {
+            return XCTFail("Missing row payload in rowDelete change")
+        }
+        XCTAssertEqual(row["_id"] as? String, rowToDelete)
+
+        guard let children = row["children"] as? [String: Any],
+              let nestedSchema = children[grandchildSchemaKey] as? [String: Any],
+              let grandchildren = nestedSchema["value"] as? [[String: Any]] else {
+            return XCTFail("Deleted row payload should embed the L2 subtree under children[\(grandchildSchemaKey)].value")
+        }
+        let ids = Set(grandchildren.compactMap { $0["_id"] as? String })
+        XCTAssertEqual(ids, expectedGrandchildIDs, "All L2 grandchildren must appear in the embedded subtree")
+    }
+
     func testDuplicateNestedCollectionItem() {
         let collectionFieldID = "67ddc52d35de157f6d7ebb63"
         let parentRowId = "67ddc537b7c2fce05d0c8615"
@@ -1781,4 +1832,19 @@ extension DocumentEditorChangeHandlerTests {
         
         XCTAssertEqual(isVisible, false)
     }
+}
+
+private final class CaptureChangeHandler: FormChangeEvent {
+    private let onChanges: ([Change], JoyDoc) -> Void
+
+    init(_ onChange: @escaping ([Change], JoyDoc) -> Void) {
+        self.onChanges = onChange
+    }
+
+    func onChange(changes: [Change], document: JoyDoc) { onChanges(changes, document) }
+    func onFocus(event: Joyfill.Event) {}
+    func onBlur(event: Joyfill.Event) {}
+    func onUpload(event: UploadEvent) {}
+    func onCapture(event: CaptureEvent) {}
+    func onError(error: JoyfillError) {}
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerTests.swift
@@ -981,6 +981,127 @@ extension DocumentEditorChangeHandlerTests {
         
         XCTAssertEqual(updatedNestedRows.filter { !($0.deleted ?? false) }.count, initialNestedRows.count - 1)
     }
+    
+    // Deleting only a non-existent rowID must leave the document untouched and emit no rowDelete event.
+    func testDeleteNonExistingRowNestedCollectionItem() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"
+        let nestedKey = "67ddc5c9910a394a1324bfbe"
+        let nonExistingRowID = "non-existing-row-id"
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        let initialElements = documentEditor.field(fieldID: collectionFieldID)?.valueToValueElements
+
+        _ = documentEditor.deleteNestedRows(rowIDs: [nonExistingRowID],
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        XCTAssertEqual(documentEditor.field(fieldID: collectionFieldID)?.valueToValueElements, initialElements,
+                       "Field elements must be untouched when rowID doesn't exist")
+        XCTAssertEqual(events.onChangeCallCount, 0,
+                       "onChange must not fire at all when the rowID doesn't exist")
+        XCTAssertTrue(captured.isEmpty)
+    }
+
+    // Bulk delete with a mix of existing and non-existing rowIDs: only the existing ones get a rowDelete event,
+    // and the document only loses the existing ones.
+    func testBulkDeleteNestedCollectionItemsWithOneNonExistingRowID() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"
+        let nestedKey = "67ddc5c9910a394a1324bfbe"
+        let existingRowID = "67ddd18bc3a74e6b350987f9"
+        let nonExistingRowID = "non-existing-row-id"
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        _ = documentEditor.deleteNestedRows(rowIDs: [existingRowID, nonExistingRowID],
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        // Only the existing row gets removed from the tree.
+        let nestedRows = documentEditor.field(fieldID: collectionFieldID)?.valueToValueElements?
+            .first(where: { $0.id == parentRowId })?.childrens?[nestedKey]?.valueToValueElements ?? []
+        XCTAssertNil(nestedRows.first(where: { $0.id == existingRowID }),
+                     "Existing row should be removed from the nested children")
+
+        // Exactly one rowDelete event fires, for the existing row only.
+        let deleteEvents = captured.filter { $0.target == "field.value.rowDelete" }
+        XCTAssertEqual(deleteEvents.count, 1, "Only one rowDelete event should fire (for the existing row)")
+        XCTAssertEqual(deleteEvents.first?.change?["rowId"] as? String, existingRowID)
+        XCTAssertFalse((deleteEvents.first?.change?["row"] as? [String: Any])?.isEmpty ?? true,
+                       "Embedded row payload must be non-empty for the existing row")
+    }
+
+    // Bulk delete with all rowIDs valid: one rowDelete event per row, each with its own payload.
+    func testBulkDeleteNestedCollectionItemsAllExisting() {
+        let collectionFieldID = "67ddc52d35de157f6d7ebb63"
+        let parentRowId = "67ddc537b7c2fce05d0c8615"
+        let nestedKey = "67ddc5c9910a394a1324bfbe"
+        let rowIDs = ["67ddd18bc3a74e6b350987f9", "67ddd193eae737b64c24851a"]
+
+        let document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setMobileView()
+            .setPageFieldInMobileView()
+            .setPageField()
+            .setCollectionField()
+            .setCollectionFieldPosition()
+
+        var captured: [Change] = []
+        let events = CaptureChangeHandler { changes, _ in captured.append(contentsOf: changes) }
+        let documentEditor = DocumentEditor(document: document, events: events, validateSchema: false)
+
+        _ = documentEditor.deleteNestedRows(rowIDs: rowIDs,
+                                            fieldIdentifier: FieldIdentifier(fieldID: collectionFieldID, pageID: pageID, fileID: fileID),
+                                            rootSchemaKey: collectionFieldID,
+                                            nestedKey: nestedKey,
+                                            parentRowId: parentRowId)
+
+        // Both rows are gone from the tree.
+        let nestedRows = documentEditor.field(fieldID: collectionFieldID)?.valueToValueElements?
+            .first(where: { $0.id == parentRowId })?.childrens?[nestedKey]?.valueToValueElements ?? []
+        for id in rowIDs {
+            XCTAssertNil(nestedRows.first(where: { $0.id == id }), "Row \(id) should be removed")
+        }
+
+        // One rowDelete event per row, in input order, each with a non-empty payload.
+        let deleteEvents = captured.filter { $0.target == "field.value.rowDelete" }
+        XCTAssertEqual(deleteEvents.count, rowIDs.count, "One rowDelete event per deleted row")
+        XCTAssertEqual(deleteEvents.compactMap { $0.change?["rowId"] as? String }, rowIDs,
+                       "Events should be emitted in the same order as the input rowIDs")
+        for event in deleteEvents {
+            XCTAssertFalse((event.change?["row"] as? [String: Any])?.isEmpty ?? true,
+                           "Embedded row payload must be non-empty for each deleted row")
+        }
+    }
 
     // Deleting an L1 row that owns L2 grandchildren must surface the full subtree in the
     // rowDelete change-log payload. The previous test only covers leaf deletion.
@@ -1836,12 +1957,16 @@ extension DocumentEditorChangeHandlerTests {
 
 private final class CaptureChangeHandler: FormChangeEvent {
     private let onChanges: ([Change], JoyDoc) -> Void
+    private(set) var onChangeCallCount = 0
 
     init(_ onChange: @escaping ([Change], JoyDoc) -> Void) {
         self.onChanges = onChange
     }
 
-    func onChange(changes: [Change], document: JoyDoc) { onChanges(changes, document) }
+    func onChange(changes: [Change], document: JoyDoc) {
+        onChangeCallCount += 1
+        onChanges(changes, document)
+    }
     func onFocus(event: Joyfill.Event) {}
     func onBlur(event: Joyfill.Event) {}
     func onUpload(event: UploadEvent) {}

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -3097,6 +3097,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
 
         let expectedDeletedRow: [String: Any] = [
             "_id": "68599790e8593d6d76c3a09f",
+            "deleted": true,
             "cells": [
                 "685753ce949e66c62c746f62": "A",
                 "685753ca9756907c2dd4fdca": 200,

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -3091,6 +3091,26 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         let schemaId = change?["schemaId"] as? String
         XCTAssertEqual("685753be00360cf5d545a89e", schemaId)
         
+        guard let deletedRow = change?["row"] as? [String: Any] else {
+            return XCTFail("Missing deleted row object in changelog")
+        }
+
+        let expectedDeletedRow: [String: Any] = [
+            "_id": "68599790e8593d6d76c3a09f",
+            "cells": [
+                "685753ce949e66c62c746f62": "A",
+                "685753ca9756907c2dd4fdca": 200,
+                "685753cd582979929e70d64e": "A",
+                "685753c1b072d80a56f775b7": "685753c1372bdec00abf169b",
+                "685753be581f231c08d8f11c": "A",
+                "685753c51f0af9f46eacdb40": [
+                    "685753c5265c32e4ff94cfa4"
+                ]
+            ],
+            "children": [:]
+        ]
+        XCTAssertEqual(deletedRow as NSDictionary, expectedDeletedRow as NSDictionary)
+        
     }
     
     func testChangeLogsForAddRow() throws {

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
@@ -1998,7 +1998,7 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
 
         let expectedDeletedRow: [String: Any] = [
             "_id": "66e3eca93796d7435b63ce9d",
-            "deleted": false,
+            "deleted": true,
             "cells": [
                 "66e3eca9c0c6bf8bef669d21": "Boy 3",
                 "66e3eca984ddabde6a6f469d": "66e3eca9e128bcf2e560a76e"

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift
@@ -1991,6 +1991,20 @@ final class TableFieldTests: JoyfillUITestsBaseClass {
             return XCTFail("Missing or invalid 'change' dictionary")
         }
         XCTAssertEqual(change["rowId"] as? String, "66e3eca93796d7435b63ce9d")
+        
+        guard let row = change["row"] as? [String: Any] else {
+            return XCTFail("Missing deleted row object in 'change'")
+        }
+
+        let expectedDeletedRow: [String: Any] = [
+            "_id": "66e3eca93796d7435b63ce9d",
+            "deleted": false,
+            "cells": [
+                "66e3eca9c0c6bf8bef669d21": "Boy 3",
+                "66e3eca984ddabde6a6f469d": "66e3eca9e128bcf2e560a76e"
+            ]
+        ]
+        XCTAssertEqual(row as NSDictionary, expectedDeletedRow as NSDictionary)
     }
     
     func testTableMoveSingleRowAndCheckOnChange() throws {

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -30,6 +30,7 @@ extension DocumentEditor {
         guard var lastRowOrder = field.rowOrder else {
             return elements
         }
+        var deletedRowsByID = [String: [String: Any]]()
 
         for row in rowIDs {
             guard let index = elements.firstIndex(where: { $0.id == row }) else {
@@ -37,14 +38,17 @@ extension DocumentEditor {
                 return elements
             }
             var element = elements[index]
+            if shouldSendEvent {
+                deletedRowsByID[row] = element.anyDictionary
+            }
             element.setDeleted()
             elements[index] = element
             lastRowOrder.removeAll(where: { $0 == row })
         }
         fieldMap[fieldId]?.value = ValueUnion.valueElementArray(elements)
         fieldMap[fieldId]?.rowOrder = lastRowOrder
-        guard shouldSendEvent else { return  elements }
-        onChangeForDelete(fieldIdentifier: fieldIdentifier, rowIDs: rowIDs)
+        guard shouldSendEvent else { return elements }
+        onChangeForDelete(fieldIdentifier: fieldIdentifier, rowIDs: rowIDs, rowsByID: deletedRowsByID)
         return elements
     }
     
@@ -56,40 +60,47 @@ extension DocumentEditor {
         }
         guard var elements = field.valueToValueElements else { return [] }
         guard !rowIDs.isEmpty else { return elements }
+        var deletedRowsByID = [String: [String: Any]]()
         
         for row in rowIDs {
             if let index = elements.firstIndex(where: { $0.id == row }) {
-                elements.remove(at: index)
+                let deletedElement = elements.remove(at: index)
+                if shouldSendEvent {
+                    deletedRowsByID[row] = deletedElement.anyDictionary
+                }
             } else {
-                _ = deleteRowRecursively(rowId: row, in: &elements)
+                if let deletedElement = deleteRowRecursively(rowId: row, in: &elements) {
+                    if shouldSendEvent {
+                        deletedRowsByID[row] = deletedElement.anyDictionary
+                    }
+                }
             }
         }
         fieldMap[fieldId]?.value = ValueUnion.valueElementArray(elements)
         guard shouldSendEvent else { return elements }
         var parentPath = computeParentPath(targetParentId: parentRowId, nestedKey: nestedKey, in: [rootSchemaKey : elements]) ?? ""
-        onChangeForDeleteNestedRow(fieldIdentifier: fieldIdentifier, rowIDs: rowIDs, parentPath: parentPath, schemaId: nestedKey)
+        onChangeForDeleteNestedRow(fieldIdentifier: fieldIdentifier, rowIDs: rowIDs, parentPath: parentPath, schemaId: nestedKey, rowsByID: deletedRowsByID)
         return elements
     }
 
-    private func deleteRowRecursively(rowId: String, in elements: inout [ValueElement]) -> Bool {
+    private func deleteRowRecursively(rowId: String, in elements: inout [ValueElement]) -> ValueElement? {
         for i in 0..<elements.count {
             if elements[i].id == rowId {
-                elements.remove(at: i)
-                return true
+                return elements.remove(at: i)
             }
             if var children = elements[i].childrens {
-                for key in children.keys {
+                for key in Array(children.keys) {
                     if var nestedElements = children[key]?.valueToValueElements {
-                        if deleteRowRecursively(rowId: rowId, in: &nestedElements) {
+                        if let deletedElement = deleteRowRecursively(rowId: rowId, in: &nestedElements) {
                             children[key]?.value = ValueUnion.valueElementArray(nestedElements)
                             elements[i].childrens = children
-                            return true
+                            return deletedElement
                         }
                     }
                 }
             }
         }
-        return false
+        return nil
     }
     
     /// Duplicates specified rows in a table field.
@@ -1316,7 +1327,7 @@ extension DocumentEditor {
         events?.onChange(changes: changes, document: document)
     }
 
-    private func onChangeForDelete(fieldIdentifier: FieldIdentifier, rowIDs: [String]) {
+    private func onChangeForDelete(fieldIdentifier: FieldIdentifier, rowIDs: [String], rowsByID: [String: [String: Any]]) {
         guard let context = makeFieldChangeContext(for: fieldIdentifier) else { return }
         
         let event = FieldChangeData(fieldIdentifier: fieldIdentifier)
@@ -1324,6 +1335,7 @@ extension DocumentEditor {
         var changes = [Change]()
         
         for targetRow in targetRowIndexes {
+            let rowObject = rowsByID[targetRow.id] ?? [:]
             var change = Change(v: 1,
                                 sdk: "swift",
                                 target: "field.value.rowDelete",
@@ -1334,7 +1346,10 @@ extension DocumentEditor {
                                 fieldId: event.fieldIdentifier.fieldID,
                                 fieldIdentifier: context.fieldIdentifier,
                                 fieldPositionId: context.fieldPositionID,
-                                change: ["rowId": targetRow.id],
+                                change: [
+                                    "rowId": targetRow.id,
+                                    "row": rowObject
+                                ],
                                 createdOn: Date().timeIntervalSince1970)
             changes.append(change)
         }
@@ -1342,7 +1357,7 @@ extension DocumentEditor {
 //        refreshField(fieldId: fieldIdentifier.fieldID, fieldIdentifier: fieldIdentifier)
     }
     
-    private func onChangeForDeleteNestedRow(fieldIdentifier: FieldIdentifier, rowIDs: [String], parentPath: String, schemaId: String) {
+    private func onChangeForDeleteNestedRow(fieldIdentifier: FieldIdentifier, rowIDs: [String], parentPath: String, schemaId: String, rowsByID: [String: [String: Any]]) {
         guard let context = makeFieldChangeContext(for: fieldIdentifier) else { return }
         
         let event = FieldChangeData(fieldIdentifier: fieldIdentifier)
@@ -1350,6 +1365,7 @@ extension DocumentEditor {
         var changes = [Change]()
         
         for targetRow in targetRowIndexes {
+            let rowObject = rowsByID[targetRow.id] ?? [:]
             var change = Change(v: 1,
                                 sdk: "swift",
                                 target: "field.value.rowDelete",
@@ -1360,9 +1376,12 @@ extension DocumentEditor {
                                 fieldId: fieldIdentifier.fieldID,
                                 fieldIdentifier: context.fieldIdentifier,
                                 fieldPositionId: context.fieldPositionID,
-                                change: ["parentPath": parentPath,
-                                         "schemaId": schemaId,
-                                         "rowId": targetRow.id],
+                                change: [
+                                    "parentPath": parentPath,
+                                    "schemaId": schemaId,
+                                    "rowId": targetRow.id,
+                                    "row": rowObject
+                                ],
                                 createdOn: Date().timeIntervalSince1970)
             changes.append(change)
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -89,7 +89,7 @@ extension DocumentEditor {
                 return elements.remove(at: i)
             }
             if var children = elements[i].childrens {
-                for key in Array(children.keys) {
+                for key in children.keys {
                     if var nestedElements = children[key]?.valueToValueElements {
                         if let deletedElement = deleteRowRecursively(rowId: rowId, in: &nestedElements) {
                             children[key]?.value = ValueUnion.valueElementArray(nestedElements)

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -61,25 +61,28 @@ extension DocumentEditor {
         guard var elements = field.valueToValueElements else { return [] }
         guard !rowIDs.isEmpty else { return elements }
         var deletedRowsByID = [String: [String: Any]]()
-        
+        var deletedRowIDs = [String]()
+
         for row in rowIDs {
             if let index = elements.firstIndex(where: { $0.id == row }) {
                 let deletedElement = elements.remove(at: index)
                 if shouldSendEvent {
                     deletedRowsByID[row] = deletedElement.anyDictionary
+                    deletedRowIDs.append(row)
                 }
             } else {
                 if let deletedElement = deleteRowRecursively(rowId: row, in: &elements) {
                     if shouldSendEvent {
                         deletedRowsByID[row] = deletedElement.anyDictionary
+                        deletedRowIDs.append(row)
                     }
                 }
             }
         }
         fieldMap[fieldId]?.value = ValueUnion.valueElementArray(elements)
-        guard shouldSendEvent else { return elements }
+        guard shouldSendEvent, !deletedRowIDs.isEmpty else { return elements }
         var parentPath = computeParentPath(targetParentId: parentRowId, nestedKey: nestedKey, in: [rootSchemaKey : elements]) ?? ""
-        onChangeForDeleteNestedRow(fieldIdentifier: fieldIdentifier, rowIDs: rowIDs, parentPath: parentPath, schemaId: nestedKey, rowsByID: deletedRowsByID)
+        onChangeForDeleteNestedRow(fieldIdentifier: fieldIdentifier, rowIDs: deletedRowIDs, parentPath: parentPath, schemaId: nestedKey, rowsByID: deletedRowsByID)
         return elements
     }
 

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -38,10 +38,10 @@ extension DocumentEditor {
                 return elements
             }
             var element = elements[index]
+            element.setDeleted()
             if shouldSendEvent {
                 deletedRowsByID[row] = element.anyDictionary
             }
-            element.setDeleted()
             elements[index] = element
             lastRowOrder.removeAll(where: { $0 == row })
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift
@@ -65,14 +65,16 @@ extension DocumentEditor {
 
         for row in rowIDs {
             if let index = elements.firstIndex(where: { $0.id == row }) {
-                let deletedElement = elements.remove(at: index)
+                var deletedElement = elements.remove(at: index)
                 if shouldSendEvent {
+                    deletedElement.setDeleted()
                     deletedRowsByID[row] = deletedElement.anyDictionary
                     deletedRowIDs.append(row)
                 }
             } else {
-                if let deletedElement = deleteRowRecursively(rowId: row, in: &elements) {
+                if var deletedElement = deleteRowRecursively(rowId: row, in: &elements) {
                     if shouldSendEvent {
+                        deletedElement.setDeleted()
                         deletedRowsByID[row] = deletedElement.anyDictionary
                         deletedRowIDs.append(row)
                     }


### PR DESCRIPTION
## 1. Context / Spec
[NO-2140] When a table/collection row is deleted, the `field.value.rowDelete` change log only carried the `rowId` (and `parentPath`/`schemaId` for nested rows). Consumers replaying or auditing changes had no way to recover the deleted row's actual values. This PR enriches the change log with the full deleted row payload.

## 2. What Changed
- **`Sources/JoyfillUI/ViewModels/DocumentEditor+ChangeHandler.swift`**
  - Top-level delete path (`deleteRow`-style flow): capture each row's `anyDictionary` snapshot into `deletedRowsByID` before `setDeleted()` runs, then pass it through to `onChangeForDelete`.
  - Nested delete path: same snapshotting, but the snapshot is taken at the moment of `elements.remove(at:)` (both direct and recursive removal).
  - `deleteRowRecursively` now returns the removed `ValueElement?` instead of `Bool`, so the caller can attach the snapshot to the change log.
  - `onChangeForDelete` / `onChangeForDeleteNestedRow` accept `rowsByID: [String: [String: Any]]` and embed the snapshot in the `change` dict under a new `"row"` key alongside the existing `"rowId"` / `"parentPath"` / `"schemaId"`.
- **Tests**
  - `JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTests.swift` — asserts the delete changelog now contains the full deleted row properties.
  - `JoyfillSwiftUIExample/JoyfillUITests/CollectionField/CollectionFieldSearchFilterTests.swift` — same verification for the collection/nested case.

## 3. Design Decisions
- **Snapshot at delete-time, not after.** For the top-level path the row is mutated by `setDeleted()`, and for the nested path it's removed from the array — in both cases the original payload is gone by the time `onChangeForDelete*` runs. Capturing `anyDictionary` into a `[String: [String: Any]]` keyed by `rowId` keeps the snapshot intact without holding `ValueElement` references that could be mutated downstream.
- **Recursive function now returns `ValueElement?`.** Returning the removed element is strictly more information than `Bool` and avoids a second tree walk; callers that only cared about success can still treat `nil` as "not found."
- **Iterating `Array(children.keys)`** in `deleteRowRecursively` to avoid mutating-while-iterating the dictionary when a nested write-back happens.
- **Snapshot only when `shouldSendEvent` is true.** No need to allocate dictionaries for silent/internal deletes.
- **Key name `"row"`** in the change payload — matches the singular `"rowId"` already present and reads naturally next to it.

## 4. Screenshots / Video
N/A — change is in the emitted change-log payload, no UI difference.

## 5. Public API Impact
- No public Swift API changed — `onChangeForDelete` / `onChangeForDeleteNestedRow` and `deleteRowRecursively` are all `private`.
- **Change-log schema is extended**: `change` dicts for `target: "field.value.rowDelete"` now include an additional `"row"` key with the deleted row's full dictionary. Existing consumers reading only `rowId` are unaffected, but downstream docs describing the rowDelete payload should be updated to mention the new `"row"` field.

## 6. Test Coverage
- UI tests updated in both `TableFieldTests` and `CollectionFieldSearchFilterTests` to assert the full deleted-row properties are present in the changelog (covers top-level and nested cases).
- No new logic branches beyond snapshot capture; existing delete coverage exercises both `shouldSendEvent` paths.

## 7. Reviewer Notes
- Please double-check the recursive nested case — the snapshot is taken inside `deleteRowRecursively` via the returned `ValueElement?`, so the `childrens` of the deleted row are included in the snapshot (which is intentional, so a deleted parent's subtree is recoverable).
- If the backend/spec expects a different key name than `"row"` for the embedded payload, that's a one-line rename in `onChangeForDelete` / `onChangeForDeleteNestedRow`.