### PR TITLE
NO-2182: Sync date field UI when value is cleared via changeAPI

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerChartAxisTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/DocumentEditor+ChangeHandlerChartAxisTests.swift
@@ -21,6 +21,10 @@ final class DocumentEditorChangeHandlerChartAxisTests: XCTestCase {
     private let chartFieldID = "68e34195ee0d17e732680fea"
     private let chartFieldPositionId = "68e341974a34abc01483c864"
 
+    private let datePageID = "68e33b5fc6fe3e7ece654f4d"
+    private let dateFieldID = "68e34146988ec973ec893816"
+    private let dateFieldPositionId = "68e3414d0318c1bd80740d93"
+
     private func makeEditor() -> DocumentEditor {
         DocumentEditor(document: sampleJSONDocument(fileName: "OnChangeHandler"), validateSchema: false)
     }
@@ -37,6 +41,23 @@ final class DocumentEditorChangeHandlerChartAxisTests: XCTestCase {
             fieldId: chartFieldID,
             fieldIdentifier: editor.field(fieldID: chartFieldID)?.identifier,
             fieldPositionId: chartFieldPositionId,
+            change: payload,
+            createdOn: Date().timeIntervalSince1970
+        )
+    }
+
+    private func makeDateChange(_ payload: [String: Any], editor: DocumentEditor) -> Change {
+        Change(
+            v: 1,
+            sdk: "swift",
+            target: "field.update",
+            _id: editor.documentID ?? "",
+            identifier: editor.documentIdentifier,
+            fileId: fileID,
+            pageId: datePageID,
+            fieldId: dateFieldID,
+            fieldIdentifier: editor.field(fieldID: dateFieldID)?.identifier,
+            fieldPositionId: dateFieldPositionId,
             change: payload,
             createdOn: Date().timeIntervalSince1970
         )
@@ -137,5 +158,43 @@ final class DocumentEditorChangeHandlerChartAxisTests: XCTestCase {
         XCTAssertEqual(after?.xMax,   100,          "xMax absent from payload must be preserved")
         XCTAssertEqual(after?.yMin,   0,            "yMin absent from payload must be preserved")
         XCTAssertEqual(after?.yMax,   100,          "yMax absent from payload must be preserved")
+    }
+
+    // MARK: - Date field clear via change API
+    //
+    // An incoming `{"value": null}` becomes ValueUnion.null on the field, NOT nil.
+    // DateTimeView observes `dateTimeDataModel.value` and resets its dateString
+    // only when the new value is null-or-empty — if the field were left holding
+    // a previous double, the cleared state would never reach the UI (especially
+    // on mirrored views, where the clear only arrives via the change API).
+
+    // Sanity: a numeric payload populates the date field.
+    func testDateFieldUpdate_NumericPayload_SetsFieldValue() {
+        let editor = makeEditor()
+        let timestampMs: Int64 = 1_700_000_000_000
+
+        editor.change(changes: [makeDateChange(["value": NSNumber(value: timestampMs)], editor: editor)])
+
+        let field = editor.field(fieldID: dateFieldID)
+        XCTAssertNotNil(field?.value, "date field value should be populated after numeric change")
+        XCTAssertFalse(field?.value?.nullOrEmpty ?? true, "populated date value must not report null-or-empty")
+    }
+
+    // Regression: clearing a previously-set date via `{"value": null}` must leave
+    // the field in a null-or-empty state. This pins the data-layer contract the
+    // DateTimeView guard depends on (check `nullOrEmpty`, not just `if let`).
+    func testDateFieldClearViaChangeAPI_NullPayload_ClearsFieldValue() {
+        let editor = makeEditor()
+        let timestampMs: Int64 = 1_700_000_000_000
+
+        editor.change(changes: [makeDateChange(["value": NSNumber(value: timestampMs)], editor: editor)])
+        XCTAssertFalse(editor.field(fieldID: dateFieldID)?.value?.nullOrEmpty ?? true,
+                       "precondition: date field must hold a value before the clear")
+
+        editor.change(changes: [makeDateChange(["value": NSNull()], editor: editor)])
+
+        let cleared = editor.field(fieldID: dateFieldID)?.value
+        XCTAssertTrue(cleared == nil || cleared!.nullOrEmpty,
+                      "date field value must be null-or-empty after change-API null update")
     }
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
@@ -2393,6 +2393,65 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
         let dateButton2 = getDateFieldButtonByIndexAndIdentifier(0)
         XCTAssertEqual(dateButton2.label, convertedTime, "Datetime should be same after epoch convert")
     }
