### PR TITLE
NO-2184: Add decorator definitions to JSON validation schema

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -12,7 +12,7 @@ import Joyfill
 
 final class SchemaValidationTests: XCTestCase {
     /// The schema version expected in `SchemaValidationError.details`.
-    private let expectedSchemaVersion = "1.0.1"
+    private let expectedSchemaVersion = "1.0.4"
     private let sdkVersion = "3.0.0-rc19"
     
     func documentEditor(document: JoyDoc) -> DocumentEditor {

--- a/Sources/JoyfillUI/View/joyfill-schema.swift
+++ b/Sources/JoyfillUI/View/joyfill-schema.swift
@@ -419,6 +419,9 @@ public var joyfillSchema = """
           "columnTitlePadding": {
             "type": "number"
           },
+          "columnTitleTextOverflow": {
+            "type": "string"
+          },
           "titleDisplay": {
             "type": "string"
           },
@@ -676,6 +679,12 @@ public var joyfillSchema = """
           },
           "multi": {
             "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -783,6 +792,12 @@ public var joyfillSchema = """
           },
           "multi": {
             "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -883,6 +898,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -962,6 +983,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1041,6 +1068,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1128,6 +1161,12 @@ public var joyfillSchema = """
                 "const": ""
               }
             ]
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1221,6 +1260,12 @@ public var joyfillSchema = """
           },
           "format": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1300,6 +1345,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1382,6 +1433,12 @@ public var joyfillSchema = """
           },
           "signer": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1473,6 +1530,12 @@ public var joyfillSchema = """
           },
           "multi": {
             "type": "boolean"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1594,6 +1657,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1695,6 +1764,21 @@ public var joyfillSchema = """
             "items": {
               "type": "string"
             }
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          },
+          "rowDecorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          },
+          "decorate": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -1719,6 +1803,9 @@ public var joyfillSchema = """
           },
           "cells": {
             "type": "object"
+          },
+          "decorators": {
+            "$ref": "#/definitions/RowDecorators"
           }
         },
         "required": [
@@ -1784,6 +1871,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1821,6 +1914,12 @@ public var joyfillSchema = """
             "type": "array",
             "items": {
               "$ref": "#/definitions/Option"
+            }
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
             }
           }
         },
@@ -1863,6 +1962,12 @@ public var joyfillSchema = """
             "items": {
               "$ref": "#/definitions/Option"
             }
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1902,6 +2007,12 @@ public var joyfillSchema = """
           },
           "maxImageHeight": {
             "type": "number"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1934,6 +2045,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "number"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1966,6 +2083,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "number"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -1998,6 +2121,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2030,6 +2159,12 @@ public var joyfillSchema = """
           },
           "value": {
             "type": "string"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2066,6 +2201,12 @@ public var joyfillSchema = """
           },
           "maxImageHeight": {
             "type": "number"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2108,7 +2249,13 @@ public var joyfillSchema = """
           "identifier": {
             "type": "string"
           },
-          "value": {}
+          "value": {},
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          }
         },
         "required": [
           "_id",
@@ -2207,6 +2354,12 @@ public var joyfillSchema = """
           },
           "xMin": {
             "type": "number"
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2347,6 +2500,18 @@ public var joyfillSchema = """
             "items": {
               "$ref": "#/definitions/CollectionItem"
             }
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          },
+          "rowDecorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2389,6 +2554,15 @@ public var joyfillSchema = """
             "items": {
               "type": "string"
             }
+          },
+          "rowDecorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          },
+          "decorate": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -2466,6 +2640,9 @@ public var joyfillSchema = """
                 }
               }
             }
+          },
+          "decorators": {
+            "$ref": "#/definitions/RowDecorators"
           }
         },
         "required": [
@@ -2557,6 +2734,12 @@ public var joyfillSchema = """
                 "formula"
               ]
             }
+          },
+          "decorators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
           }
         },
         "required": [
@@ -2564,6 +2747,54 @@ public var joyfillSchema = """
           "file",
           "type"
         ]
+      },
+      "Decorator": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "minLength": 24
+          },
+          "action": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "anyOf": [
+          { "required": ["icon"] },
+          { "required": ["label"] }
+        ]
+      },
+      "RowDecorators": {
+        "type": "object",
+        "properties": {
+          "cells": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Decorator"
+              }
+            }
+          },
+          "all": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Decorator"
+            }
+          }
+        }
       },
       "Formula": {
         "type": "object",
@@ -2594,7 +2825,7 @@ public var joyfillSchema = """
         ]
       }
     },
-    "$joyfillSchemaVersion": "1.0.1"
+    "$joyfillSchemaVersion": "1.0.4"
   }
 
 """


### PR DESCRIPTION
## Context

The Decorator feature lets fields, table/collection rows, and cells carry small action badges (icon/label/color). The SDK already exposes the runtime API (`get/add/update/removeDecorator`) and renders them, but the bundled JSON validation schema (`joyfillSchema`) did not describe these properties. Documents using decorators therefore risked failing schema validation. This PR brings the schema in line with the feature.

## What changed

Single file: `Sources/JoyfillUI/View/joyfill-schema.swift`.

- Added two new definitions:
  - `Decorator` — `{ _id, action, color, icon, label }`, with `action` required and an `anyOf` requiring at least one of `icon` / `label`.
  - `RowDecorators` — `{ all: [Decorator], cells: { <columnId>: [Decorator] } }`.
- Added a `decorators: [Decorator]` array to every field-type definition (text, number, date, dropdown, signature, image, multiline, chart, block, collection, table, etc.).
- Added `rowDecorators: [Decorator]` and `decorate: boolean` to table/collection field definitions.
- Added `decorators: RowDecorators` to the row / `CollectionItem` definitions.
- Added `columnTitleTextOverflow: string` to the field-position definition.
- Bumped `$joyfillSchemaVersion` `1.0.1` → `1.0.4`.

## Decisions

- **`action` required + `anyOf(icon|label)`** mirrors the runtime validation in `DocumentEditor+Decorators.validateDecorator` (action mandatory; a decorator must be displayable via an icon or a label). Keeping the schema and runtime rules aligned avoids documents that pass one but fail the other.
- **`decorators` added per field type rather than to a shared base** — the schema defines each field type explicitly with its own `required`/`properties`, so the property is added in place to match the existing structure rather than introducing a shared mixin.
- **Version bump to 1.0.4** to reflect the additive schema changes shipped since 1.0.1.

## Screenshot / video

N/A — schema-only change, no UI.

## Public API

- No Swift API surface change (no structs/methods/signatures touched).
- `joyfillSchema` is a `public var`; its **content** changed, which loosens validation to accept decorator properties. Purely additive — previously valid documents remain valid.
- Docs: the decorator schema/spec should be reflected in the public schema docs if they're versioned there.

## Tests

- Schema-content change; covered indirectly by existing schema-validation tests (`JoyfillTests/SchemaValidation/`). No new behavior logic to unit-test here.
- If we want an explicit guard, a follow-up test asserting a decorator-bearing document validates against `joyfillSchema` would lock it in.

## Notes for reviewer

- Diff is large but mechanical/repetitive — the same `decorators` block is added to each field type. Worth a quick scan that no field type was missed and that `required` arrays were not altered.
