### PR TITLE
NO-2186: Fix date field rendering current time for empty string value

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		36294F1D2BD67FC4006C03A6 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 36294F1C2BD67FC4006C03A6 /* JoyfillAPIService */; };
 		362A560D2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362A560C2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift */; };
 		363A34CB2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */; };
+		DA7EFA0011111111111111B1 /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7EFA0011111111111111A1 /* DateFormattingTests.swift */; };
 		363AEF702C510DF00082359B /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 363AEF6F2C510DF00082359B /* JoyfillAPIService */; };
 		363B43F62E29593D0027FFB9 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 363B43F52E29593D0027FFB9 /* JoyfillAPIService */; };
 		364300ED2C510BEC00BA870F /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 364300EC2C510BEC00BA870F /* JoyfillAPIService */; };
@@ -546,6 +547,7 @@
 		362746752E26E266005B0FA7 /* FormulaTemplate_DateFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_DateFieldTests.swift; sourceTree = "<group>"; };
 		362A560C2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillUITestsBaseClass.swift; sourceTree = "<group>"; };
 		363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueUnionNSNumberTests.swift; sourceTree = "<group>"; };
+		DA7EFA0011111111111111A1 /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		364615A92E29692D00F237F6 /* DeficiencyTableDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeficiencyTableDemoView.swift; sourceTree = "<group>"; };
 		364615AA2E29692D00F237F6 /* OnChangeHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeHandlerTest.swift; sourceTree = "<group>"; };
 		364615AD2E29694800F237F6 /* SchemaValidationExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationExampleView.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 			isa = PBXGroup;
 			children = (
 				363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */,
+				DA7EFA0011111111111111A1 /* DateFormattingTests.swift */,
 				E29FF86A2F2161DD0079A614 /* NavigationJSONTests.swift */,
 				E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */,
 				E2C8BD262E4628A900B93B9E /* MobileTitleDisplayTests.swift */,
@@ -2081,6 +2084,7 @@
 				E2B8E3E42E4378D200AC6018 /* FormulaTemplate_LessThanOrEqualOperatorTests.swift in Sources */,
 				E2B8E3E52E4378D200AC6018 /* FormulaTemplate_UnequalOperatorTests.swift in Sources */,
 				363A34CB2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift in Sources */,