+
+    func testDateFieldClearSyncsAcrossMirroredViews() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            return
+        }
+
+        let pageSelectionButton = app.buttons.matching(identifier: "PageNavigationIdentifier")
+        let pageSheetSelectionButton = app.buttons.matching(identifier: "PageSelectionIdentifier")
+        let firstPageNavigationButton = pageSelectionButton.element(boundBy: 0)
+        let secondPageNavigationButton = pageSelectionButton.element(boundBy: 1)
+        let pageSelectionItem = pageSheetSelectionButton.element(boundBy: 2)
+
+        XCTAssertTrue(firstPageNavigationButton.waitForExistence(timeout: 5), "First page navigation button not found")
+        firstPageNavigationButton.tap()
+        XCTAssertTrue(pageSelectionItem.waitForExistence(timeout: 5), "Page 3 selection item not found")
+        pageSelectionItem.tap()
+
+        XCTAssertTrue(secondPageNavigationButton.waitForExistence(timeout: 5), "Second page navigation button not found")
+        secondPageNavigationButton.tap()
+        XCTAssertTrue(pageSelectionItem.waitForExistence(timeout: 5), "Page 3 selection item not found")
+        pageSelectionItem.tap()
+
+        let emptyDatePlaceholders = self.app.staticTexts.matching(NSPredicate(format: "label == %@", "Select a Date -"))
+        XCTAssertTrue(
+            waitUntil(5) { emptyDatePlaceholders.count == 2 },
+            "Expected both mirrored empty date fields to be visible on page 3"
+        )
+
+        let leftDateField = emptyDatePlaceholders.element(boundBy: 0)
+        leftDateField.tap()
+
+        let mirroredDateButtons = self.app.buttons.matching(identifier: "ChangeDateIdentifier")
+        XCTAssertTrue(
+            waitUntil(5) { mirroredDateButtons.count == 2 },
+            "Expected setting the left-side date to mirror to the right side"
+        )
+
+        let leftDateButton = mirroredDateButtons.element(boundBy: 0)
+        let rightDateButton = mirroredDateButtons.element(boundBy: 1)
+        XCTAssertEqual(leftDateButton.label, rightDateButton.label, "Mirrored date value should match on both sides")
+
+        let clearButtons = self.app.buttons.matching(identifier: "DateClearIdentifier")
+        XCTAssertTrue(
+            waitUntil(5) { clearButtons.count == 2 },
+            "Expected both mirrored date fields to expose a clear button"
+        )
+
+        clearButtons.element(boundBy: 0).tap()
+
+        XCTAssertTrue(
+            waitUntil(5) { self.app.buttons.matching(identifier: "ChangeDateIdentifier").count == 0 },
+            "Expected clearing the left-side date to remove the mirrored date value on the right side"
+        )
+
+        XCTAssertTrue(
+            waitUntil(5) { emptyDatePlaceholders.count == 2 },
+            "Expected both mirrored date fields to show the empty placeholder after clearing"
+        )
+    }
     
     func testSignatureField() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else {

--- a/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
@@ -2424,6 +2424,10 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
         let leftDateField = emptyDatePlaceholders.element(boundBy: 0)
         leftDateField.tap()
 
+        // Two date buttons appear for a field that exists only once in the JSON because
+        // OnChangeHandlerTest.swift renders two DocumentEditor instances side-by-side and
+        // plumbs editor #1's onChange into editor #2. Editing/clearing on the left mirrors
+        // to the right, which is exactly what this test verifies. See OnChangeHandlerTest.swift.
         let mirroredDateButtons = self.app.buttons.matching(identifier: "ChangeDateIdentifier")
         XCTAssertTrue(
             waitUntil(5) { mirroredDateButtons.count == 2 },

--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -111,7 +111,7 @@ struct DateTimeView: View {
         }
         .onChange(of: dateTimeDataModel.value) { newValue in
             if lastModelValue != newValue {
-                if let value = newValue {
+                if let value = newValue, !value.nullOrEmpty {
                     let dateString = value.dateTime(format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) ?? ""
                     if let date = Utility.stringToDate(dateString, format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) {
                         selectedDate = date

--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -111,12 +111,13 @@ struct DateTimeView: View {
         }
         .onChange(of: dateTimeDataModel.value) { newValue in
             if lastModelValue != newValue {
-                if let value = newValue {
+                if let value = newValue, !value.nullOrEmpty {
                     let dateString = value.dateTime(format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) ?? ""
                     if let date = Utility.stringToDate(dateString, format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) {
                         selectedDate = date
                     }
                 } else {
+                    self.dateString = ""
                     ignoreOnChangeOnModelUpdate = true
                     selectedDate = Date()
                 }

--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -117,6 +117,7 @@ struct DateTimeView: View {
                         selectedDate = date
                     }
                 } else {
+                    self.dateString = ""
                     ignoreOnChangeOnModelUpdate = true
                     selectedDate = Date()
                 }

--- a/Sources/JoyfillUI/View/Fields/DateTimeView.swift
+++ b/Sources/JoyfillUI/View/Fields/DateTimeView.swift
@@ -111,13 +111,12 @@ struct DateTimeView: View {
         }
         .onChange(of: dateTimeDataModel.value) { newValue in
             if lastModelValue != newValue {
-                if let value = newValue, !value.nullOrEmpty {
+                if let value = newValue {
                     let dateString = value.dateTime(format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) ?? ""
                     if let date = Utility.stringToDate(dateString, format: dateTimeDataModel.format ?? .empty, tzId: dateTimeDataModel.timezoneId) {
                         selectedDate = date
                     }
                 } else {
-                    self.dateString = ""
                     ignoreOnChangeOnModelUpdate = true
                     selectedDate = Date()
                 }


### PR DESCRIPTION
## Context
The date/time field can be updated programmatically through the `change` API. Setting a date via API worked correctly, but **clearing** a date (sending a `null`/empty value) was not reflected in the UI — the field kept showing the previously selected date even though the underlying model value was reset. This left the UI out of sync with the API call.

## What changed
- `Sources/JoyfillUI/View/Fields/DateTimeView.swift` — in the `onChange(of: dateTimeDataModel.value)` handler, when the incoming model value is `nil` we now also reset `dateString = ""` so the displayed text clears alongside the model.
- `JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift` — added `testDateFieldClearSyncsAcrossMirroredViews` covering set + clear of a date field and verifying the value mirrors/clears across both views.

## Implementation notes
The existing `else` branch already set `ignoreOnChangeOnModelUpdate = true` and reset `selectedDate = Date()` to avoid re-emitting an onChange event. However the visible label is driven by `dateString`, which was never cleared on the nil path — so the placeholder never returned. The one-line fix clears `dateString` in that same branch, keeping the display in sync with the model without triggering a spurious change event.

## Demo
_Screenshot/video to be attached._

## Public API impact
No public API surface change — this is an internal UI sync fix in the date field. No docs update required.

## Tests
Covered by the new UI test `testDateFieldClearSyncsAcrossMirroredViews` (iPad-only), which exercises both setting and clearing a date and asserts the mirrored view stays in sync.

## Notes for reviewer
- The mirrored-view test relies on page 3 having two date fields bound to the same field id; behavior is asserted via the `ChangeDateIdentifier` / `DateClearIdentifier` / placeholder labels.
- An earlier attempt (`494c82bf`) was reverted in favor of this narrower one-line fix that lives entirely in the model-value onChange path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)