### PR TITLE
NO-2182 Fix changeAPI date clearing sync

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
@@ -2393,6 +2393,65 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
         let dateButton2 = getDateFieldButtonByIndexAndIdentifier(0)
         XCTAssertEqual(dateButton2.label, convertedTime, "Datetime should be same after epoch convert")
     }
+
+    func testDateFieldClearSyncsAcrossMirroredViews() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            return
+        }
+
+        let pageSelectionButton = app.buttons.matching(identifier: "PageNavigationIdentifier")
+        let pageSheetSelectionButton = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        let firstPageNavigationButton = pageSelectionButton.element(boundBy: 0)
+        let secondPageNavigationButton = pageSelectionButton.element(boundBy: 1)
+        let pageSelectionItem = pageSheetSelectionButton.element(boundBy: 2)
+
+        XCTAssertTrue(firstPageNavigationButton.waitForExistence(timeout: 5), "First page navigation button not found")
+        firstPageNavigationButton.tap()
+        XCTAssertTrue(pageSelectionItem.waitForExistence(timeout: 5), "Page 3 selection item not found")
+        pageSelectionItem.tap()
+
+        XCTAssertTrue(secondPageNavigationButton.waitForExistence(timeout: 5), "Second page navigation button not found")
+        secondPageNavigationButton.tap()
+        XCTAssertTrue(pageSelectionItem.waitForExistence(timeout: 5), "Page 3 selection item not found")
+        pageSelectionItem.tap()
+
+        let emptyDatePlaceholders = self.app.staticTexts.matching(NSPredicate(format: "label == %@", "Select a Date -"))
+        XCTAssertTrue(
+            waitUntil(5) { emptyDatePlaceholders.count == 2 },
+            "Expected both mirrored empty date fields to be visible on page 3"
+        )
+
+        let leftDateField = emptyDatePlaceholders.element(boundBy: 0)
+        leftDateField.tap()
+
+        let mirroredDateButtons = self.app.buttons.matching(identifier: "ChangeDateIdentifier")
+        XCTAssertTrue(
+            waitUntil(5) { mirroredDateButtons.count == 2 },
+            "Expected setting the left-side date to mirror to the right side"
+        )
+
+        let leftDateButton = mirroredDateButtons.element(boundBy: 0)
+        let rightDateButton = mirroredDateButtons.element(boundBy: 1)
+        XCTAssertEqual(leftDateButton.label, rightDateButton.label, "Mirrored date value should match on both sides")
+
+        let clearButtons = self.app.buttons.matching(identifier: "DateClearIdentifier")
+        XCTAssertTrue(
+            waitUntil(5) { clearButtons.count == 2 },
+            "Expected both mirrored date fields to expose a clear button"
+        )
+
+        clearButtons.element(boundBy: 0).tap()
+
+        XCTAssertTrue(
+            waitUntil(5) { self.app.buttons.matching(identifier: "ChangeDateIdentifier").count == 0 },
+            "Expected clearing the left-side date to remove the mirrored date value on the right side"
+        )
+
+        XCTAssertTrue(
+            waitUntil(5) { emptyDatePlaceholders.count == 2 },
+            "Expected both mirrored date fields to show the empty placeholder after clearing"
+        )
+    }
     
     func testSignatureField() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else {

--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -111,12 +111,13 @@ struct DateTimeView: View {
         }
         .onChange(of: dateTimeDataModel.value) { newValue in
             if lastModelValue != newValue {
-                if let value = newValue {
+                if let value = newValue, !value.nullOrEmpty {
                     let dateString = value.dateTime(format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) ?? ""
                     if let date = Utility.stringToDate(dateString, format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) {
                         selectedDate = date
                     }
                 } else {
+                    self.dateString = ""
                     ignoreOnChangeOnModelUpdate = true
                     selectedDate = Date()
                 }


### PR DESCRIPTION
## Context
NO-2182 fixes the changeAPI date-field sync path: when one mirrored date field is cleared, the null model update should clear every rendered instance instead of leaving a stale formatted date.

## Changed
- `Sources/JoyfillUI/View/Fields/DateTimeView.swift`: treats null/empty values as cleared state, resets `dateString`, and avoids re-emitting `onChange` from model-driven clears.
- `JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift`: adds an iPad UI regression test that sets a mirrored date and verifies clearing one side clears both.

## Decisions
- Used `ValueUnion.nullOrEmpty` before parsing because clear events arrive as null/empty model updates, not valid timestamps.
- Reset `selectedDate` behind `ignoreOnChangeOnModelUpdate` so the UI returns to the placeholder without creating another changeAPI event.

## Validation
- Added coverage for date set/clear sync across mirrored views.
- Not run locally in this session; this should run in the existing Xcode UITest pipeline.

## Media
- No screenshot/video attached; this is state-sync behavior and the new UI test demonstrates the visible before/after.

## API / Docs
- No public API change.
- No docs update needed.

## Reviewer Notes
- Focus review on null/empty date handling and ensuring mirrored date fields do not keep stale labels after clear.
