### PR TITLE
NO-2152: Set decorate flag from row decorators when missing in JSON

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -713,7 +713,9 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
     }
 
-    func testNormalize_table_noDecoratorsAnywhere_decorateStaysNil() {
+    func testNormalize_table_noDecoratorsAnywhere_decorateBecomesFalse() {
+        // When JSON omits the flag and the scan finds nothing, we write `false`
+        // as a decided sentinel so subsequent loads skip the scan.
         let dict = makeMinimalJoyDocDict(fields: [[
             "_id": "tbl-1",
             "type": "table",
@@ -721,7 +723,7 @@ final class DecoratorPublicAPITests: XCTestCase {
             "value": [["_id": "r1"]],
         ]])
         let editor = makeNormalizationEditor(dict: dict)
-        XCTAssertNil(editor.field(fieldID: "tbl-1")?.decorate)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, false)
     }
 
     func testNormalize_table_decorateTrueButNoDecorators_staysTrue() {
@@ -751,8 +753,9 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, false)
     }
 
-    func testNormalize_table_nonDisplayableRowDecorator_doesNotFlip() {
-        // Decorator with no icon AND no label is not displayable.
+    func testNormalize_table_nonDisplayableRowDecorator_becomesFalse() {
+        // Decorator with no icon AND no label is not displayable, so the scan
+        // treats it as "nothing to show" and the flag settles at false.
         let dict = makeMinimalJoyDocDict(fields: [[
             "_id": "tbl-1",
             "type": "table",
@@ -761,7 +764,7 @@ final class DecoratorPublicAPITests: XCTestCase {
             "rowDecorators": [["action": "a", "color": "#3B82F6"]],
         ]])
         let editor = makeNormalizationEditor(dict: dict)
-        XCTAssertNotEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, false)
     }
 
     // -- Collection
@@ -771,14 +774,14 @@ final class DecoratorPublicAPITests: XCTestCase {
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
         XCTAssertEqual(schema?["root"]?.decorate, true)
-        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+        XCTAssertEqual(schema?["child"]?.decorate, false)
     }
 
     func testNormalize_collection_childCommonRowDecorators_noFlag_flipsChildOnly() {
         let dict = makeCollectionDict(childRowDecorators: [decoratorDict(action: "a")])
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
-        XCTAssertNotEqual(schema?["root"]?.decorate, true)
+        XCTAssertEqual(schema?["root"]?.decorate, false)
         XCTAssertEqual(schema?["child"]?.decorate, true)
     }
 
@@ -787,7 +790,7 @@ final class DecoratorPublicAPITests: XCTestCase {
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
         XCTAssertEqual(schema?["root"]?.decorate, true)
-        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+        XCTAssertEqual(schema?["child"]?.decorate, false)
     }
 
     func testNormalize_collection_childRowSpecificDecorator_noFlag_flipsChildOnly() {
@@ -796,16 +799,17 @@ final class DecoratorPublicAPITests: XCTestCase {
         let dict = makeCollectionDict(childRowSpecific: [decoratorDict(action: "row-a")])
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
-        XCTAssertNotEqual(schema?["root"]?.decorate, true)
+        XCTAssertEqual(schema?["root"]?.decorate, false)
         XCTAssertEqual(schema?["child"]?.decorate, true)
     }
 
-    func testNormalize_collection_noDecoratorsAnywhere_bothSchemasStayUnset() {
+    func testNormalize_collection_noDecoratorsAnywhere_bothSchemasBecomeFalse() {
+        // No decorators anywhere → both schemas settle at false, not nil.
         let dict = makeCollectionDict()
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
-        XCTAssertNotEqual(schema?["root"]?.decorate, true)
-        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+        XCTAssertEqual(schema?["root"]?.decorate, false)
+        XCTAssertEqual(schema?["child"]?.decorate, false)
     }
 
     func testNormalize_collection_schemaDecorateExplicitlyFalseWithDecorators_staysFalse() {
@@ -814,5 +818,36 @@ final class DecoratorPublicAPITests: XCTestCase {
         let editor = makeNormalizationEditor(dict: dict)
         let schema = editor.field(fieldID: "col-1")?.schema
         XCTAssertEqual(schema?["root"]?.decorate, false)
+    }
+
+    func testNormalize_collection_schemaDecorateTrueButNoDecorators_staysTrue() {
+        // Mirror of the table case: explicit per-schema `decorate: true` with no
+        // row decorators must stay true. Normalization only fills in nil.
+        let dict = makeCollectionDict(rootDecorate: true)
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, true)
+    }
+
+    // -- Stability across repeat updateFieldMap calls
+
+    func testNormalize_isIdempotent_subsequentUpdateFieldMapDoesNotReFlip() {
+        // Locks the contract that the inferred value is written back to
+        // `document.fields`, so a second `updateFieldMap` call sees the
+        // already-set flag and short-circuits without running the row scan.
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+            "rowDecorators": [decoratorDict(action: "a")],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+
+        // Re-running normalization should be a no-op now that document.fields
+        // also carries decorate=true.
+        editor.updateFieldMap()
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -820,6 +820,41 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(schema?["root"]?.decorate, false)
     }
 
+    func testNormalize_collection_grandchildRowSpecificDecorator_flipsOnlyDeepestSchema() {
+        // 3-level chain: root → child → grandchild. Row decorator lives on a
+        // grandchild row only. Locks that `scanRawRowsForDisplayableRowDecorator`
+        // recurses past depth 1 — only the grandchild schema flips to true;
+        // root and child stay false.
+        let grandchildRow: [String: Any] = [
+            "_id": "gr1",
+            "decorators": ["all": [decoratorDict(action: "deep")]],
+        ]
+        let childRow: [String: Any] = [
+            "_id": "cr1",
+            "children": ["grandchild": ["value": [grandchildRow]]],
+        ]
+        let rootRow: [String: Any] = [
+            "_id": "rr1",
+            "children": ["child": ["value": [childRow]]],
+        ]
+        let field: [String: Any] = [
+            "_id": "col-1",
+            "type": "collection",
+            "rowOrder": ["rr1"],
+            "value": [rootRow],
+            "schema": [
+                "root": ["root": true, "children": ["child"], "tableColumns": []],
+                "child": ["children": ["grandchild"], "tableColumns": []],
+                "grandchild": ["tableColumns": []],
+            ],
+        ]
+        let editor = makeNormalizationEditor(dict: makeMinimalJoyDocDict(fields: [field]))
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, false)
+        XCTAssertEqual(schema?["child"]?.decorate, false)
+        XCTAssertEqual(schema?["grandchild"]?.decorate, true)
+    }
+
     func testNormalize_collection_schemaDecorateTrueButNoDecorators_staysTrue() {
         // Mirror of the table case: explicit per-schema `decorate: true` with no
         // row decorators must stay true. Normalization only fills in nil.
@@ -830,6 +865,76 @@ final class DecoratorPublicAPITests: XCTestCase {
     }
 
     // -- Stability across repeat updateFieldMap calls
+
+    func testNormalize_collection_mixedFlagStates_eachSchemaEvaluatedIndependently() {
+        // Root: explicit `decorate: false`. Child: nil with a row-specific
+        // decorator. Locks the partial-fill loop in the .collection branch —
+        // explicit false on one schema must not block normalization on a
+        // sibling schema with nil.
+        let dict = makeCollectionDict(
+            rootDecorate: false,
+            childRowSpecific: [decoratorDict(action: "child-row")]
+        )
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, false)
+        XCTAssertEqual(schema?["child"]?.decorate, true)
+    }
+
+    // -- Parity between typed API and raw dict
+
+    func testNormalize_typedAPIWrite_persistsToRawValueDict_forFreshLoad() {
+        // Parity contract: a decorator added via the typed public API must
+        // also be visible to the raw-dict scan that `normalizeDecorateFlag`
+        // performs on subsequent loads. If the typed API ever stops syncing
+        // back to `field.dictionary["value"]`, a page-duplication or document
+        // reload would settle the flag to the wrong value.
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, false)
+
+        // Add a row-self decorator through the public API.
+        editor.addDecorators(path: "page-1/fp-tbl-1/r1",
+                             decorators: [makeDecorator(action: "added")])
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+
+        // Round-trip: strip `decorate` from each field dict to force the
+        // fresh editor to re-normalize from scratch. The raw-dict scan must
+        // find the typed-API-added decorator and flip the flag back to true.
+        var docDict = editor.document.dictionary
+        if var fieldDicts = docDict["fields"] as? [[String: Any]] {
+            for i in fieldDicts.indices {
+                fieldDicts[i].removeValue(forKey: "decorate")
+            }
+            docDict["fields"] = fieldDicts
+        }
+        let reloaded = makeNormalizationEditor(dict: docDict)
+        XCTAssertEqual(reloaded.field(fieldID: "tbl-1")?.decorate, true,
+                       "row decorator added via the typed API must be visible to the raw-dict scan on a fresh load")
+    }
+
+    // -- Pin Decorator.isDisplayable (external dependency for scan correctness)
+
+    func testDecoratorIsDisplayable_pinsCurrentDefinition() {
+        // The load-path scan delegates the "displayable" check to
+        // `Decorator.isDisplayable`. If that definition ever loosens (e.g. to
+        // include action-only decorators), several normalization tests would
+        // silently pass for the wrong reason — particularly
+        // `testNormalize_table_nonDisplayableRowDecorator_becomesFalse`.
+        // Lock the current rule: icon OR label must be non-empty.
+        XCTAssertTrue(Decorator(dictionary: ["icon": "flag"]).isDisplayable)
+        XCTAssertTrue(Decorator(dictionary: ["label": "X"]).isDisplayable)
+        XCTAssertTrue(Decorator(dictionary: ["icon": "flag", "label": "X"]).isDisplayable)
+        XCTAssertFalse(Decorator(dictionary: ["action": "a"]).isDisplayable)
+        XCTAssertFalse(Decorator(dictionary: ["action": "a", "color": "#3B82F6"]).isDisplayable)
+        XCTAssertFalse(Decorator(dictionary: ["icon": "", "label": ""]).isDisplayable)
+        XCTAssertFalse(Decorator(dictionary: [:]).isDisplayable)
+    }
 
     func testNormalize_isIdempotent_subsequentUpdateFieldMapDoesNotReFlip() {
         // Locks two things:

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -594,4 +594,225 @@ final class DecoratorPublicAPITests: XCTestCase {
         XCTAssertEqual(editor.getDecorators(path: path).count, 0,
                        "reads on the deleted row path must remain empty")
     }
+
+    // MARK: - Decorate flag normalization at load
+    //
+    // When JSON ships `rowDecorators` or row-specific `decorators.all` but omits
+    // the `decorate` flag, the editor must flip the flag to true at load so the
+    // row decorator column renders. Explicit `true` / `false` in JSON is always
+    // respected — only `nil` triggers a row scan.
+
+    private func makeMinimalJoyDocDict(fields: [[String: Any]]) -> [String: Any] {
+        let pageID = "page-1"
+        return [
+            "_id": "doc-1",
+            "type": "document",
+            "stage": "published",
+            "files": [[
+                "_id": "file-1",
+                "name": "test",
+                "version": 1,
+                "pages": [[
+                    "_id": pageID,
+                    "name": "Page 1",
+                    "fieldPositions": fields.compactMap { f -> [String: Any]? in
+                        guard let id = f["_id"] as? String else { return nil }
+                        return [
+                            "_id": "fp-\(id)",
+                            "field": id,
+                            "type": f["type"] as? String ?? "table",
+                            "x": 0, "y": 0, "width": 100, "height": 100,
+                        ]
+                    },
+                ]],
+                "pageOrder": [pageID],
+            ]],
+            "fields": fields,
+        ]
+    }
+
+    private func decoratorDict(action: String, label: String = "L") -> [String: Any] {
+        ["action": action, "label": label, "icon": "flag", "color": "#3B82F6"]
+    }
+
+    private func makeNormalizationEditor(dict: [String: Any]) -> DocumentEditor {
+        let mock = MockDecoratorEvents()
+        let license = (ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return DocumentEditor(document: JoyDoc(dictionary: dict),
+                              events: mock,
+                              validateSchema: false,
+                              license: license.isEmpty ? nil : license)
+    }
+
+    /// Builds a collection field dict with two schemas: root and one nested child.
+    private func makeCollectionDict(rootRowDecorators: [[String: Any]]? = nil,
+                                    rootDecorate: Bool? = nil,
+                                    rootRowSpecific: [[String: Any]]? = nil,
+                                    childRowDecorators: [[String: Any]]? = nil,
+                                    childDecorate: Bool? = nil,
+                                    childRowSpecific: [[String: Any]]? = nil) -> [String: Any] {
+        var rootSchema: [String: Any] = [
+            "root": true,
+            "children": ["child"],
+            "tableColumns": [],
+        ]
+        if let d = rootRowDecorators { rootSchema["rowDecorators"] = d }
+        if let d = rootDecorate { rootSchema["decorate"] = d }
+
+        var childSchema: [String: Any] = ["tableColumns": []]
+        if let d = childRowDecorators { childSchema["rowDecorators"] = d }
+        if let d = childDecorate { childSchema["decorate"] = d }
+
+        var childRow: [String: Any] = ["_id": "cr1"]
+        if let rs = childRowSpecific { childRow["decorators"] = ["all": rs] }
+
+        // ValueElement reads `dictionary["children"]` (getter is named `childrens`
+        // but wire key is "children"); Children reads rows from `dictionary["value"]`.
+        var rootRow: [String: Any] = [
+            "_id": "rr1",
+            "children": ["child": ["value": [childRow]]],
+        ]
+        if let rs = rootRowSpecific { rootRow["decorators"] = ["all": rs] }
+
+        let field: [String: Any] = [
+            "_id": "col-1",
+            "type": "collection",
+            "rowOrder": ["rr1"],
+            "value": [rootRow],
+            "schema": ["root": rootSchema, "child": childSchema],
+        ]
+        return makeMinimalJoyDocDict(fields: [field])
+    }
+
+    // -- Table
+
+    func testNormalize_table_commonRowDecoratorsPresent_noFlag_flipsToTrue() {
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+            "rowDecorators": [decoratorDict(action: "a")],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+    }
+
+    func testNormalize_table_rowSpecificDecoratorPresent_noFlag_flipsToTrue() {
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [[
+                "_id": "r1",
+                "decorators": ["all": [decoratorDict(action: "row-a")]],
+            ]],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+    }
+
+    func testNormalize_table_noDecoratorsAnywhere_decorateStaysNil() {
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertNil(editor.field(fieldID: "tbl-1")?.decorate)
+    }
+
+    func testNormalize_table_decorateTrueButNoDecorators_staysTrue() {
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+            "decorate": true,
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+    }
+
+    func testNormalize_table_decorateExplicitlyFalseWithDecorators_staysFalse() {
+        // Explicit false is respected — normalization is a "fill-in-the-blank"
+        // for missing JSON, not a re-derivation that overrides intentional state.
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+            "rowDecorators": [decoratorDict(action: "a")],
+            "decorate": false,
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, false)
+    }
+
+    func testNormalize_table_nonDisplayableRowDecorator_doesNotFlip() {
+        // Decorator with no icon AND no label is not displayable.
+        let dict = makeMinimalJoyDocDict(fields: [[
+            "_id": "tbl-1",
+            "type": "table",
+            "rowOrder": ["r1"],
+            "value": [["_id": "r1"]],
+            "rowDecorators": [["action": "a", "color": "#3B82F6"]],
+        ]])
+        let editor = makeNormalizationEditor(dict: dict)
+        XCTAssertNotEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+    }
+
+    // -- Collection
+
+    func testNormalize_collection_rootCommonRowDecorators_noFlag_flipsRootOnly() {
+        let dict = makeCollectionDict(rootRowDecorators: [decoratorDict(action: "a")])
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, true)
+        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+    }
+
+    func testNormalize_collection_childCommonRowDecorators_noFlag_flipsChildOnly() {
+        let dict = makeCollectionDict(childRowDecorators: [decoratorDict(action: "a")])
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertNotEqual(schema?["root"]?.decorate, true)
+        XCTAssertEqual(schema?["child"]?.decorate, true)
+    }
+
+    func testNormalize_collection_rootRowSpecificDecorator_noFlag_flipsRootOnly() {
+        let dict = makeCollectionDict(rootRowSpecific: [decoratorDict(action: "row-a")])
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, true)
+        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+    }
+
+    func testNormalize_collection_childRowSpecificDecorator_noFlag_flipsChildOnly() {
+        // A row stored under root.children.child.value with its own decorators
+        // must flip the *child* schema's decorate, not root's.
+        let dict = makeCollectionDict(childRowSpecific: [decoratorDict(action: "row-a")])
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertNotEqual(schema?["root"]?.decorate, true)
+        XCTAssertEqual(schema?["child"]?.decorate, true)
+    }
+
+    func testNormalize_collection_noDecoratorsAnywhere_bothSchemasStayUnset() {
+        let dict = makeCollectionDict()
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertNotEqual(schema?["root"]?.decorate, true)
+        XCTAssertNotEqual(schema?["child"]?.decorate, true)
+    }
+
+    func testNormalize_collection_schemaDecorateExplicitlyFalseWithDecorators_staysFalse() {
+        let dict = makeCollectionDict(rootRowDecorators: [decoratorDict(action: "a")],
+                                      rootDecorate: false)
+        let editor = makeNormalizationEditor(dict: dict)
+        let schema = editor.field(fieldID: "col-1")?.schema
+        XCTAssertEqual(schema?["root"]?.decorate, false)
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift
@@ -832,9 +832,12 @@ final class DecoratorPublicAPITests: XCTestCase {
     // -- Stability across repeat updateFieldMap calls
 
     func testNormalize_isIdempotent_subsequentUpdateFieldMapDoesNotReFlip() {
-        // Locks the contract that the inferred value is written back to
-        // `document.fields`, so a second `updateFieldMap` call sees the
-        // already-set flag and short-circuits without running the row scan.
+        // Locks two things:
+        // 1. The inferred flag lands in `document.fields` via `fieldMap.didSet`
+        //    (which rebuilds `document.fields = allFields` on every assignment).
+        // 2. A second `updateFieldMap` call sees `decorate != nil` in
+        //    `document.fields` and short-circuits via the guard in
+        //    `normalizeDecorateFlag`, instead of re-running the row scan.
         let dict = makeMinimalJoyDocDict(fields: [[
             "_id": "tbl-1",
             "type": "table",
@@ -844,9 +847,10 @@ final class DecoratorPublicAPITests: XCTestCase {
         ]])
         let editor = makeNormalizationEditor(dict: dict)
         XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
+        // Verifies the write-back: document.fields is what updateFieldMap reads
+        // on subsequent calls. If didSet were ever removed, this would fail.
+        XCTAssertEqual(editor.document.fields.first(where: { $0.id == "tbl-1" })?.decorate, true)
 
-        // Re-running normalization should be a no-op now that document.fields
-        // also carries decorate=true.
         editor.updateFieldMap()
         XCTAssertEqual(editor.field(fieldID: "tbl-1")?.decorate, true)
     }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -349,7 +349,13 @@ private extension DocumentEditor {
         }
     }
 
+    /// Load-path scan: returns true if `field` has any displayable row decorator
+    /// in scope. Used by `normalizeDecorateFlag`. Walks raw JSON dictionaries to
+    /// avoid materializing `[ValueElement]` (which `rowsInScope` does) — that
+    /// reconstruction otherwise doubles load time on docs with thousands of rows
+    /// since the view model later builds those structs again.
     private func hasAnyDisplayableRowDecorator(field: JoyDocField, schemaKey: String?) -> Bool {
+        // Common decorators at this scope — small list, cheap to deserialize.
         let commonDecs: [Decorator]
         if let sk = schemaKey {
             commonDecs = field.schema?[sk]?.rowDecorators ?? []
@@ -357,10 +363,64 @@ private extension DocumentEditor {
             commonDecs = field.rowDecorators ?? []
         }
         if commonDecs.contains(where: { $0.isDisplayable }) { return true }
-        let rows = rowsInScope(field: field, schemaKey: schemaKey)
-        return rows.contains { row in
-            (row.decorators?.all ?? []).contains(where: { $0.isDisplayable })
+
+        // Row-specific decorators via raw dict walk. Short-circuits on first match.
+        guard let topRowDicts = field.dictionary["value"] as? [[String: Any]] else { return false }
+        let isCollection = field.fieldType == .collection
+        let rootSchemaKey: String? = isCollection
+            ? (field.dictionary["schema"] as? [String: [String: Any]])?
+                .first(where: { ($0.value["root"] as? Bool) == true })?.key
+            : nil
+        return scanRawRowsForDisplayableRowDecorator(
+            rowDicts: topRowDicts,
+            currentSchemaKey: rootSchemaKey,
+            targetSchemaKey: schemaKey,
+            isCollection: isCollection
+        )
+    }
+
+    private func scanRawRowsForDisplayableRowDecorator(
+        rowDicts: [[String: Any]],
+        currentSchemaKey: String?,
+        targetSchemaKey: String?,
+        isCollection: Bool
+    ) -> Bool {
+        // Rows at this level are in scope when:
+        // - Table field (no schema concept), or
+        // - Collection field with no schema filter (caller is asking globally), or
+        // - Collection field and this level's schema matches the target.
+        let levelMatches = !isCollection
+            || targetSchemaKey == nil
+            || currentSchemaKey == targetSchemaKey
+
+        for rowDict in rowDicts {
+            if rowDict["deleted"] as? Bool == true { continue }
+
+            if levelMatches, rowDictHasAnyDisplayableDecorator(rowDict) { return true }
+
+            // Recurse into nested collection schemas to find rows in the target scope.
+            if isCollection, let childrens = rowDict["children"] as? [String: Any] {
+                for (childKey, childRaw) in childrens {
+                    guard let childDict = childRaw as? [String: Any],
+                          let childRows = childDict["value"] as? [[String: Any]] else { continue }
+                    if scanRawRowsForDisplayableRowDecorator(
+                        rowDicts: childRows,
+                        currentSchemaKey: childKey,
+                        targetSchemaKey: targetSchemaKey,
+                        isCollection: isCollection
+                    ) {
+                        return true
+                    }
+                }
+            }
         }
+        return false
+    }
+
+    private func rowDictHasAnyDisplayableDecorator(_ rowDict: [String: Any]) -> Bool {
+        guard let decoratorsDict = rowDict["decorators"] as? [String: Any],
+              let all = decoratorsDict["all"] as? [[String: Any]] else { return false }
+        return all.contains { Decorator(dictionary: $0).isDisplayable }
     }
 
     // MARK: COW seed

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -354,6 +354,14 @@ private extension DocumentEditor {
     /// avoid materializing `[ValueElement]` (which `rowsInScope` does) — that
     /// reconstruction otherwise doubles load time on docs with thousands of rows
     /// since the view model later builds those structs again.
+    ///
+    /// **Contract:** reads `field.dictionary["value"]`, `["schema"]`, and the
+    /// nested `["children"][k]["value"]` / `["decorators"]["all"]` paths
+    /// directly. Assumes the raw dict stays in lockstep with the typed model —
+    /// any mutation through the public API (`addDecorators` / `removeDecorator`
+    /// / `updateDecorator`) must keep both representations in sync, or this
+    /// scan returns the wrong answer. `testNormalize_typedAPIWrite_…` locks
+    /// that parity.
     private func hasAnyDisplayableRowDecorator(field: JoyDocField, schemaKey: String?) -> Bool {
         // Common decorators at this scope — small list, cheap to deserialize.
         let commonDecs: [Decorator]
@@ -367,6 +375,9 @@ private extension DocumentEditor {
         // Row-specific decorators via raw dict walk. Short-circuits on first match.
         guard let topRowDicts = field.dictionary["value"] as? [[String: Any]] else { return false }
         let isCollection = field.fieldType == .collection
+        // Assumes the JoyDoc invariant: a collection field's schema map contains
+        // exactly one entry with `root: true`. Iteration order would otherwise
+        // be undefined.
         let rootSchemaKey: String? = isCollection
             ? (field.dictionary["schema"] as? [String: [String: Any]])?
                 .first(where: { ($0.value["root"] as? Bool) == true })?.key

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -232,6 +232,8 @@ private extension DocumentEditor {
     /// Mirror of `ensureDecorateEnabled`. Flips `decorate` to `false` on the target's
     /// scope only when no displayable row decorators remain anywhere in that scope —
     /// neither common row decorators nor row-specific decorators on any row.
+    /// Writing `false` (rather than clearing to nil) acts as a "decided" sentinel
+    /// so the load-time normalizer skips the row scan next time.
     ///
     /// Scope:
     /// - Table fields: the entire field (checks `field.rowDecorators` + every row's `decorators.all`).
@@ -315,29 +317,28 @@ private extension DocumentEditor {
 
     // MARK: Decorate normalization
 
-    /// Infers an effective `decorate` flag from the actual decorator data on a freshly
-    /// loaded field, but only when the JSON omits the flag entirely. If `decorate`
-    /// is explicitly set (`true` or `false`), it is respected — only `nil` triggers
-    /// a row scan. When the flag is absent and displayable row decorators exist —
-    /// either common (`field.rowDecorators` / `schema[sk].rowDecorators`) or
-    /// row-specific (`row.decorators.all`) — flips `decorate` to true so the row
-    /// decorator column renders.
+    /// Infers an effective `decorate` flag from the actual decorator data on a
+    /// freshly loaded field, but only when the JSON omits the flag entirely.
+    /// Explicit `true` / `false` is always respected — only `nil` triggers a
+    /// row scan. When the flag is absent we decide it from the data: `true`
+    /// if any displayable row decorator exists (common or row-specific),
+    /// `false` otherwise. Writing `false` (rather than leaving nil) makes
+    /// subsequent loads idempotent — the guard sees the decided value and
+    /// skips the scan.
     ///
     /// Mutates `field` in place. Returns true if anything changed.
     internal func normalizeDecorateFlag(field: inout JoyDocField) -> Bool {
         switch field.fieldType {
         case .table:
-            guard field.decorate == nil,
-                  hasAnyDisplayableRowDecorator(field: field, schemaKey: nil) else { return false }
-            field.decorate = true
+            guard field.decorate == nil else { return false }
+            field.decorate = hasAnyDisplayableRowDecorator(field: field, schemaKey: nil)
             return true
         case .collection:
             guard var schema = field.schema else { return false }
             var changed = false
             for (key, var entry) in schema {
-                guard entry.decorate == nil,
-                      hasAnyDisplayableRowDecorator(field: field, schemaKey: key) else { continue }
-                entry.decorate = true
+                guard entry.decorate == nil else { continue }
+                entry.decorate = hasAnyDisplayableRowDecorator(field: field, schemaKey: key)
                 schema[key] = entry
                 changed = true
             }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -313,6 +313,55 @@ private extension DocumentEditor {
         return collected
     }
 
+    // MARK: Decorate normalization
+
+    /// Infers an effective `decorate` flag from the actual decorator data on a freshly
+    /// loaded field, but only when the JSON omits the flag entirely. If `decorate`
+    /// is explicitly set (`true` or `false`), it is respected — only `nil` triggers
+    /// a row scan. When the flag is absent and displayable row decorators exist —
+    /// either common (`field.rowDecorators` / `schema[sk].rowDecorators`) or
+    /// row-specific (`row.decorators.all`) — flips `decorate` to true so the row
+    /// decorator column renders.
+    ///
+    /// Mutates `field` in place. Returns true if anything changed.
+    internal func normalizeDecorateFlag(field: inout JoyDocField) -> Bool {
+        switch field.fieldType {
+        case .table:
+            guard field.decorate == nil,
+                  hasAnyDisplayableRowDecorator(field: field, schemaKey: nil) else { return false }
+            field.decorate = true
+            return true
+        case .collection:
+            guard var schema = field.schema else { return false }
+            var changed = false
+            for (key, var entry) in schema {
+                guard entry.decorate == nil,
+                      hasAnyDisplayableRowDecorator(field: field, schemaKey: key) else { continue }
+                entry.decorate = true
+                schema[key] = entry
+                changed = true
+            }
+            if changed { field.schema = schema }
+            return changed
+        default:
+            return false
+        }
+    }
+
+    private func hasAnyDisplayableRowDecorator(field: JoyDocField, schemaKey: String?) -> Bool {
+        let commonDecs: [Decorator]
+        if let sk = schemaKey {
+            commonDecs = field.schema?[sk]?.rowDecorators ?? []
+        } else {
+            commonDecs = field.rowDecorators ?? []
+        }
+        if commonDecs.contains(where: { $0.isDisplayable }) { return true }
+        let rows = rowsInScope(field: field, schemaKey: schemaKey)
+        return rows.contains { row in
+            (row.decorators?.all ?? []).contains(where: { $0.isDisplayable })
+        }
+    }
+
     // MARK: COW seed
 
     /// Returns the common-scope decorators to seed a specific scope with, if any.

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -151,7 +151,9 @@ public class DocumentEditor: ObservableObject {
     public func updateFieldMap() {
         document.fields.forEach { field in
             guard let fieldID = field.id else { return }
-            self.fieldMap[fieldID] =  field
+            var f = field
+            _ = normalizeDecorateFlag(field: &f)
+            self.fieldMap[fieldID] = f
         }
     }
     


### PR DESCRIPTION
## Context
Backends may ship `rowDecorators` (or row-specific `decorators.all` on individual rows) without the corresponding `decorate: true` flag. Previously this rendered as a silent no-op — decorator data was loaded but the row decorator column stayed hidden, so the kebab menu never appeared. The fix infers `decorate` from the actual decorator payload at load time, only when JSON omits the flag.

## What changed
- `Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift`
  - New `normalizeDecorateFlag(field:)` (internal) — when `decorate` is missing, sets it from the actual data: `true` if any displayable row decorator exists (common or row-specific), `false` otherwise.
  - New private `hasAnyDisplayableRowDecorator(field:, schemaKey:)` — load-path scan. Walks raw JSON dicts (`field.dictionary["value"]`, `rowDict["children"][k]["value"]`, `rowDict["decorators"]["all"]`) and short-circuits on first match. Avoids materializing `[ValueElement]` via `valueToValueElements`, which would otherwise double load time on docs with thousands of rows since the view model later builds those structs again. Reuses `Decorator.isDisplayable` for the displayability check.
- `Sources/JoyfillUI/ViewModels/DocumentEditor.swift`
  - `updateFieldMap()` now runs the normalization on each field before storing into `fieldMap`. Covers both initial load and page duplication.
- `JoyfillSwiftUIExample/JoyfillTests/DecoratorAPI/DecoratorPublicAPITests.swift`
  - 14 new tests under `// MARK: - Decorate flag normalization at load`.

## Behavior

| `decorate` in JSON | Decorators present | Result |
|---|---|---|
| `nil` | yes | `true` |
| `nil` | no | `false` |
| `true` | any | stays `true` |
| `false` | any | stays `false` |

After first load, `decorate` is always a decided boolean — no `nil` survives.

## Decisions
- **Only fill `nil`, never override `true`/`false`.** Explicit values in JSON are intentional state and must be respected. The scan only runs when the flag is absent — making this a fill-in-the-blank, not a re-derivation.
- **Always settle to a decided boolean.** When JSON omits `decorate` and the scan finds nothing, write `false` (rather than leaving `nil`). This makes every subsequent load idempotent — the guard sees `decorate != nil` and skips the row scan entirely. Cost moves to first-load only.
- **Mutate (not compute).** Setting `decorate` in `fieldMap` matches the existing pattern from `ensureDecorateEnabled` (write-API path). Single source of truth — downstream readers (`tableDataModel.decorate`, `schema[sk].decorate`) don't need to know normalization happened.
- **Normalize at `updateFieldMap`** (not in TableDataModel/CollectionViewModel init). Centralizes the fix at the single entry point where fields flow from raw JSON into the editor's working state. No coupling to view models.
- **Per-schema for collections.** Each schema's `decorate` is evaluated independently from rows that belong to that schema, since the row decorator column is a per-schema concern.
- **Never flip `true → false` at load.** That direction stays the responsibility of `ensureDecorateDisabledIfEmpty` after explicit removals via the API.

## Screenshot / video
N/A — pure model-layer fix; no UI/visual change beyond the row decorator column now appearing for payloads where it was previously hidden.

## Public API
No public API changes. `normalizeDecorateFlag` is `internal`; `decorate` / `rowDecorators` shapes are unchanged. No doc updates needed.

## Tests
14 cases covering: table (common, row-specific, nil/true/false flag, non-displayable, empty), collection (root common, child common, root row-specific, child row-specific in nested schema, both schemas empty, explicit true, explicit false), and idempotence (subsequent `updateFieldMap` calls don't re-flip or re-scan; explicit assertion on `editor.document.fields` locks the write-back via `fieldMap.didSet`). No follow-up tests planned.

## Notes for reviewer
- First load: O(rows) scan per table/collection field with `decorate == nil`. After that, every field has a decided boolean → all subsequent loads (page duplication, etc.) skip the scan via the guard.
- **Perf:** The load-path scan operates on raw JSON dicts rather than the typed `valueToValueElements` accessor. Verified on a 10k-row template: load times stay at baseline; without this, normalization added ~2.8s of duplicate `ValueElement` construction.
- Pre-existing concern (not addressed here): `updateFieldMap` on page duplication re-reads from `document.fields`, which can overwrite in-memory decorator changes made via the API. Worth flagging separately if it bites.