+				DA7EFA0011111111111111B1 /* DateFormattingTests.swift in Sources */,
 				E2C8BD272E4628A900B93B9E /* MobileTitleDisplayTests.swift in Sources */,
 				E2B8E3E62E4378D200AC6018 /* FormulaTemplate_GreaterThanOrEqualOperatorTests.swift in Sources */,
 				E2B8E3E72E4378D200AC6018 /* FormulaTemplate_LessThanOperatorTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillTests/DateFormattingTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DateFormattingTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import JoyfillModel
+
+/// Unit tests for date formatting, covering the fix where an invalid/empty
+/// ISO8601 string used to fall back to `Date()` (the current time) instead of
+/// producing an empty result.
+final class DateFormattingTests: XCTestCase {
+
+    // MARK: - getTimeFromISO8601Format
+
+    func testInvalidISO8601StringReturnsNil() {
+        // Previously these fell back to Date() and rendered the current time.
+        XCTAssertNil(getTimeFromISO8601Format(iso8601String: "", format: .dateOnlyISO, tzId: "UTC"))
+        XCTAssertNil(getTimeFromISO8601Format(iso8601String: "garbage", format: .dateOnlyISO, tzId: "UTC"))
+        // Date-only without time component is not a valid full ISO8601 date-time.
+        XCTAssertNil(getTimeFromISO8601Format(iso8601String: "2024-03-15", format: .dateOnlyISO, tzId: "UTC"))
+    }
+
+    func testValidISO8601StringIsFormattedWithGivenFormat() {
+        let result = getTimeFromISO8601Format(iso8601String: "2024-03-15T13:30:00Z",
+                                              format: .dateTime24,
+                                              tzId: "UTC")
+        XCTAssertEqual(result, "03/15/2024 13:30")
+    }
+
+    func testValidISO8601StringHonorsDateOnlyFormat() {
+        let result = getTimeFromISO8601Format(iso8601String: "1970-01-01T00:00:00Z",
+                                              format: .dateOnlyISO,
+                                              tzId: "UTC")
+        XCTAssertEqual(result, "1970-01-01")
+    }
+
+    // MARK: - ValueUnion.dateTime
+
+    func testEmptyStringValueReturnsNil() {
+        // The empty-string date value must not render a date.
+        XCTAssertNil(ValueUnion.string("").dateTime(format: .empty, tzId: "UTC"))
+    }
+
+    func testGarbageStringValueReturnsNil() {
+        XCTAssertNil(ValueUnion.string("not-a-date").dateTime(format: .dateTime, tzId: "UTC"))
+    }
+
+    func testNullValueReturnsNil() {
+        XCTAssertNil(ValueUnion.null.dateTime(format: .empty, tzId: "UTC"))
+    }
+
+    func testDoubleTimestampValueIsFormatted() {
+        // epoch 0 ms == 1970-01-01 00:00:00 UTC
+        XCTAssertEqual(ValueUnion.double(0).dateTime(format: .dateOnlyISO, tzId: "UTC"), "1970-01-01")
+    }
+
+    func testIntTimestampValueIsFormatted() {
+        XCTAssertEqual(ValueUnion.int(0).dateTime(format: .dateOnlyISO, tzId: "UTC"), "1970-01-01")
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/DateTimeField/DateTimeFieldTestData.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DateTimeField/DateTimeFieldTestData.json
@@ -117,6 +117,14 @@
       "identifier": "field_695cb7ba2bb03caceb8ae978",
       "value": 1767252026000,
       "tz": "Asia/Calcutta"
+    },
+    {
+      "file": "66a14ced9dc829a95e272506",
+      "_id": "6a27d28b656b1bbecbb2a956",
+      "type": "date",
+      "title": "Test empty date string",
+      "value": "",
+      "identifier": "field_6a27d28b656b1bbecbb2a956"
     }
   ],
   "_id": "66a14cedd6e1ebcdf176a8da",
@@ -273,6 +281,17 @@
               "width": 4,
               "height": 8,
               "field": "695cb7ba2bb03caceb8ae978"
+            },
+            {
+              "_id": "6a27d28b81ee0056ebf9f314",
+              "type": "date",
+              "displayType": "original",
+              "format": "MM/DD/YYYY hh:mma",
+              "x": 1,
+              "y": 96,
+              "width": 4,
+              "height": 8,
+              "field": "6a27d28b656b1bbecbb2a956"
             }
           ],
           "hidden": false,
@@ -281,7 +300,12 @@
           "_id": "66a14ced15a9dc96374e091e",
           "width": 816,
           "name": "Every Field Type",
-          "margin": 0
+          "margin": 0,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         }
       ]
     }

--- a/JoyfillSwiftUIExample/JoyfillUITests/DateTimeField/DateTimeFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DateTimeField/DateTimeFieldTests.swift
@@ -1,6 +1,40 @@
 import XCTest
 
 final class DateTimeFieldTests: JoyfillUITestsBaseClass {
+    override func getJSONFileNameForTest() -> String {
+        return "DateTimeFieldTestData"
+    }
+
+    func testEmptyStringDateRendersEmptyState() {
+        // A date field with value "" must render the empty "Select a Date -" placeholder,
+        // not a fabricated current date/time.
+        let placeholder = app.staticTexts["Select a Date -"]
+
+        var attempts = 0
+        while !placeholder.exists && attempts < 8 {
+            app.swipeUp()
+            _ = placeholder.waitForExistence(timeout: 1)
+            attempts += 1
+        }
+
+        XCTAssertTrue(placeholder.waitForExistence(timeout: 5),
+                      "Empty-string date field should show the 'Select a Date -' empty state")
+        let placeholderQuery = app.staticTexts.matching(NSPredicate(format: "label == %@", "Select a Date -"))
+        XCTAssertEqual(placeholderQuery.count, 1,
+                       "Only the empty-string date field should show the empty placeholder")
+
+        // Now set a date/time on the previously-empty field and confirm it gets set.
+        placeholder.tap()
+
+        XCTAssertTrue(waitUntil(5) { placeholderQuery.count == 0 },
+                      "After tapping, the empty placeholder should disappear (field is now filled)")
+
+        // A change should have been emitted carrying a numeric (millisecond) value.
+        let emittedValue = onChangeResultValue()
+        XCTAssertNotNil(emittedValue.number,
+                        "Setting the date should emit a numeric timestamp value, got \(emittedValue)")
+    }
+
     func testDatePicker() {
         app.swipeUp()
         // Tap a date button using its identifier to open the picker popup

--- a/Sources/JoyfillModel/DocumentModel.swift
+++ b/Sources/JoyfillModel/DocumentModel.swift
@@ -278,25 +278,35 @@ public enum DateFormatType: String {
     }
 }
 
-/// Converts an ISO8601 formatted string to a time string.
+/// Converts an ISO8601 formatted string to a formatted date/time string.
 ///
 /// - Parameters:
 ///   - iso8601String: The ISO8601 formatted string representing a date and time.
+///   - format: The desired output format. Defaults to `.empty` (MM/dd/yyyy hh:mma).
+///   - tzId: Optional timezone identifier to render the value in.
 ///
-/// - Returns: A formatted time string in the format "hh:mm a".
-public func getTimeFromISO8601Format(iso8601String: String, tzId: String? = nil) -> String {
-    let dateFormatter = ISO8601DateFormatter()
-    let instant = dateFormatter.date(from: iso8601String)
-    
+/// - Returns: A formatted date/time string honoring `format`, or `nil` if the
+///   input is not a valid ISO8601 string. Returning `nil` (rather than falling
+///   back to the current date) lets callers render an empty state for invalid input.
+public func getTimeFromISO8601Format(iso8601String: String, format: DateFormatType = .empty, tzId: String? = nil) -> String? {
+    guard let instant = ISO8601DateFormatter().date(from: iso8601String) else {
+        return nil
+    }
+
     let timeZone = TimeZone(identifier: tzId ?? TimeZone.current.identifier)
-    let zonedDateTime = instant ?? Date()
-    
     let formatter = DateFormatter()
-    formatter.dateFormat = "hh:mm a"
     formatter.timeZone = timeZone
-    
-    let timeString = formatter.string(from: zonedDateTime)
-    return timeString
+    formatter.dateFormat = format.dateFormat
+
+    // Match the locale handling used by timestampMillisecondsToDate so the
+    // string and numeric value paths format 12h/24h identically.
+    if format.rawValue.contains("HH") {
+        formatter.locale = Locale(identifier: "en_GB")
+    } else if format == .empty || format.rawValue.contains("hh") {
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+    }
+
+    return formatter.string(from: instant)
 }
 
 /// Converts a timestamp value in milliseconds to a formatted date string.

--- a/Sources/JoyfillModel/ValueUnion.swift
+++ b/Sources/JoyfillModel/ValueUnion.swift
@@ -470,8 +470,7 @@ public extension ValueUnion {
         switch self {
         case .string(let string):
             guard !string.isEmpty else { return nil }
-            let date = getTimeFromISO8601Format(iso8601String: string, tzId: tzId)
-            return date
+            return getTimeFromISO8601Format(iso8601String: string, format: format, tzId: tzId)
         case .double(let integer):
             let date = timestampMillisecondsToDate(value: Int(integer), format: format, tzId: tzId)
             return date

--- a/Sources/JoyfillModel/ValueUnion.swift
+++ b/Sources/JoyfillModel/ValueUnion.swift
@@ -469,6 +469,7 @@ public extension ValueUnion {
     func dateTime(format: DateFormatType, tzId: String? = nil) -> String? {
         switch self {
         case .string(let string):
+            guard !string.isEmpty else { return nil }
             let date = getTimeFromISO8601Format(iso8601String: string, tzId: tzId)
             return date
         case .double(let integer):


### PR DESCRIPTION
## Context
A `date` field whose stored `value` is an empty string (`""`) — or any invalid ISO8601 string — was rendering the **current** date/time instead of an empty state. Root cause: `getTimeFromISO8601Format` fell back to `Date()` (now) when ISO8601 parsing failed, and it also ignored the requested display format (always emitting `hh:mm a`).

## What changed
- **`Sources/JoyfillModel/DocumentModel.swift`** — `getTimeFromISO8601Format(iso8601String:format:tzId:)`:
  - Returns `nil` for invalid/empty ISO8601 input instead of falling back to the current date.
  - Now honors the passed `format` (new `format: DateFormatType = .empty` parameter) rather than hardcoding `hh:mm a`.
  - Applies the same 12h/24h locale handling used by `timestampMillisecondsToDate`, so the string and numeric value paths format identically.
- **`Sources/JoyfillModel/ValueUnion.swift`** — `dateTime(format:tzId:)` guards empty strings and forwards `format` into `getTimeFromISO8601Format`.
- **`DateTimeFieldTestData.json` / `DateTimeFieldTests.swift`** — added a `"Test empty date string"` field (`value: ""`) and the UI test `testEmptyStringDateRendersEmptyState` (empty placeholder shows, then tapping sets a numeric timestamp).
- **`JoyfillTests/DateFormattingTests.swift`** (new) — unit tests for `getTimeFromISO8601Format` and `ValueUnion.dateTime` covering empty/garbage/null/valid input and int/double timestamps.

## Implementation notes
- Returning `nil` for any unparseable input (not just empty string) unifies the empty-state path and removes the silent "now" fabrication.
- Locale handling mirrors `timestampMillisecondsToDate` (`en_GB` for `HH`, `en_US_POSIX` for `hh`/`.empty`) so a value formats the same whether it arrives as an ISO string or a millisecond timestamp.

## Public API
**Breaking change** to the public `getTimeFromISO8601Format`:
- Return type changed from `String` to `String?`.
- New `format: DateFormatType = .empty` parameter (defaulted, source-compatible for call sites that don't pass it, but the optional return type still requires unwrapping).

Only one internal caller (`ValueUnion.dateTime`) exists and is updated. External consumers of this public function will need to handle the optional return. **Docs should be updated** to reflect the new signature and nil-on-invalid behavior.

## Tests
Covered by the new unit tests (`DateFormattingTests`) and the UI test (`testEmptyStringDateRendersEmptyState`): empty, garbage, null, valid ISO, and int/double timestamp cases. No further cases planned for now.

## Notes for reviewer
- Worth confirming the locale-by-format heuristic matches `timestampMillisecondsToDate` for every `DateFormatType` case.
- Screenshot/video omitted (iOS simulator UI run); behavior change: empty/invalid date field now shows `Select a Date -` instead of the current time.