### PR TITLE
NO-2139: Fix spurious rowUpdate events on row form text cell focus

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
@@ -7,13 +7,93 @@ import JoyfillModel
 import JoyfillAPIService
 import Joyfill
 
+/// Kinds of events surfaced in the test changelog view.
+enum ChangelogKind: String {
+    case change
+    case focus
+    case blur
+    case pageFocus
+    case pageBlur
+    case upload
+    case capture
+
+    var label: String {
+        switch self {
+        case .change:    return "Change"
+        case .focus:     return "Focus"
+        case .blur:      return "Blur"
+        case .pageFocus: return "Page Focus"
+        case .pageBlur:  return "Page Blur"
+        case .upload:    return "Upload"
+        case .capture:   return "Capture"
+        }
+    }
+}
+
+/// One entry per event callback. A single `onChange` invocation — including
+/// a bulk edit that produces many `Change` rows — collapses to ONE entry.
+struct ChangelogEntry: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let kind: ChangelogKind
+    /// Structured payload entries displayed in the expanded view (each item is
+    /// rendered as its own row card). For `change`, this is the list of changes.
+    /// For single events (focus/blur/upload/capture), it has one item.
+    let items: [[String: Any]]
+
+    var count: Int { items.count }
+
+    /// Compact one-line summary shown on the collapsed card.
+    var summary: String {
+        switch kind {
+        case .change:
+            let targets = items.compactMap { $0["target"] as? String }
+            let uniqueTargets = Array(Set(targets)).sorted()
+            let fields = Array(Set(items.compactMap { $0["fieldId"] as? String })).sorted()
+            let rowsCount = items.reduce(0) { acc, item in
+                if let inner = item["change"] as? [String: Any] {
+                    if let rowIds = inner["rowIds"] as? [String] { return acc + rowIds.count }
+                    if inner["rowId"] != nil { return acc + 1 }
+                }
+                return acc
+            }
+            var parts: [String] = []
+            if !uniqueTargets.isEmpty { parts.append(uniqueTargets.joined(separator: ", ")) }
+            if !fields.isEmpty { parts.append("field: \(fields.first!)\(fields.count > 1 ? " (+\(fields.count - 1))" : "")") }
+            if rowsCount > 0 { parts.append("\(rowsCount) row\(rowsCount == 1 ? "" : "s")") }
+            return parts.joined(separator: " · ")
+        default:
+            let first = items.first ?? [:]
+            if let fieldID = first["fieldID"] as? String { return "field: \(fieldID)" }
+            if let pageDict = first["page"] as? [String: Any], let pageName = pageDict["name"] as? String {
+                return "page: \(pageName)"
+            }
+            return ""
+        }
+    }
+
+    /// Multi-line plain-text dump used by Copy / Export.
+    var copyText: String {
+        let ts = DateFormatter.timestamp.string(from: timestamp)
+        let header = "[\(ts)] \(kind.label)\(count > 1 ? " (\(count))" : "")"
+        let body = items.enumerated().map { idx, item -> String in
+            let prefix = count > 1 ? "  #\(idx + 1) " : "  "
+            let json = (try? JSONSerialization.data(withJSONObject: item, options: [.prettyPrinted, .sortedKeys]))
+                .flatMap { String(data: $0, encoding: .utf8) } ?? "<unserializable>"
+            return prefix + json.replacingOccurrences(of: "\n", with: "\n  ")
+        }.joined(separator: "\n")
+        return header + "\n" + body
+    }
+}
+
 class ChangeManager: ObservableObject {
     private let apiService: APIService?
     var showScan: (@escaping (ValueUnion) -> Void) -> Void
     private let showImagePicker:  (@escaping ([String]) -> Void) -> Void
-    
-    // Published property to display changelogs on screen
-    @Published var displayedChangelogs: [String] = []
+
+    /// Structured entries — one per event callback. Bulk `onChange` (many
+    /// changes in one call) shows up as a single entry with `items.count > 1`.
+    @Published var displayedEntries: [ChangelogEntry] = []
     @Published var showChangelogView: Bool = false
 
     init(apiService: APIService? = nil, showImagePicker:  @escaping(@escaping ([String]) -> Void) -> Void, showScan: @escaping (@escaping (ValueUnion) -> Void) -> Void) {
@@ -50,6 +130,12 @@ class ChangeManager: ObservableObject {
             }
         }
     }
