### PR TITLE
NO-2145: Support row form in readonly mode with disabled cells

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/Footer Example/SampleFormFooter.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/Footer Example/SampleFormFooter.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // MARK: - Footer coordinator (validate / navigate + FormChangeEvent)
 
+@MainActor
 final class SampleFormFooterController: ObservableObject, FormChangeEvent {
 
     weak var documentEditor: DocumentEditor?
@@ -57,39 +58,45 @@ final class SampleFormFooterController: ObservableObject, FormChangeEvent {
 
     // MARK: - FormChangeEvent
 
-    func onChange(changes: [Change], document: JoyDoc) {
-        guard let editor = self.documentEditor else { return }
-        
-        let validation = editor.validate()
-        let validities = validation.fieldValidities
-        let total = validities.count
-        let completed = validities.filter { $0.status == .valid }.count
-        
-        self.fieldPaths = Self.buildPaths(from: validities)
-        if self.currentFieldIndex >= self.fieldPaths.count {
-            self.currentFieldIndex = self.fieldPaths.isEmpty ? -1 : self.fieldPaths.count - 1
+    nonisolated func onChange(changes: [Change], document: JoyDoc) {
+        Task { @MainActor in
+            guard let editor = self.documentEditor else { return }
+
+            let validation = editor.validate()
+            let validities = validation.fieldValidities
+            let total = validities.count
+            let completed = validities.filter { $0.status == .valid }.count
+
+            self.fieldPaths = Self.buildPaths(from: validities)
+            if self.currentFieldIndex >= self.fieldPaths.count {
+                self.currentFieldIndex = self.fieldPaths.isEmpty ? -1 : self.fieldPaths.count - 1
+            }
+            self.completedText = "\(completed) of \(total) Completed"
+            self.navigationEnabled = validation.status == .invalid
         }
-        self.completedText = "\(completed) of \(total) Completed"
-        self.navigationEnabled = validation.status == .invalid
     }
 
-    func onFocus(event: Event) {
+    nonisolated func onFocus(event: Event) {
         let focusedPageID = event.pageEvent?.page.id ?? event.fieldEvent?.pageID
-        updateFooterVisibility(for: focusedPageID)
+        Task { @MainActor in
+            self.updateFooterVisibility(for: focusedPageID)
+        }
     }
 
-    func onBlur(event: Event) {
+    nonisolated func onBlur(event: Event) {
         guard let pageEvent = event.pageEvent,
               pageEvent.type == "page.blur",
               let blurredPageID = pageEvent.page.id else { return }
 
-        if blurredPageID == footerPageID {
-            isFooterVisible = false
+        Task { @MainActor in
+            if blurredPageID == self.footerPageID {
+                self.isFooterVisible = false
+            }
         }
     }
-    func onUpload(event: Joyfill.UploadEvent) {}
-    func onCapture(event: Joyfill.CaptureEvent) {}
-    func onError(error: Joyfill.JoyfillError) {}
+    nonisolated func onUpload(event: Joyfill.UploadEvent) {}
+    nonisolated func onCapture(event: Joyfill.CaptureEvent) {}
+    nonisolated func onError(error: Joyfill.JoyfillError) {}
 
     // MARK: - Paths
 

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/Decorator.json
@@ -100,10 +100,20 @@
               "displayType" : "original"
             },
             {
+              "_id" : "6a2b0d11a1b2c3d4e5f60721",
+              "x" : 0,
+              "height" : 8,
+              "y" : 128,
+              "width" : 4,
+              "field" : "6a2b0d11a1b2c3d4e5f60722",
+              "type" : "text",
+              "displayType" : "original"
+            },
+            {
               "_id" : "6970a3eceab9374076e43a0b",
               "x" : 0,
               "height" : 27,
-              "y" : 128,
+              "y" : 136,
               "width" : 8,
               "field" : "6970a3ec734506f1afc2f7ee",
               "type" : "collection",
@@ -613,6 +623,15 @@
       ],
       "file" : "691f3762c80bfb0005c57b48",
       "identifier" : "field_6970a3ec734506f1afc2f7ee"
+    },
+    {
+      "title" : "Between Table And Collection",
+      "identifier" : "field_6a2b0d11a1b2c3d4e5f60722",
+      "value" : "",
+      "type" : "text",
+      "file" : "691f3762c80bfb0005c57b48",
+      "_id" : "6a2b0d11a1b2c3d4e5f60722",
+      "hidden" : false
     },
     {
       "title" : "Number",

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
@@ -878,3 +878,150 @@ final class DecoratorReadonlyAPIUITests: DecoratorAPIUITestsBase {
         S.run(S.removeCommand(path: rootRowsPath, action: action), in: app)
     }
 }
+
+// MARK: - Readonly Row Form: cells disabled, column-header decorators still tappable
+
+final class RowFormReadonlyUITests: DecoratorAPIUITestsBase {
+
+    override func getJSONFileNameForTest() -> String { "Decorator" }
+
+    override func getGotoLaunchArguments() -> [(String, String?)] {
+        return [("--disable-animations", nil), ("--mode", "readonly")]
+    }
+
+    /// Assert every supplied cell exists in the row form and is disabled, then actively
+    /// attempt to tap it and verify nothing interactive fires (no keyboard appears).
+    private func assertCellsNotTappable(_ cells: [(name: String, element: XCUIElement)],
+                                        file: StaticString = #file, line: UInt = #line) {
+        for (name, element) in cells {
+            XCTAssertTrue(element.waitForExistence(timeout: 2),
+                          "\(name) cell should render in readonly row form",
+                          file: file, line: line)
+            XCTAssertFalse(element.isEnabled,
+                           "\(name) cell should be disabled (not tappable) in readonly row form",
+                           file: file, line: line)
+            // Actively probe the disabled cell: tap if it is reachable and confirm the tap
+            // had no interactive effect (no keyboard opens). isHittable guard avoids
+            // coordinate errors when the cell sits below the visible viewport.
+            if element.isHittable { element.tap() }
+            XCTAssertFalse(app.keyboards.element.waitForExistence(timeout: 1),
+                           "Tapping disabled \(name) cell must not show keyboard in readonly row form",
+                           file: file, line: line)
+        }
+    }
+
+    // Table: common cell decorator on the text column appears in every row's edit form.
+    func testTable_CellDecoratorInsideRowFormStaysTappable() {
+        typealias S = DecoratorUITestSupport
+        let action = "ro_table_cell"
+        let commonCellPath = "\(pageID)/\(fpTable)/columns/\(tColText)"
+        let decoratorButton = app.buttons[S.fieldDecoratorID(action: action)]
+
+        S.openTableDetailView(in: app)
+        S.run(S.addCommand(path: commonCellPath,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        // Decorator existence also proves the row form opened.
+        XCTAssertTrue(waitUntil(3) { decoratorButton.exists && decoratorButton.isHittable },
+                      "Cell decorator should be hittable inside readonly row form")
+
+        // Schema (Decorator.json table): text, dropdown, multiSelect, image, number,
+        // date, block, barcode, signature. Block has no editable identifier (omitted).
+        // Barcode uses TableBarcodeView which renders a static Text in readonly —
+        // checked via absence of the editable TextEditor below, like collection text.
+        assertCellsNotTappable([
+            ("text",        app.textFields["EditRowsTextFieldIdentifier"]),
+            ("dropdown",    app.buttons["EditRowsDropdownFieldIdentifier"]),
+            ("multiSelect", app.buttons["EditRowsMultiSelecionFieldIdentifier"]),
+            ("image",       app.buttons["EditRowsImageFieldIdentifier"]),
+            ("number",      app.textFields["EditRowsNumberFieldIdentifier"]),
+            ("date",        app.images["EditRowsDateFieldIdentifier"]),
+            ("signature",   app.buttons["EditRowsSignatureFieldIdentifier"]),
+        ])
+        XCTAssertFalse(app.textViews["EditRowsBarcodeFieldIdentifier"].exists,
+                       "Barcode cell should not be an editable TextEditor in readonly row form")
+        // Decorator tap still fires onFocus despite the parent .disabled wrapper.
+        decoratorButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        }, "Tapping cell decorator in readonly row form should fire onFocus")
+
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Collection root: common cell decorator on the text column appears in every root row's edit form.
+    func testCollection_RootCellDecoratorInsideRowFormStaysTappable() {
+        typealias S = DecoratorUITestSupport
+        let action = "ro_collection_root_cell"
+        let commonRootCellPath = "\(pageID)/\(fpCollection)/columns/\(cColText)"
+        let decoratorButton = app.buttons[S.fieldDecoratorID(action: action)]
+
+        S.openCollectionDetailView(in: app)
+        S.run(S.addCommand(path: commonRootCellPath,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        // Decorator existence also proves the row form opened.
+        XCTAssertTrue(waitUntil(3) { decoratorButton.exists && decoratorButton.isHittable },
+                      "Root cell decorator should be hittable inside readonly row form")
+
+        // Schema (Decorator.json collection root): text, dropdown, image.
+        // Text uses TableTextRowFormView which renders a static Text in readonly —
+        // the editable TextField never gets created, so the absence check is the
+        // appropriate "not tappable" assertion here (helper would fail to find it).
+        XCTAssertFalse(app.textFields["EditRowsTextFieldIdentifier"].exists,
+                       "Text cell should not be an editable TextField in readonly root row form")
+        assertCellsNotTappable([
+            ("dropdown", app.buttons["EditRowsDropdownFieldIdentifier"]),
+            ("image",    app.buttons["EditRowsImageFieldIdentifier"]),
+        ])
+
+        // Decorator tap still fires onFocus despite the parent .disabled wrapper.
+        decoratorButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        }, "Tapping root cell decorator in readonly row form should fire onFocus")
+
+        S.dismissRowEditForm(in: app)
+    }
+
+    // Collection nested L1: specific cell decorator on the multiSelect column under root row 2.
+    func testCollection_NestedL1CellDecoratorStaysTappable() {
+        typealias S = DecoratorUITestSupport
+        let action = "ro_collection_l1_cell"
+        let l1CellPath = "\(pageID)/\(fpCollection)/\(collRootRow2)/schemas/\(schemaL1)/\(l1Row1UnderRoot2)/\(cL1ColMultiSelect)"
+        let decoratorButton = app.buttons[S.fieldDecoratorID(action: action)]
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 2, in: app)
+        S.run(S.addCommand(path: l1CellPath,
+                           decorators: [S.decorator(action: action, icon: "flag", label: "Flag")]),
+              in: app)
+
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+
+        // Decorator existence also proves the row form opened.
+        XCTAssertTrue(waitUntil(3) { decoratorButton.exists && decoratorButton.isHittable },
+                      "Nested L1 cell decorator should be hittable inside readonly row form")
+
+        // Schema (Decorator.json level1Table1): multiSelect, number, date.
+        assertCellsNotTappable([
+            ("multiSelect", app.buttons["EditRowsMultiSelecionFieldIdentifier"]),
+            ("number",      app.textFields["EditRowsNumberFieldIdentifier"]),
+            ("date",        app.images["EditRowsDateFieldIdentifier"]),
+        ])
+
+        // Decorator tap still fires onFocus despite the parent .disabled wrapper.
+        decoratorButton.tap()
+        XCTAssertTrue(waitUntil(2) {
+            S.decoratorFocusEvent(action: action, in: self.focusBlurOptionalResults()) != nil
+        }, "Tapping nested L1 cell decorator in readonly row form should fire onFocus")
+
+        S.dismissRowEditForm(in: app)
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorAPIUITests.swift
@@ -583,9 +583,7 @@ final class DecoratorCollectionAPIUITests: DecoratorAPIUITestsBase {
               in: app)
         S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
         XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
-        S.dismissRowEditForm(in: app)
 
-        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
         XCTAssertTrue(flag.waitForExistence(timeout: 1))
         flag.tap()
         XCTAssertTrue(waitUntil(2) {
@@ -721,9 +719,7 @@ final class DecoratorCollectionAPIUITests: DecoratorAPIUITestsBase {
               in: app)
         S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
         XCTAssertTrue(waitUntil(2) { flag.label == "Done" })
-        S.dismissRowEditForm(in: app)
 
-        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
         XCTAssertTrue(flag.waitForExistence(timeout: 1))
         flag.tap()
         XCTAssertTrue(waitUntil(2) {
@@ -1023,5 +1019,53 @@ final class RowFormReadonlyUITests: DecoratorAPIUITestsBase {
         }, "Tapping nested L1 cell decorator in readonly row form should fire onFocus")
 
         S.dismissRowEditForm(in: app)
+    }
+
+    // Readonly row form flow:
+    // open single-row form -> dismiss -> row stays selected contextually,
+    // and More action must stay hidden in readonly mode.
+    func testTable_ReadonlyRowFormDismiss_SelectionContextAndNoMoreButton() {
+        typealias S = DecoratorUITestSupport
+        S.openTableDetailView(in: app)
+
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        let dismissButton = app.buttons["DismissEditSingleRowSheetButtonIdentifier"].firstMatch
+        XCTAssertTrue(dismissButton.waitForExistence(timeout: 3),
+                      "Readonly single-row form should open")
+        XCTAssertTrue(app.staticTexts["1 row selected"].exists,
+                      "Opening single-row form should indicate exactly one selected row")
+
+        dismissButton.tap()
+        XCTAssertTrue(waitUntil(3) { !dismissButton.exists },
+                      "Readonly row form should dismiss")
+
+        let moreButton = app.buttons["TableMoreButtonIdentifier"].firstMatch
+        XCTAssertTrue(moreButton.waitForNonExistence(timeout: 2),
+                      "More button must stay hidden in readonly mode")
+    }
+
+    // Readonly collection row form flow:
+    // open single-row form -> dismiss -> single-row context was active,
+    // and More action stays hidden in readonly mode.
+    func testCollection_ReadonlyRowFormDismiss_SelectionContextAndNoMoreButton() {
+        typealias S = DecoratorUITestSupport
+        S.openCollectionDetailView(in: app)
+
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        let dismissButton = app.buttons["DismissEditSingleRowSheetButtonIdentifier"].firstMatch
+        XCTAssertTrue(dismissButton.waitForExistence(timeout: 3),
+                      "Readonly collection single-row form should open")
+        XCTAssertTrue(app.buttons["UpperRowButtonIdentifier"].exists,
+                      "Opening collection single-row form should enter single-row selection context")
+
+        dismissButton.tap()
+        XCTAssertTrue(waitUntil(3) { !dismissButton.exists },
+                      "Readonly collection row form should dismiss")
+
+        let moreButton = app.buttons["TableMoreButtonIdentifier"].firstMatch
+        XCTAssertTrue(moreButton.waitForNonExistence(timeout: 2),
+                      "More button must stay hidden in readonly mode")
     }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -61,7 +61,7 @@ struct CollectionModalTopNavigationView: View {
                 })
             }
 
-            if !viewModel.tableDataModel.selectedRows.isEmpty {
+            if !viewModel.tableDataModel.selectedRows.isEmpty && viewModel.tableDataModel.mode == .fill {
                 Button(action: {
                     showingPopover = true
                 }) {
@@ -316,6 +316,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                         parentPath: parentPathForSelection
                     )
                 }
+                .environment(\.isEnabled, true)
             }
         }
         .padding(.bottom, -8)
@@ -362,19 +363,21 @@ struct CollectionEditMultipleRowsSheetView: View {
                             .disabled(viewModel.tableDataModel.shouldDisableMoveDownFilterActive)
                             .accessibilityIdentifier("LowerRowButtonIdentifier")
                             
-                            Button(action: {
-                                viewModel.insertBelowFromBulkEdit()
-                            }, label: {
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .stroke(.blue, lineWidth: 1)
-                                        .frame(width: 27, height: 27)
-                                    
-                                    Image(systemName: "plus")
-                                        .foregroundStyle(.blue)
-                                }
-                            })
-                            .accessibilityIdentifier("PlusTheRowButtonIdentifier")
+                            if viewModel.tableDataModel.mode == .fill {
+                                Button(action: {
+                                    viewModel.insertBelowFromBulkEdit()
+                                }, label: {
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .stroke(.blue, lineWidth: 1)
+                                            .frame(width: 27, height: 27)
+
+                                        Image(systemName: "plus")
+                                            .foregroundStyle(.blue)
+                                    }
+                                })
+                                .accessibilityIdentifier("PlusTheRowButtonIdentifier")
+                            }
                         } else {
                             Spacer()
                         }
@@ -718,5 +721,6 @@ struct CollectionEditMultipleRowsSheetView: View {
             }
             .id(col.id)
         }
+        .disabled(viewModel.tableDataModel.mode == .readonly)
     }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -32,7 +32,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
 
     func showSingleClickEditButton(for tableDataModel: TableDataModel) -> Bool {
-        return tableDataModel.singleClickRowEdit && tableDataModel.mode == .fill
+        return tableDataModel.singleClickRowEdit
     }
 
     func showRowDecorators(forSchemaKey schemaKey: String) -> Bool {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -16,7 +16,7 @@ struct TableModalTopNavigationView: View {
 
             Spacer()
 
-            if !viewModel.tableDataModel.selectedRows.isEmpty {
+            if !viewModel.tableDataModel.selectedRows.isEmpty && viewModel.tableDataModel.mode == .fill {
                 Button(action: {
                     showingPopover = true
                 }) {
@@ -245,6 +245,7 @@ struct EditMultipleRowsSheetView: View {
                 FieldDecoratorsView(decorators: decorators, visibleLimit: viewModel.decoratorConfig.visibleLimitInFields) { decorator in
                     viewModel.tableDataModel.documentEditor?.reportDecoratorAction(fieldIdentifier: viewModel.tableDataModel.fieldIdentifier, action: decorator.action ?? "", rowIds: viewModel.tableDataModel.selectedRows, columnId: col.id)
                 }
+                .environment(\.isEnabled, true)
             }
         }
         .padding(.bottom, -8)
@@ -291,19 +292,21 @@ struct EditMultipleRowsSheetView: View {
                                 .disabled(viewModel.tableDataModel.shouldDisableMoveDown)
                                 .accessibilityIdentifier("LowerRowButtonIdentifier")
                                 
-                                Button(action: {
-                                    viewModel.insertBelowFromBulkEdit()
-                                }, label: {
-                                    ZStack {
-                                        RoundedRectangle(cornerRadius: 6)
-                                            .stroke(.blue, lineWidth: 1)
-                                            .frame(width: 27, height: 27)
-                                        
-                                        Image(systemName: "plus")
-                                            .foregroundStyle(.blue)
-                                    }
-                                })
-                                .accessibilityIdentifier("PlusTheRowButtonIdentifier")
+                                if viewModel.tableDataModel.mode == .fill {
+                                    Button(action: {
+                                        viewModel.insertBelowFromBulkEdit()
+                                    }, label: {
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 6)
+                                                .stroke(.blue, lineWidth: 1)
+                                                .frame(width: 27, height: 27)
+
+                                            Image(systemName: "plus")
+                                                .foregroundStyle(.blue)
+                                        }
+                                    })
+                                    .accessibilityIdentifier("PlusTheRowButtonIdentifier")
+                                }
                             } else {
                                 Spacer()
                             }
@@ -612,6 +615,7 @@ struct EditMultipleRowsSheetView: View {
                     }
                     .id(col.id)
                 }
+                .disabled(viewModel.tableDataModel.mode == .readonly)
                 Spacer()
             }
             .padding(.all, 16)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableTextRowFormView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableTextRowFormView.swift
@@ -31,6 +31,7 @@ struct TableTextRowFormView: View {
                     .font(.system(size: 15))
                     .lineLimit(1)
                     .padding(.leading, 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         } else {
             HStack(spacing: 0) {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -20,7 +20,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
     @Published var uuid = UUID()
     
     var showSingleClickEditButton: Bool {
-        return tableDataModel.singleClickRowEdit && tableDataModel.mode == .fill
+        return tableDataModel.singleClickRowEdit
     }
 
     var showRowDecorators: Bool {


### PR DESCRIPTION
## Context
In readonly mode, the row form was never reachable, so users couldn't see cell decorators that only render inside the form. Spec: allow the row form to open in readonly so decorators are visible, but every editor inside must be disabled.

## What changed
- `TableViewModel.showSingleClickEditButton` / `CollectionViewModel.showSingleClickEditButton`: dropped `mode == .fill` gate so the pencil opens the form in readonly too
- `EditMultipleRowsSheetView` / `CollectionEditMultipleRowsSheetView`: single `.disabled(mode == .readonly)` on the column `ForEach`; decorator buttons inside `columnTitle` / `fieldTitle` use `.environment(\.isEnabled, true)` to stay tappable
- Hid the table "More" popover and the in-form "+" insert-row button in readonly (their actions all mutate data)
- `TableTextRowFormView`: readonly text now uses `.frame(maxWidth: .infinity)` so empty cells don't collapse to zero width
- Example app: `SampleFormFooterController` marked `@MainActor` to fix "Publishing changes from background threads" warning
- Added `RowFormReadonlyUITests` in `DecoratorAPIUITests.swift` covering the contract above (table, collection root, nested L1)

## Design decisions
- Single `.disabled` on the `ForEach` instead of per-cell — keeps the override surface to one line per file
- `.environment(\.isEnabled, true)` chosen over restructuring into Groups because it preserves the existing view tree and only re-enables the decorator subtree
- Row selector and "More" popover stay hidden in readonly — bulk operations don't make sense without edit capability; single-click pencil is the entry point

## Screenshots
_Attach: readonly row form showing decorators + disabled editors._

## Public API
No public API changes. No docs update needed.

## Tests
Automated: new `RowFormReadonlyUITests` class launches with `--mode readonly` and exercises the row form contract end-to-end across three scopes:
- `testTable_CellDecoratorInsideRowFormStaysTappable` — table row form
- `testCollection_RootCellDecoratorInsideRowFormStaysTappable` — collection root row form
- `testCollection_NestedL1CellDecoratorStaysTappable` — collection nested L1 row form

Each test:
1. Adds a common/specific cell decorator via the existing `DecoratorUITestSupport` bridge.
2. Opens the row form via the single-click pencil (only entry point in readonly).
3. Asserts the column-title decorator is hittable and that tapping it fires `onFocus` — proves the `.environment(\.isEnabled, true)` override works through the parent `.disabled`.
4. Iterates every column in that row form's schema via the `assertCellsNotTappable` helper: `waitForExistence` → `isEnabled == false` → `tap()` → `keyboards.element` must not appear.
5. Cells that swap to a static `Text` in readonly (`TableTextRowFormView` → collection text, `TableBarcodeView` → table barcode) are checked via absence of the editable element instead, since they never surface as an interactive control.

Manual: verified readonly form opens, all cell types are non-editable, decorators remain tappable, "+" / "More" / row selector all hidden.

## Notes for reviewer
- `.disabled` propagates by default; the `.environment(\.isEnabled, true)` override on `FieldDecoratorsView` is the only way decorators stay live. If you move decorators around, keep that modifier on the new home.
- Same shape applied to both table and collection paths — diffs mirror each other on purpose.
- The UI tests use `Decorator.json` and the existing pasteboard-free `decorator_command_input` bridge; no new infrastructure was added.