### PR TITLE
NO-2191: Fix Xcode 27 build error (@State assignment in init)

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/FormBuilderView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/FormBuilderView.swift
@@ -24,20 +24,7 @@ struct FormBuilderView: View {
     let imagePicker = ImagePicker()
     let changeManager: ChangeManager
 
-    init(fields: [BuilderField] = [], formulas: [BuilderFormula] = [], tableColumns: [FieldTableColumn] = [], showingAddField: Bool = false, showingAddFormula: Bool = false, editingField: BuilderField? = nil, editingFormula: BuilderFormula? = nil, builtDocument: JoyDoc? = nil, documentEditor: DocumentEditor? = nil, selectedTemplate: FormTemplate = .allFieldTypes, isFormulasExpanded: Bool = true, isFieldsExpanded: Bool = true, isTemplateExpanded: Bool = false) {
-        self.fields = fields
-        self.formulas = formulas
-        self.tableColumns = tableColumns
-        self.showingAddField = showingAddField
-        self.showingAddFormula = showingAddFormula
-        self.editingField = editingField
-        self.editingFormula = editingFormula
-        self.builtDocument = builtDocument
-        self.documentEditor = documentEditor
-        self.selectedTemplate = selectedTemplate
-        self.isFormulasExpanded = isFormulasExpanded
-        self.isFieldsExpanded = isFieldsExpanded
-        self.isTemplateExpanded = isTemplateExpanded
+    init() {
         self.changeManager = ChangeManager(showImagePicker: imagePicker.showPickerOptions, showScan: {_ in })
     }
     

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -113,11 +113,9 @@ struct PagesView: View {
     @Binding var pageFieldModels: [String: PageModel]
     @ObservedObject var documentEditor: DocumentEditor
 
-    init(isSheetPresented: Bool = false,
-         pageOrder: [String]?,
+    init(pageOrder: [String]?,
          pageFieldModels: Binding<[String : PageModel]>,
          documentEditor: DocumentEditor) {
-        self.isSheetPresented = isSheetPresented
         self.pageOrder = pageOrder
         _pageFieldModels = pageFieldModels
         self.documentEditor = documentEditor


### PR DESCRIPTION
## Context
Xcode 27 beta ships a stricter Swift compiler that now rejects assigning to a `@State` property via `self.x = value` inside an `init` while other stored properties are still uninitialized. Because the property already carries an inline default, that statement is a property-wrapper *setter call* (which touches `self`), not an initialization — so the compiler emits `'self' used before all stored properties are initialized`. Earlier Xcode versions accepted this; Xcode 27 does not, breaking the build.

## What changed
- **`Sources/JoyfillUI/View/FormView.swift`** — `PagesView.init`: removed the unused `isSheetPresented` parameter and its `self.isSheetPresented = ...` assignment.
- **`JoyfillSwiftUIExample/JoyfillExample/FormBuilderView.swift`** — `FormBuilderView.init`: reduced to `init()`, removing 13 dead defaulted parameters and their `@State` assignments.

## Why this approach
The flagged `@State` vars already declare inline defaults and **no caller ever injected them** (`PagesView` callers pass only the 3 real params; `FormBuilderView` is only ever called as `FormBuilderView()`). So rather than work around the error with `_x = State(initialValue:)`, the parameters were simply dropped — fixing the build *and* removing dead code. `FormBuilderView`'s `init()` is kept (not removed) solely to build `changeManager`, which references the `imagePicker` instance property and therefore cannot be an inline default. The `@State` declarations and their defaults are unchanged.

## Screenshots / video
N/A — compile-only fix, no behavioral or UI change.

## Public API
No public API change. `PagesView` and `FormBuilderView` are both internal types. No docs update required.

## Tests
No new tests — this is a compiler-conformance fix with no behavior change. Verified by building the `JoyfillExample` scheme against Xcode 27.0 beta (iOS Simulator): **BUILD SUCCEEDED**. Existing test suite is unaffected.

## Notes for reviewer
- The removed parameters were verified unused across `Sources/`, both example apps, and all test targets before deletion.
- Safe on older toolchains too — the change is strictly a simplification, not a workaround.