+
+    private func append(_ entry: ChangelogEntry) {
+        DispatchQueue.main.async {
+            self.displayedEntries.append(entry)
+        }
+    }
 }
 
 extension ChangeManager: FormChangeEvent {
@@ -67,229 +153,107 @@ extension ChangeManager: FormChangeEvent {
 
     func onChange(changes: [Change], document: JoyfillModel.JoyDoc) {
         if let firstChange = changes.first {
-            print(">>>>>>>>onChange", firstChange.fieldId ?? "")
+            print(">>>>>>>>onChange", firstChange.fieldId ?? "", "count:", changes.count)
         } else {
             print(">>>>>>>>onChange: no changes")
         }
-        
-        // Format changelogs for display
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        let changelogEntries = changes.map { change in
-            let changeDict = change.dictionary
-            let changeJson = try? JSONSerialization.data(withJSONObject: changeDict, options: .prettyPrinted)
-            let changeString = changeJson.flatMap { String(data: $0, encoding: .utf8) } ?? "Invalid change data"
-            return "[\(timestamp)] Change: \(changeString)"
-        }
-        
-        DispatchQueue.main.async {
-            self.displayedChangelogs.append(contentsOf: changelogEntries)
-        }
-        
-        let changeLogs = ["changelogs": changes.map { $0.dictionary }]
 
+        let items = changes.map { $0.dictionary }
+        append(ChangelogEntry(timestamp: Date(), kind: .change, items: items))
+
+        let changeLogs = ["changelogs": items]
         if let identifier = document.identifier, let apiService = apiService, apiService.hasValidToken {
             updateDocument(identifier: identifier, changeLogs: changeLogs)
         }
     }
 
     func onFocus(event: Event) {
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        
         if let fieldEvent = event.fieldEvent {
             let fieldDict = createFieldIdentifierDict(fieldEvent)
             print(">>>>>>>>onFocus", formatDictionary(fieldDict))
-            
-            if let jsonData = try? JSONSerialization.data(withJSONObject: fieldDict, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                DispatchQueue.main.async {
-                    self.displayedChangelogs.append("[\(timestamp)] Focus: \(jsonString)")
-                }
-            }
+            append(ChangelogEntry(timestamp: Date(), kind: .focus, items: [fieldDict]))
         } else if let pageEvent = event.pageEvent {
             print(">>>>>>>>onPageFocus", pageEvent.type, pageEvent.page.id ?? "unknown", pageEvent.page.name ?? "Untitled")
-            
-            // Create proper JSON string for the viewer
             var eventDict: [String: Any] = [:]
             eventDict["type"] = pageEvent.type
             eventDict["page"] = pageEvent.page.dictionary
-            
-            if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                DispatchQueue.main.async {
-                    self.displayedChangelogs.append("[\(timestamp)] PageEvent: \(jsonString)")
-                }
-            }
+            append(ChangelogEntry(timestamp: Date(), kind: .pageFocus, items: [eventDict]))
         }
     }
 
     func onBlur(event: Event) {
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        
         if let fieldEvent = event.fieldEvent {
             let fieldDict = createFieldIdentifierDict(fieldEvent)
             print(">>>>>>>>onBlur", formatDictionary(fieldDict))
-            
-            if let jsonData = try? JSONSerialization.data(withJSONObject: fieldDict, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                DispatchQueue.main.async {
-                    self.displayedChangelogs.append("[\(timestamp)] Blur: \(jsonString)")
-                }
-            }
+            append(ChangelogEntry(timestamp: Date(), kind: .blur, items: [fieldDict]))
         } else if let pageEvent = event.pageEvent {
             print(">>>>>>>>onPageBlur", pageEvent.type, pageEvent.page.id ?? "unknown", pageEvent.page.name ?? "Untitled")
-            
-            // Create proper JSON string for the viewer
             var eventDict: [String: Any] = [:]
             eventDict["type"] = pageEvent.type
             eventDict["page"] = pageEvent.page.dictionary
-            
-            if let jsonData = try? JSONSerialization.data(withJSONObject: eventDict, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                DispatchQueue.main.async {
-                    self.displayedChangelogs.append("[\(timestamp)] PageEvent: \(jsonString)")
-                }
-            }
+            append(ChangelogEntry(timestamp: Date(), kind: .pageBlur, items: [eventDict]))
         }
     }
 
     func onUpload(event: UploadEvent) {
         print(">>>>>>>>onUpload", event.fieldEvent.fieldID)
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        DispatchQueue.main.async {
-            self.displayedChangelogs.append("[\(timestamp)] Upload: \(self.formatUploadEvent(event))")
-        }
+        append(ChangelogEntry(timestamp: Date(), kind: .upload, items: [uploadEventDict(event)]))
         showImagePicker(event.uploadHandler)
     }
-    
+
     func onCapture(event: CaptureEvent) {
         print(">>>>>>>>onCapture", event.fieldEvent.fieldID)
-        let timestamp = DateFormatter.timestamp.string(from: Date())
-        DispatchQueue.main.async {
-            self.displayedChangelogs.append("[\(timestamp)] Capture: \(self.formatCaptureEvent(event))")
-        }
+        append(ChangelogEntry(timestamp: Date(), kind: .capture, items: [captureEventDict(event)]))
         showScan(event.captureHandler)
     }
-    
+
     // MARK: - Event Formatting Helpers
-    
-    private func formatUploadEvent(_ event: UploadEvent) -> String {
+
+    private func uploadEventDict(_ event: UploadEvent) -> [String: Any] {
         var eventDict: [String: Any] = [:]
-        
-        // Add fieldEvent details as nested dictionary
         eventDict["fieldEvent"] = createFieldIdentifierDict(event.fieldEvent)
-        
-        // Add non-nil optional values
-        if let target = event.target {
-            eventDict["target"] = target
-        }
-        
+        if let target = event.target { eventDict["target"] = target }
         eventDict["multi"] = event.multi
-        
-        if let schemaId = event.schemaId {
-            eventDict["schemaId"] = schemaId
-        }
-        
-        if let parentPath = event.parentPath, !parentPath.isEmpty {
-            eventDict["parentPath"] = parentPath
-        }
-        
-        if let rowIds = event.rowIds, !rowIds.isEmpty {
-            eventDict["rowIds"] = rowIds
-        }
-        
-        if let columnId = event.columnId {
-            eventDict["columnId"] = columnId
-        }
-        
-        return "UploadEvent: \(formatDictionary(eventDict))"
+        if let schemaId = event.schemaId { eventDict["schemaId"] = schemaId }
+        if let parentPath = event.parentPath, !parentPath.isEmpty { eventDict["parentPath"] = parentPath }
+        if let rowIds = event.rowIds, !rowIds.isEmpty { eventDict["rowIds"] = rowIds }
+        if let columnId = event.columnId { eventDict["columnId"] = columnId }
+        return eventDict
     }
-    
-    private func formatCaptureEvent(_ event: CaptureEvent) -> String {
+
+    private func captureEventDict(_ event: CaptureEvent) -> [String: Any] {
         var eventDict: [String: Any] = [:]
-        
-        // Add fieldEvent details as nested dictionary
         eventDict["fieldEvent"] = createFieldIdentifierDict(event.fieldEvent)
-        
-        // Add non-nil optional values
-        if let target = event.target {
-            eventDict["target"] = target
-        }
-        
-        if let schemaId = event.schemaId {
-            eventDict["schemaId"] = schemaId
-        }
-        
-        if let parentPath = event.parentPath, !parentPath.isEmpty {
-            eventDict["parentPath"] = parentPath
-        }
-        
-        if let rowIds = event.rowIds, !rowIds.isEmpty {
-            eventDict["rowIds"] = rowIds
-        }
-        
-        if let columnId = event.columnId {
-            eventDict["columnId"] = columnId
-        }
-        
-        return "CaptureEvent: \(formatDictionary(eventDict))"
+        if let target = event.target { eventDict["target"] = target }
+        if let schemaId = event.schemaId { eventDict["schemaId"] = schemaId }
+        if let parentPath = event.parentPath, !parentPath.isEmpty { eventDict["parentPath"] = parentPath }
+        if let rowIds = event.rowIds, !rowIds.isEmpty { eventDict["rowIds"] = rowIds }
+        if let columnId = event.columnId { eventDict["columnId"] = columnId }
+        return eventDict
     }
-    
+
     private func createFieldIdentifierDict(_ fieldEvent: FieldIdentifier) -> [String: Any] {
         var fieldDict: [String: Any] = [:]
-        
-        // Always include fieldID (required)
         fieldDict["fieldID"] = fieldEvent.fieldID
-        
-        // Add optional properties if they exist
-        if let id = fieldEvent._id {
-            fieldDict["_id"] = id
-        }
-        
-        if let identifier = fieldEvent.identifier {
-            fieldDict["identifier"] = identifier
-        }
-        
-        if let fieldIdentifier = fieldEvent.fieldIdentifier {
-            fieldDict["fieldIdentifier"] = fieldIdentifier
-        }
-        
-        if let pageID = fieldEvent.pageID {
-            fieldDict["pageID"] = pageID
-        }
-        
-        if let fileID = fieldEvent.fileID {
-            fieldDict["fileID"] = fileID
-        }
-        
-        if let fieldPositionId = fieldEvent.fieldPositionId {
-            fieldDict["fieldPositionId"] = fieldPositionId
-        }
-        
-        if let type = fieldEvent.type {
-            fieldDict["type"] = type
-        }
-        if let target = fieldEvent.target {
-            fieldDict["target"] = target
-        }
-        if let rowIDs = fieldEvent.rowIds, !rowIDs.isEmpty {
-            fieldDict["rowIds"] = rowIDs
-        }
-        if let parentPath = fieldEvent.parentPath {
-            fieldDict["parentPath"] = parentPath
-        }
-        if let columnId = fieldEvent.columnId {
-            fieldDict["columnId"] = columnId
-        }
+        if let id = fieldEvent._id { fieldDict["_id"] = id }
+        if let identifier = fieldEvent.identifier { fieldDict["identifier"] = identifier }
+        if let fieldIdentifier = fieldEvent.fieldIdentifier { fieldDict["fieldIdentifier"] = fieldIdentifier }
+        if let pageID = fieldEvent.pageID { fieldDict["pageID"] = pageID }
+        if let fileID = fieldEvent.fileID { fieldDict["fileID"] = fileID }
+        if let fieldPositionId = fieldEvent.fieldPositionId { fieldDict["fieldPositionId"] = fieldPositionId }
+        if let type = fieldEvent.type { fieldDict["type"] = type }
+        if let target = fieldEvent.target { fieldDict["target"] = target }
+        if let rowIDs = fieldEvent.rowIds, !rowIDs.isEmpty { fieldDict["rowIds"] = rowIDs }
+        if let parentPath = fieldEvent.parentPath { fieldDict["parentPath"] = parentPath }
+        if let columnId = fieldEvent.columnId { fieldDict["columnId"] = columnId }
         return fieldDict
     }
-    
+
     private func formatDictionary(_ dict: [String: Any], indent: String = "") -> String {
         var result = "{\n"
         let nextIndent = indent + "  "
-        
         for (key, value) in dict.sorted(by: { $0.key < $1.key }) {
             result += "\(nextIndent)\"\(key)\": "
-            
             if let nestedDict = value as? [String: Any] {
                 result += formatDictionary(nestedDict, indent: nextIndent)
             } else if let stringValue = value as? String {
@@ -299,19 +263,14 @@ extension ChangeManager: FormChangeEvent {
             } else {
                 result += "\(value)"
             }
-            
             result += ",\n"
         }
-        
-        // Remove last comma and newline, then close bracket
         if result.hasSuffix(",\n") {
             result = String(result.dropLast(2)) + "\n"
         }
         result += "\(indent)}"
-        
         return result
     }
-    
 }
 
 extension DateFormatter {

--- a/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift
@@ -59,7 +59,10 @@ struct ChangelogEntry: Identifiable {
             }
             var parts: [String] = []
             if !uniqueTargets.isEmpty { parts.append(uniqueTargets.joined(separator: ", ")) }
-            if !fields.isEmpty { parts.append("field: \(fields.first!)\(fields.count > 1 ? " (+\(fields.count - 1))" : "")") }
+            if let firstField = fields.first {
+                let extra = fields.count > 1 ? " (+\(fields.count - 1))" : ""
+                parts.append("field: \(firstField)\(extra)")
+            }
             if rowsCount > 0 { parts.append("\(rowsCount) row\(rowsCount == 1 ? "" : "s")") }
             return parts.joined(separator: " · ")
         default:

--- a/JoyfillSwiftUIExample/JoyfillExample/ChangelogView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/ChangelogView.swift
@@ -2,146 +2,434 @@
 //  ChangelogView.swift
 //  JoyfillExample
 //
-//  Created by Vivek on [Date]
-//
 
 import SwiftUI
 
 struct ChangelogView: View {
     @ObservedObject var changeManager: ChangeManager
     @Environment(\.presentationMode) var presentationMode
-    @State private var selectedText: String = ""
-    
+    @State private var selectedKind: ChangelogKind? = nil
+    @State private var searchText: String = ""
+    @State private var expandedEntryIDs: Set<UUID> = []
+    @State private var copyToast: String? = nil
+
+    private var filteredEntries: [ChangelogEntry] {
+        changeManager.displayedEntries.reversed().filter { entry in
+            if let k = selectedKind, entry.kind != k { return false }
+            if !searchText.isEmpty {
+                let needle = searchText.lowercased()
+                if entry.copyText.lowercased().contains(needle) { return true }
+                return false
+            }
+            return true
+        }
+    }
+
     var body: some View {
         NavigationView {
-            VStack {
-                HStack {
-                    Text("Changelogs (\(changeManager.displayedChangelogs.count))")
-                        .font(.title2)
-                        .bold()
-                    
-                    Spacer()
-                    
-                    Button("Clear All") {
-                        changeManager.displayedChangelogs.removeAll()
-                    }
-                    .foregroundColor(.red)
-                }
-                .padding()
-                
-                if changeManager.displayedChangelogs.isEmpty {
-                    Spacer()
-                    Text("No changelogs yet")
-                        .foregroundColor(.gray)
-                        .font(.title3)
-                    Spacer()
-                } else {
-                    ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 8) {
-                            ForEach(Array(changeManager.displayedChangelogs.enumerated()), id: \.offset) { index, log in
-                                ChangelogEntryView(log: log, index: index + 1)
-                            }
-                        }
-                        .padding()
-                    }
-                    
-                    HStack {
-                        Button("Copy All Logs") {
-                            let allLogs = changeManager.displayedChangelogs.joined(separator: "\n\n")
-                            copyToClipboard(allLogs)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        
-                        Button("Export as JSON") {
-                            exportAsJSON()
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                    .padding()
-                }
+            VStack(spacing: 0) {
+                header
+                filterBar
+                Divider()
+                content
             }
             .navigationTitle("Change Logs")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) {
                     Button("Done") {
                         presentationMode.wrappedValue.dismiss()
                     }
                 }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button {
+                            copyAll()
+                        } label: { Label("Copy All", systemImage: "doc.on.doc") }
+                        Button {
+                            exportAsJSON()
+                        } label: { Label("Copy as JSON", systemImage: "curlybraces") }
+                        Button(role: .destructive) {
+                            changeManager.displayedEntries.removeAll()
+                            expandedEntryIDs.removeAll()
+                        } label: { Label("Clear All", systemImage: "trash") }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if let msg = copyToast {
+                    Text(msg)
+                        .font(.caption)
+                        .padding(.horizontal, 12).padding(.vertical, 8)
+                        .background(Color.black.opacity(0.8))
+                        .foregroundColor(.white)
+                        .clipShape(Capsule())
+                        .padding(.bottom, 24)
+                        .transition(.opacity)
+                }
             }
         }
     }
-    
-    private func copyToClipboard(_ text: String) {
-        UIPasteboard.general.string = text
-        // Show a toast or alert to confirm copy
-        print("Copied to clipboard!")
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack {
+                statBadge(label: "Events", value: "\(changeManager.displayedEntries.count)", color: .blue)
+                statBadge(label: "Changes", value: "\(totalChangeCount())", color: .purple)
+                Spacer()
+            }
+            TextField("Search fieldId, target, payload…", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+        }
+        .padding(.horizontal)
+        .padding(.top, 8)
     }
-    
+
+    private func statBadge(label: String, value: String, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Text(value).font(.caption).bold().foregroundColor(color)
+            Text(label).font(.caption2).foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 4)
+        .background(color.opacity(0.12))
+        .clipShape(Capsule())
+    }
+
+    private func totalChangeCount() -> Int {
+        changeManager.displayedEntries.reduce(0) { $0 + $1.count }
+    }
+
+    // MARK: - Filter bar
+
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                filterChip(title: "All", isOn: selectedKind == nil) { selectedKind = nil }
+                ForEach(activeKinds, id: \.self) { kind in
+                    filterChip(title: kind.label, isOn: selectedKind == kind) {
+                        selectedKind = (selectedKind == kind) ? nil : kind
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var activeKinds: [ChangelogKind] {
+        let order: [ChangelogKind] = [.change, .focus, .blur, .pageFocus, .pageBlur, .upload, .capture]
+        let present = Set(changeManager.displayedEntries.map { $0.kind })
+        return order.filter { present.contains($0) }
+    }
+
+    private func filterChip(title: String, isOn: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption)
+                .padding(.horizontal, 10).padding(.vertical, 6)
+                .background(isOn ? Color.accentColor : Color(.systemGray5))
+                .foregroundColor(isOn ? .white : .primary)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if changeManager.displayedEntries.isEmpty {
+            VStack(spacing: 8) {
+                Spacer()
+                Image(systemName: "tray").font(.largeTitle).foregroundColor(.gray)
+                Text("No changelogs yet").foregroundColor(.gray)
+                Spacer()
+            }
+        } else if filteredEntries.isEmpty {
+            VStack {
+                Spacer()
+                Text("No entries match the filter").foregroundColor(.gray)
+                Spacer()
+            }
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(filteredEntries) { entry in
+                        EntryCard(
+                            entry: entry,
+                            isExpanded: expandedEntryIDs.contains(entry.id),
+                            onToggle: {
+                                if expandedEntryIDs.contains(entry.id) {
+                                    expandedEntryIDs.remove(entry.id)
+                                } else {
+                                    expandedEntryIDs.insert(entry.id)
+                                }
+                            },
+                            onCopy: { copy(entry.copyText, label: "Entry copied") }
+                        )
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func copyAll() {
+        let text = changeManager.displayedEntries.map { $0.copyText }.joined(separator: "\n\n")
+        copy(text, label: "All entries copied")
+    }
+
     private func exportAsJSON() {
-        let jsonData = [
+        let payload: [String: Any] = [
             "exportedAt": ISO8601DateFormatter().string(from: Date()),
-            "totalLogs": changeManager.displayedChangelogs.count,
-            "logs": changeManager.displayedChangelogs
-        ] as [String : Any]
-        
-        if let jsonString = try? JSONSerialization.data(withJSONObject: jsonData, options: .prettyPrinted),
-           let jsonText = String(data: jsonString, encoding: .utf8) {
-            copyToClipboard(jsonText)
+            "totalEvents": changeManager.displayedEntries.count,
+            "totalChanges": totalChangeCount(),
+            "events": changeManager.displayedEntries.map { entry -> [String: Any] in
+                [
+                    "timestamp": ISO8601DateFormatter().string(from: entry.timestamp),
+                    "kind": entry.kind.rawValue,
+                    "items": entry.items
+                ]
+            }
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]),
+           let s = String(data: data, encoding: .utf8) {
+            copy(s, label: "JSON copied")
+        }
+    }
+
+    private func copy(_ text: String, label: String) {
+        UIPasteboard.general.string = text
+        withAnimation { copyToast = label }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+            withAnimation { copyToast = nil }
         }
     }
 }
 
-struct ChangelogEntryView: View {
-    let log: String
-    let index: Int
-    @State private var isExpanded = false
-    
+// MARK: - Entry card
+
+private struct EntryCard: View {
+    let entry: ChangelogEntry
+    let isExpanded: Bool
+    let onToggle: () -> Void
+    let onCopy: () -> Void
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("#\(index)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(width: 30, alignment: .leading)
-                
-                Text(log)
-                    .font(.system(.caption, design: .monospaced))
-                    .lineLimit(isExpanded ? nil : 3)
-                
-                Spacer()
-                
-                Button(action: {
-                    copyToClipboard(log)
-                }) {
-                    Image(systemName: "doc.on.doc")
-                        .foregroundColor(.blue)
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: onToggle) {
+                HStack(spacing: 10) {
+                    kindBadge
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(DateFormatter.timestamp.string(from: entry.timestamp))
+                                .font(.caption.monospaced())
+                                .foregroundColor(.secondary)
+                            if entry.count > 1 {
+                                Text("×\(entry.count)")
+                                    .font(.caption.bold())
+                                    .padding(.horizontal, 6).padding(.vertical, 1)
+                                    .background(Color.orange.opacity(0.2))
+                                    .foregroundColor(.orange)
+                                    .clipShape(Capsule())
+                            }
+                        }
+                        if !entry.summary.isEmpty {
+                            Text(entry.summary)
+                                .font(.caption)
+                                .foregroundColor(.primary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
+                .padding(10)
+                .contentShape(Rectangle())
             }
-            
-            HStack {
-                Spacer()
-                
-                Button(isExpanded ? "Collapse" : "Expand") {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isExpanded.toggle()
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(entry.items.enumerated()), id: \.offset) { idx, item in
+                        ItemDetailRow(index: idx + 1, total: entry.items.count, item: item, kind: entry.kind)
+                    }
+                    HStack {
+                        Spacer()
+                        Button {
+                            onCopy()
+                        } label: {
+                            Label("Copy entry", systemImage: "doc.on.doc")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
                     }
                 }
-                .font(.caption)
-                .foregroundColor(.blue)
+                .padding(10)
             }
         }
-        .padding(12)
-        .background(Color(.systemGray6))
-        .cornerRadius(8)
+        .background(Color(.systemBackground))
         .overlay(
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: 10)
                 .stroke(Color(.systemGray4), lineWidth: 1)
         )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
-    
-    private func copyToClipboard(_ text: String) {
-        UIPasteboard.general.string = text
-        print("Copied entry to clipboard!")
+
+    private var kindBadge: some View {
+        Text(entry.kind.label)
+            .font(.caption2.bold())
+            .padding(.horizontal, 8).padding(.vertical, 4)
+            .background(kindColor.opacity(0.18))
+            .foregroundColor(kindColor)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var kindColor: Color {
+        switch entry.kind {
+        case .change:    return .purple
+        case .focus:     return .blue
+        case .blur:      return .gray
+        case .pageFocus: return .teal
+        case .pageBlur:  return .indigo
+        case .upload:    return .green
+        case .capture:   return .pink
+        }
+    }
+}
+
+// MARK: - Item detail
+
+private struct ItemDetailRow: View {
+    let index: Int
+    let total: Int
+    let item: [String: Any]
+    let kind: ChangelogKind
+    @State private var showRaw = false
+
+    private var headline: String {
+        if kind == .change {
+            let target = item["target"] as? String ?? "—"
+            let fieldId = item["fieldId"] as? String ?? "—"
+            return "\(target) · \(fieldId)"
+        }
+        if let fieldID = item["fieldID"] as? String { return fieldID }
+        if let pageDict = item["page"] as? [String: Any],
+           let name = pageDict["name"] as? String { return name }
+        return "—"
+    }
+
+    private var keyValues: [(String, String)] {
+        var pairs: [(String, String)] = []
+        if kind == .change, let inner = item["change"] as? [String: Any] {
+            let preferredOrder = ["rowId", "rowIds", "columnId", "value", "schemaId", "parentPath"]
+            for key in preferredOrder {
+                if let v = inner[key] { pairs.append((key, stringify(v))) }
+            }
+            for (k, v) in inner where !preferredOrder.contains(k) {
+                pairs.append((k, stringify(v)))
+            }
+        } else {
+            let preferredOrder = ["target", "rowIds", "columnId", "schemaId", "parentPath", "type", "multi"]
+            for key in preferredOrder {
+                if let v = item[key] { pairs.append((key, stringify(v))) }
+            }
+        }
+        return pairs
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                if total > 1 {
+                    Text("#\(index)")
+                        .font(.caption2.monospaced())
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 6).padding(.vertical, 1)
+                        .background(Color(.systemGray6))
+                        .clipShape(Capsule())
+                }
+                Text(headline)
+                    .font(.caption.monospaced())
+                    .lineLimit(2)
+                Spacer()
+                Button {
+                    showRaw.toggle()
+                } label: {
+                    Image(systemName: showRaw ? "chevron.up" : "curlybraces")
+                        .font(.caption2)
+                }
+                .buttonStyle(.borderless)
+            }
+
+            if !keyValues.isEmpty && !showRaw {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(keyValues, id: \.0) { kv in
+                        HStack(alignment: .top, spacing: 6) {
+                            Text(kv.0)
+                                .font(.caption2.bold())
+                                .foregroundColor(.secondary)
+                                .frame(minWidth: 70, alignment: .leading)
+                            Text(kv.1)
+                                .font(.caption2.monospaced())
+                                .textSelection(.enabled)
+                                .lineLimit(3)
+                        }
+                    }
+                }
+                .padding(.leading, 4)
+            }
+
+            if showRaw {
+                Text(prettyJSON(item))
+                    .font(.caption2.monospaced())
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.systemGray6))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func stringify(_ value: Any) -> String {
+        if let s = value as? String { return s }
+        if let arr = value as? [String] { return "[\(arr.joined(separator: ", "))]" }
+        if let dict = value as? [String: Any] {
+            return prettyJSON(dict)
+        }
+        if let arr = value as? [Any],
+           let data = try? JSONSerialization.data(withJSONObject: arr, options: [.sortedKeys]),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return "\(value)"
+    }
+
+    private func prettyJSON(_ dict: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(dict),
+              let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys]),
+              let s = String(data: data, encoding: .utf8) else {
+            return "\(dict)"
+        }
+        return s
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillExample/FormContainerView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/FormContainerView.swift
@@ -33,8 +33,8 @@ struct FormContainerView: View {
                         HStack {
                             Image(systemName: "list.clipboard")
                             Text("Logs")
-                            if !changeManager.displayedChangelogs.isEmpty {
-                                Text("\(changeManager.displayedChangelogs.count)")
+                            if !changeManager.displayedEntries.isEmpty {
+                                Text("\(changeManager.displayedEntries.count)")
                                     .font(.caption)
                                     .foregroundColor(.white)
                                     .padding(.horizontal, 6)

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -336,8 +336,8 @@ struct FormDestinationView: View {
                         HStack {
                             Image(systemName: "list.clipboard")
                             Text("Logs")
-                            if !changeManager.displayedChangelogs.isEmpty {
-                                Text("\(changeManager.displayedChangelogs.count)")
+                            if !changeManager.displayedEntries.isEmpty {
+                                Text("\(changeManager.displayedEntries.count)")
                                     .font(.caption)
                                     .foregroundColor(.white)
                                     .padding(.horizontal, 6)

--- a/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
@@ -591,7 +591,7 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
         editRowsButton().tap()
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
@@ -827,7 +827,7 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
         editRowsButton().tap()
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -1738,7 +1738,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         tapOnMoreButton()
         editRowsButton().tap()
         
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         textField.tap()
         textField.clearText()
         textField.typeText("Hello ji")
@@ -1805,7 +1805,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         tapOnMoreButton()
         editRowsButton().tap()
         
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         textField.tap()
         textField.clearText()
         textField.typeText("Joyfill")
@@ -1863,7 +1863,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         XCTAssertEqual(editSingleRowUpperButton().isEnabled, true)
         XCTAssertEqual(editSingleRowLowerButton().isEnabled, true)
         
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         textField.tap()
         textField.clearText()
         textField.typeText("A")
@@ -2075,7 +2075,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         textField.typeText("hide depth2")
@@ -2191,7 +2191,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         textField.typeText("one")
@@ -2307,7 +2307,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         XCTAssertEqual(editSingleRowUpperButton().isEnabled, false)
         XCTAssertEqual(editSingleRowLowerButton().isEnabled, true)
         
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         textField.tap()
         textField.clearText()
         textField.typeText("qu")
@@ -2430,7 +2430,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         textField.typeText("one")
@@ -2615,7 +2615,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         tapOnMoreButton()
         editRowsButton().tap()
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         textField.typeText("hide depth2")
@@ -2768,7 +2768,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         tapOnMoreButton()
         editRowsButton().tap()
         
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         XCTAssertTrue(textField.waitForExistence(timeout: 5), "Edit row text field should exist")
         textField.tap()
         
@@ -3153,7 +3153,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
         
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
         textField.tap()
         textField.press(forDuration: 1.0)

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -810,7 +810,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         waitForAppToSettle()
         XCTAssertTrue(textField.waitForExistence(timeout: 5), "Edit text field did not appear")
         textField.tap()
@@ -1022,7 +1022,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         XCTAssertEqual(editSingleRowLowerButton().isEnabled, false)
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         textField.tap()
         textField.typeText("A")
         app.dismissKeyboardIfVisible()
@@ -1208,7 +1208,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
 
         editRowsMenuBefore.tap()
 
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         XCTAssertTrue(textField.waitForExistence(timeout: 1), "Bulk edit text field should be visible")
         textField.tap()
         textField.typeText("BulkSelectionPersistence")
@@ -1236,7 +1236,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         editRowsButton().tap()
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         waitForAppToSettle()
         textField.tap()
         waitForAppToSettle()
@@ -1356,7 +1356,7 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         editRowsButton().tap()
         
         // Textfield
-        let textField = app.textViews["EditRowsTextFieldIdentifier"]
+        let textField = app.textFields["EditRowsTextFieldIdentifier"]
         waitForAppToSettle()
         XCTAssertTrue(textField.waitForExistence(timeout: 5))
         textField.tap()

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -226,7 +226,6 @@ struct EditMultipleRowsSheetView: View {
     @State var changes = [Int: ValueUnion]()
     @State private var viewID = UUID() // Unique ID for the view
     @State private var debounceTask: Task<Void, Never>?
-    @FocusState private var focusedColumnIndex: Int?
 
     init(viewModel: TableViewModel) {
         self.viewModel =  viewModel
@@ -492,44 +491,11 @@ struct EditMultipleRowsSheetView: View {
                             switch cellModel.data.type {
                             case .text:
                                 columnTitle(col)
-                                
-                                var str = !isUsedForBulkEdit ? cellModel.data.title : ""
-                                let binding = Binding<String>(
-                                    get: {
-                                        if isUsedForBulkEdit {
-                                            if case .string(let changedStr) = changes[colIndex] { return changedStr }
-                                            return ""
-                                        } else {
-                                            return str
-                                        }
-                                    },
-                                    set: { newValue in
-                                        str = newValue
-                                        if isUsedForBulkEdit {
-                                            if !str.isEmpty {
-                                                self.changes[colIndex] = ValueUnion.string(newValue)
-                                            } else {
-                                                self.changes.removeValue(forKey: colIndex)
-                                            }
-                                        } else {
-                                            self.changes[colIndex] = ValueUnion.string(newValue)
-                                        }
-                                        
-                                        Task { @MainActor in
-                                            if !isUsedForBulkEdit {
-                                                await viewModel.bulkEdit(changes: changes)
-                                            }
-                                        }
-                                    }
-                                )
-                                TextField("", text: binding)
-                                    .font(.system(size: 15))
-                                    .accessibilityIdentifier("EditRowsTextFieldIdentifier")
-                                    .padding(.horizontal, 10)
-                                    .frame(height: 40)
+                                TableTextRowFormView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
+                                    .frame(minHeight: 40)
                                     .cellBorder(isFocused: isFocused)
-                                    .focused($focusedColumnIndex, equals: colIndex)
-                                
+                                    .accessibilityIdentifier("EditRowsTextFieldIdentifier")
+
                             case .dropdown:
                                 columnTitle(col)
                                 TableDropDownOptionListView(cellModel: Binding.constant(cellModel), isUsedForBulkEdit: isUsedForBulkEdit)
@@ -622,7 +588,6 @@ struct EditMultipleRowsSheetView: View {
             if let columnId = viewModel.tableDataModel.navigationIntent.scrollToColumnId {
                 scrollProxy.scrollTo(columnId, anchor: .top)
             }
-            triggerInlineTextFocus()
         }
         .onChange(of: viewModel.tableDataModel.selectedRows.first ){ newValue in
             viewID = UUID()
@@ -640,10 +605,4 @@ struct EditMultipleRowsSheetView: View {
         }
     }
 
-    private func triggerInlineTextFocus() {
-        guard let columnId = viewModel.tableDataModel.navigationIntent.focusColumnId,
-              let colIndex = viewModel.tableDataModel.tableColumns.firstIndex(where: { $0.id == columnId }),
-              viewModel.tableDataModel.tableColumns[colIndex].type == .text else { return }
-        focusedColumnIndex = colIndex
-    }
 }

--- a/Sources/JoyfillUI/View/Fields/TableView/TableTextRowFormView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableTextRowFormView.swift
@@ -34,40 +34,22 @@ struct TableTextRowFormView: View {
             }
         } else {
             HStack(spacing: 0) {
-                if #available(iOS 16.0, *) {
-                    TextEditor(text: $text)
-                        .font(.system(size: 15))
-                        .accessibilityIdentifier("EditRowsTextFieldIdentifier")
-                        .scrollContentBackground(.hidden)
-                        .onChange(of: text) { newValue in
-                            updateFieldValue(newText: newValue)
+                TextField("", text: $text)
+                    .font(.system(size: 15))
+                    .accessibilityIdentifier("EditRowsTextFieldIdentifier")
+                    .padding(.horizontal, 10)
+                    .onChange(of: text) { newValue in
+                        updateFieldValue(newText: newValue)
+                    }
+                    .focused($isTextFieldFocused)
+                    .onChange(of: isTextFieldFocused) { focused in
+                        if focused {
+                            cellModel.didFocusBlur?(.focus, cellModel.data)
+                        } else {
+                            cellModel.didFocusBlur?(.blur, cellModel.data)
                         }
-                        .focused($isTextFieldFocused)
-                        .onChange(of: isTextFieldFocused) { focused in
-                            if focused {
-                                cellModel.didFocusBlur?(.focus, cellModel.data)
-                            } else {
-                                cellModel.didFocusBlur?(.blur, cellModel.data)
-                            }
-                        }
-                        .onAppear { autoFocusIfNeeded() }
-                } else {
-                    TextEditor(text: $text)
-                        .font(.system(size: 15))
-                        .accessibilityIdentifier("EditRowsTextFieldIdentifier")
-                        .onChange(of: text) { newValue in
-                            updateFieldValue(newText: newValue)
-                        }
-                        .focused($isTextFieldFocused)
-                        .onChange(of: isTextFieldFocused) { focused in
-                            if focused {
-                                cellModel.didFocusBlur?(.focus, cellModel.data)
-                            } else {
-                                cellModel.didFocusBlur?(.blur, cellModel.data)
-                            }
-                        }
-                        .onAppear { autoFocusIfNeeded() }
-                }
+                    }
+                    .onAppear { autoFocusIfNeeded() }
             }
         }
     }


### PR DESCRIPTION
## 1. Context

Tapping a text cell in the table/collection row edit form (just to open the keyboard, without typing) produced multiple `field.value.rowUpdate` events and **no** `focus` event. The same flow on a 1-row form emitted ~4 spurious `rowUpdate` callbacks before any user input — noisy for `onChange` consumers and visibly misleading in the example app's changelog.

While debugging this, it became obvious that the example app's changelog screen was hard to read for testing — every change in a bulk emission rendered as its own card, with no grouping or filtering — so this PR also refactors that screen.

## 2. What changed

**SDK fix** (the actual bug):
- `Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift` — replaced the custom `TextField` + `Binding<String>` block for `.text` cells with `TableTextRowFormView` (the same component the collection form already used). Removed the now-dead `@FocusState focusedColumnIndex` and `triggerInlineTextFocus()`.
- `Sources/JoyfillUI/View/Fields/TableView/TableTextRowFormView.swift` — swapped `TextEditor` → `TextField`. Removed the iOS-15/16 `#available` split (only existed to hide `TextEditor`'s scroll background).

**UI test migration** (consequence of TextEditor → TextField):
- `JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift`, `CollectionFieldSearchFilterTests.swift`, `ChangeUITests/OnChangeHandlerUITests.swift` — 18 lookups switched from `app.textViews[\"EditRowsTextFieldIdentifier\"]` to `app.textFields[...]`. Table tests already used `textFields` and stay.

**Example app — Changelog screen refactor** (DX, not SDK):
- `JoyfillSwiftUIExample/JoyfillExample/ChangeManager.swift` — replaced `displayedChangelogs: [String]` with structured `displayedEntries: [ChangelogEntry]`. One `onChange` call (even bulk with N changes) is now one entry.
- `JoyfillSwiftUIExample/JoyfillExample/ChangelogView.swift` — rewritten: kind badges, summary line, expandable detail with structured key/value pairs and a raw-JSON toggle, kind filter chips, search box, copy/export menu, toast.
- `FormContainerView.swift` / `UserAccessTokenTextFieldView.swift` — badge counters updated to read the new property.

## 3. Implementation decisions

- **Why use `TableTextRowFormView` for table too?** The collection form already used it correctly with focus/blur emission and an `onChange(of: text)`-only `didChange` path. The table form had a parallel custom binding whose setter fired `bulkEdit` on every render-driven refresh — root cause of the spurious rowUpdates. Unifying onto one component fixes the bug and removes a code-path divergence.
- **Why `TextField` and not `TextEditor`?** Row form cells are conceptually single-line. `TextEditor` shipped a built-in scroll background that needed `scrollContentBackground(.hidden)` (iOS 16+) plus a `UITextView.appearance()` workaround for iOS 15 — only ever there to make `TextEditor` look like a `TextField`. `TextField` removes the iOS version split entirely.
- **Why combine bulk-emit changes into one changelog card?** A single `onChange(changes:document:)` call is one event from the SDK's perspective; rendering each `Change` in the array as a separate UI card was misleading and made bulk-edit testing tedious. The new entry preserves the array internally (`items: [[String: Any]]`) and shows `×N` on the card.
- **Why a structured changelog type?** A `[String]` of pre-formatted JSON blobs forces every consumer to re-parse to filter, summarize, or group. A typed `ChangelogEntry { kind, timestamp, items }` makes the UI cheap and accurate, and the `copyText` computed property keeps the copy/export output unchanged.

## 4. Screenshot / video

Before vs after of the example app's changelog screen, plus a recording of the row form focus flow showing no spurious events, will be attached as a follow-up comment. Not embedded here because the change spans behavior + UI and a single still doesn't capture it.

## 5. Public API / docs

No public API change.
- `ChangeManager.displayedChangelogs: [String]` → `displayedEntries: [ChangelogEntry]` is an **example-app internal** property — not part of the SDK surface.
- `TableTextRowFormView` is internal to `JoyfillUI`.
- No SDK type, public method, or callback signature changed.
- No docs update needed.

## 6. Tests

- **UI tests:** 18 lookups migrated as part of this PR; selectors compile and resolve against the new element type. UI test suite has **not** been re-run end-to-end yet — any collection test that typed strings containing `\\n` into this cell may now assert against truncated text (`TextField` strips newlines). I'll flag specific failures and fix on the test side; the production behavior change is intentional.
- **Unit tests:** No SDK-level behavior changed in a way that requires new unit tests (the fix is wiring/binding, not logic). The existing `OnChangeHandlerUITests` covers the rowUpdate emission count end-to-end.
- **Manual:** verified focus → 1 `focus` event, 0 `rowUpdate`; typing → one `rowUpdate` per change as before; blur → 1 `blur` event.

## 7. Notes for reviewer

- **iOS 15 compatibility:** removing the `#available(iOS 16.0, *)` branch is safe — that branch only chose between two `TextEditor` variants. `TextField` works identically on iOS 15+.
- **Single-line input is a real UX change.** Row-form text cells can no longer accept `\\n`. If any customer JSON has pre-existing newlines in text-cell values, SwiftUI will display them collapsed when the user edits — the underlying value is unchanged unless the user types over it.
- **`focusedColumnIndex` / `triggerInlineTextFocus()` removed** because they were only bound to the now-deleted `TextField`'s `.focused(...)`. Auto-focus on form open continues to work via the existing `navigationFocusColumnId` environment value that `TableTextRowFormView.autoFocusIfNeeded()` reads on appear.