### PR TITLE
NO-2201: Fix readonly multiline text not scrolling

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTestData.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTestData.json
@@ -113,6 +113,15 @@
           }
         ]
       }
+    },
+    {
+      "file": "66a14ced9dc829a95e272506",
+      "_id": "6870c873000000000000aaaa",
+      "type": "textarea",
+      "title": "Readonly Large Multiline",
+      "identifier": "field_readonly_large_multiline",
+      "disabled": true,
+      "value": "Readonly line 01: the quick brown fox jumps over the lazy dog\nReadonly line 02: the quick brown fox jumps over the lazy dog\nReadonly line 03: the quick brown fox jumps over the lazy dog\nReadonly line 04: the quick brown fox jumps over the lazy dog\nReadonly line 05: the quick brown fox jumps over the lazy dog\nReadonly line 06: the quick brown fox jumps over the lazy dog\nReadonly line 07: the quick brown fox jumps over the lazy dog\nReadonly line 08: the quick brown fox jumps over the lazy dog\nReadonly line 09: the quick brown fox jumps over the lazy dog\nReadonly line 10: the quick brown fox jumps over the lazy dog\nReadonly line 11: the quick brown fox jumps over the lazy dog\nReadonly line 12: the quick brown fox jumps over the lazy dog\nReadonly line 13: the quick brown fox jumps over the lazy dog\nReadonly line 14: the quick brown fox jumps over the lazy dog\nReadonly line 15: the quick brown fox jumps over the lazy dog\nReadonly line 16: the quick brown fox jumps over the lazy dog\nReadonly line 17: the quick brown fox jumps over the lazy dog\nReadonly line 18: the quick brown fox jumps over the lazy dog\nReadonly line 19: the quick brown fox jumps over the lazy dog\nReadonly line 20: the quick brown fox jumps over the lazy dog\nReadonly line 21: the quick brown fox jumps over the lazy dog\nReadonly line 22: the quick brown fox jumps over the lazy dog\nReadonly line 23: the quick brown fox jumps over the lazy dog\nReadonly line 24: the quick brown fox jumps over the lazy dog\nReadonly line 25: the quick brown fox jumps over the lazy dog\nReadonly line 26: the quick brown fox jumps over the lazy dog\nReadonly line 27: the quick brown fox jumps over the lazy dog\nReadonly line 28: the quick brown fox jumps over the lazy dog\nReadonly line 29: the quick brown fox jumps over the lazy dog\nReadonly line 30: the quick brown fox jumps over the lazy dog\nReadonly line 31: the quick brown fox jumps over the lazy dog\nReadonly line 32: the quick brown fox jumps over the lazy dog\nReadonly line 33: the quick brown fox jumps over the lazy dog\nReadonly line 34: the quick brown fox jumps over the lazy dog\nReadonly line 35: the quick brown fox jumps over the lazy dog\nReadonly line 36: the quick brown fox jumps over the lazy dog\nReadonly line 37: the quick brown fox jumps over the lazy dog\nReadonly line 38: the quick brown fox jumps over the lazy dog\nReadonly line 39: the quick brown fox jumps over the lazy dog\nReadonly line 40: the quick brown fox jumps over the lazy dog"
     }
   ],
   "_id": "66a14cedd6e1ebcdf176a8da",
@@ -177,6 +186,16 @@
               "displayType": "original",
               "x": 2,
               "y": 57,
+              "width": 4,
+              "height": 23
+            },
+            {
+              "_id": "6870c873000000000000bbbb",
+              "type": "textarea",
+              "field": "6870c873000000000000aaaa",
+              "displayType": "original",
+              "x": 2,
+              "y": 80,
               "width": 4,
               "height": 23
             }

--- a/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
@@ -50,8 +50,8 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         app.swipeUp()
         app.swipeDown()
         
-        // Check if field is hidden
-        XCTAssertEqual(app.textViews.count, 2, "Target multiline text field should be hidden when condition is met.")
+        // Check if field is hidden (2 editable fields; readonly field is not a textView)
+        XCTAssertEqual(app.textViews.count, 1, "Target multiline text field should be hidden when condition is met.")
         
         
                                         
@@ -116,8 +116,8 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
     }
 
     func testFieldVisibilityToggleBackAndForth() {
-        // Initially all 3 fields should be visible
-        XCTAssertEqual(app.textViews.count, 3, "All fields should be visible initially.")
+        // Initially 2 editable fields are textViews (readonly field is not a textView)
+        XCTAssertEqual(app.textViews.count, 2, "All fields should be visible initially.")
         
         // Step 1: Use the second field (index 1) as trigger to hide the first field
         let triggerField = app.textViews.element(boundBy: 1)
@@ -131,9 +131,9 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         
         app.swipeUp()
         app.swipeDown()
-        
-        XCTAssertEqual(app.textViews.count, 2, "Target multiline text field should be hidden when condition is met.")
-        
+
+        XCTAssertEqual(app.textViews.count, 1, "Target multiline text field should be hidden when condition is met.")
+
         // Step 2: Reset the trigger field (now at index 0 since first field is hidden)
         let resetTriggerField = app.textViews.element(boundBy: 0)
         XCTAssertTrue(resetTriggerField.exists, "Reset trigger field should exist")
@@ -147,12 +147,12 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         app.swipeUp()
         app.swipeDown()
         
-        XCTAssertEqual(app.textViews.count, 3, "Target multiline text field should be shown when condition is met.")
+        XCTAssertEqual(app.textViews.count, 2, "Target multiline text field should be shown when condition is met.")
     }
 
     func testHideDisplayTextThenMultilineFieldAndUnhideAll() {
-        // Start fresh - check initial state
-        XCTAssertEqual(app.textViews.count, 3, "Should start with 3 text views")
+        // Start fresh - check initial state (2 editable fields; readonly field is not a textView)
+        XCTAssertEqual(app.textViews.count, 2, "Should start with 2 editable text views")
         
         let firstField = app.textViews.element(boundBy: 0)
         let secondField = app.textViews.element(boundBy: 1)
@@ -200,7 +200,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         app.swipeUp()
         app.swipeDown()
         
-        XCTAssertEqual(app.textViews.count, 2, "First multiline field should be hidden, leaving 2 fields.")
+        XCTAssertEqual(app.textViews.count, 1, "First multiline field should be hidden, leaving 1 editable field.")
         
         // Step 3: Unhide the first field by changing second field value
         let remainingSecondField = app.textViews.element(boundBy: 0) // Now at index 0 since first field is hidden
@@ -215,7 +215,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         app.swipeDown()
         
         // Verify first field is visible again
-        XCTAssertEqual(app.textViews.count, 3, "First multiline field should be visible again.")
+        XCTAssertEqual(app.textViews.count, 2, "First multiline field should be visible again.")
         
         // Step 4: Unhide display text by changing the first field value
         let restoredFirstField = app.textViews.element(boundBy: 0)
@@ -252,7 +252,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         let longTitle = app.staticTexts["This is multiline text. Enter 'hide first' for hide first multiline"]
         XCTAssertTrue(longTitle.exists, "Multiline title should be visible")
         
-        let noTitleField = app.textViews.element(boundBy: 2)
+        let noTitleField = app.scrollViews["MultilineReadonlyTextIdentifier"]
         XCTAssertTrue(noTitleField.exists, "Multiline field without title should be rendered")
     }
 
@@ -274,7 +274,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
     }
 
     func testMultilineReadonlyFieldBehavior() {
-        let readonlyField = app.textViews.element(boundBy: 2)
+        let readonlyField = app.scrollViews["MultilineReadonlyTextIdentifier"]
         XCTAssertTrue(readonlyField.exists)
 
         readonlyField.tap()
@@ -476,7 +476,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         Thread.sleep(forTimeInterval: 0.5)
         app.swipeUp()
         app.swipeDown()
-        XCTAssertEqual(app.textViews.count, 2, "Third multiline should be hidden when first is empty and second contains 'xyz'")
+        XCTAssertFalse(app.scrollViews["MultilineReadonlyTextIdentifier"].exists, "Third multiline should be hidden when first is empty and second contains 'xyz'")
     }
     
     func testMultilineFieldCallOnChangeAfterTwoSeconds() throws {

--- a/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
@@ -252,7 +252,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         let longTitle = app.staticTexts["This is multiline text. Enter 'hide first' for hide first multiline"]
         XCTAssertTrue(longTitle.exists, "Multiline title should be visible")
         
-        let noTitleField = app.scrollViews["MultilineReadonlyTextIdentifier"]
+        let noTitleField = app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").element(boundBy: 0)
         XCTAssertTrue(noTitleField.exists, "Multiline field without title should be rendered")
     }
 
@@ -274,7 +274,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
     }
 
     func testMultilineReadonlyFieldBehavior() {
-        let readonlyField = app.scrollViews["MultilineReadonlyTextIdentifier"]
+        let readonlyField = app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").element(boundBy: 0)
         XCTAssertTrue(readonlyField.exists)
 
         readonlyField.tap()
@@ -476,7 +476,7 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         Thread.sleep(forTimeInterval: 0.5)
         app.swipeUp()
         app.swipeDown()
-        XCTAssertFalse(app.scrollViews["MultilineReadonlyTextIdentifier"].exists, "Third multiline should be hidden when first is empty and second contains 'xyz'")
+        XCTAssertEqual(app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").count, 1, "Empty readonly multiline should be hidden when first is empty and second contains 'xyz', leaving only the large readonly field")
     }
     
     func testMultilineFieldCallOnChangeAfterTwoSeconds() throws {
@@ -502,6 +502,28 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
         XCTAssertEqual("Hello sir", onChangeResultValue().multilineText)
     }
     
+    func testReadonlyLargeMultilineIsScrollableNotEditable() {
+        // The large readonly multiline is the second readonly scrollView (boundBy 1)
+        let readonlyField = app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").element(boundBy: 1)
+        XCTAssertTrue(readonlyField.waitForExistence(timeout: 10), "Large readonly multiline should exist")
+
+        // Only the two editable fields are textViews; readonly fields are ScrollView + Text
+        XCTAssertEqual(app.textViews.count, 2, "Readonly fields must not be editable text views")
+
+        // Tapping must not bring up a keyboard (not editable)
+        readonlyField.tap()
+        XCTAssertFalse(app.keyboards.element.waitForExistence(timeout: 2), "Keyboard should not appear for readonly field")
+
+        // Scroll down: the content should move up (proves it is scrollable)
+        let content = readonlyField.staticTexts.firstMatch
+        XCTAssertTrue(content.exists, "Readonly content should be rendered")
+        let beforeY = content.frame.minY
+        readonlyField.swipeUp()
+        let afterY = content.frame.minY
+        XCTAssertLessThan(afterY, beforeY, "Readonly multiline content should scroll up when swiped")
+        readonlyField.swipeDown()
+    }
+
     func dismissSheet() {
         let bottomCoordinate = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
         let topCoordinate = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))

--- a/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift
@@ -503,25 +503,31 @@ final class MultilineTextFieldUITestCases: JoyfillUITestsBaseClass {
     }
     
     func testReadonlyLargeMultilineIsScrollableNotEditable() {
-        // The large readonly multiline is the second readonly scrollView (boundBy 1)
-        let readonlyField = app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").element(boundBy: 1)
-        XCTAssertTrue(readonlyField.waitForExistence(timeout: 10), "Large readonly multiline should exist")
-
-        // Only the two editable fields are textViews; readonly fields are ScrollView + Text
+        // Readonly fields render as ScrollView + Text, not editable text views.
         XCTAssertEqual(app.textViews.count, 2, "Readonly fields must not be editable text views")
 
-        // Tapping must not bring up a keyboard (not editable)
+        // Scroll the bottom readonly field into the accessibility tree.
+        let readonlyField = app.scrollViews.matching(identifier: "MultilineReadonlyTextIdentifier").element(boundBy: 1)
+        var findAttempts = 0
+        while !readonlyField.exists && findAttempts < 10 {
+            app.swipeUp()
+            findAttempts += 1
+        }
+        XCTAssertTrue(readonlyField.waitForExistence(timeout: 10), "Large readonly multiline should exist")
+
         readonlyField.tap()
         XCTAssertFalse(app.keyboards.element.waitForExistence(timeout: 2), "Keyboard should not appear for readonly field")
 
-        // Scroll down: the content should move up (proves it is scrollable)
         let content = readonlyField.staticTexts.firstMatch
         XCTAssertTrue(content.exists, "Readonly content should be rendered")
-        let beforeY = content.frame.minY
+
+        // Measure content offset relative to its field frame: outer-form scrolling
+        // moves both together, so only the inner ScrollView changes this delta.
+        readonlyField.swipeDown() // reset inner scroll to the top
+        let relBefore = content.frame.minY - readonlyField.frame.minY
         readonlyField.swipeUp()
-        let afterY = content.frame.minY
-        XCTAssertLessThan(afterY, beforeY, "Readonly multiline content should scroll up when swiped")
-        readonlyField.swipeDown()
+        let relAfter = content.frame.minY - readonlyField.frame.minY
+        XCTAssertLessThan(relAfter, relBefore, "Inner readonly ScrollView should scroll independently of the outer form")
     }
 
     func dismissSheet() {

--- a/Sources/JoyfillUI/View/Fields/MultiLineTextView.swift
+++ b/Sources/JoyfillUI/View/Fields/MultiLineTextView.swift
@@ -18,6 +18,7 @@ struct MultiLineTextView: View {
     }
 
     var body: some View {
+        let isReadonly = multiLineDataModel.mode == .readonly
         // Create a custom binding that gives us more control
         let textBinding = Binding<String>(
             get: { displayText },
@@ -32,27 +33,37 @@ struct MultiLineTextView: View {
             FieldHeaderView(multiLineDataModel.fieldHeaderModel, isFilled: !displayText.isEmpty) { decorator in
                 eventHandler.onDecoratorAction(event: multiLineDataModel.fieldIdentifier, action: decorator.action ?? "")
             }
-            TextEditor(text: textBinding)
-                .accessibilityIdentifier("MultilineTextFieldIdentifier")
-                .disabled(multiLineDataModel.mode == .readonly)
-                .padding(.horizontal, 10)
-                .autocorrectionDisabled()
-                .frame(minHeight: 200, maxHeight: 200)
-                .cornerRadius(10)
-                .fieldBorder(isFocused: navigationFocusFieldId == multiLineDataModel.fieldIdentifier.fieldID)
-                .focused($isFocused)
-                .onChange(of: isFocused) { focused in
-                    if focused {
-                        eventHandler.onFocus(event: multiLineDataModel.fieldIdentifier)
-                    } else {
-                        updateFieldValue()
+            Group {
+                if isReadonly {
+                    ScrollView {
+                        Text(displayText)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 8)
                     }
+                    .accessibilityIdentifier("MultilineReadonlyTextIdentifier")
+                } else {
+                    TextEditor(text: textBinding)
+                        .accessibilityIdentifier("MultilineTextFieldIdentifier")
+                        .autocorrectionDisabled()
+                        .focused($isFocused)
+                        .onChange(of: isFocused) { focused in
+                            if focused {
+                                eventHandler.onFocus(event: multiLineDataModel.fieldIdentifier)
+                            } else {
+                                updateFieldValue()
+                            }
+                        }
+                        .onChange(of: displayText) { newValue in
+                            if isFocused {
+                                debounceTextChange(newValue: newValue)
+                            }
+                        }
                 }
-                .onChange(of: displayText) { newValue in
-                    if isFocused {
-                        debounceTextChange(newValue: newValue)
-                    }
-                }
+            }
+            .padding(.horizontal, 10)
+            .frame(minHeight: 200, maxHeight: 200)
+            .cornerRadius(10)
+            .fieldBorder(isFocused: navigationFocusFieldId == multiLineDataModel.fieldIdentifier.fieldID)
         }
         .onAppear {
             // Initialize on first appear

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -258,9 +258,7 @@ struct FormView: View {
             DropdownView(dropdownDataModel: model, eventHandler: self)
                 .disabled(listModel.fieldEditMode == .readonly)
         case .textarea(let model):
-
             MultiLineTextView(multiLineDataModel: model, eventHandler: self)
-                .disabled(listModel.fieldEditMode == .readonly)
         case .date(let model):
             DateTimeView(dateTimeDataModel: model, eventHandler: self)
                 .disabled(listModel.fieldEditMode == .readonly)


### PR DESCRIPTION
## Context
Readonly multiline (textarea) fields could not be scrolled, so any value taller than the fixed 200pt frame was unreadable — the overflow was clipped with no way to reach it.

## What changed
- `Sources/JoyfillUI/View/Fields/MultiLineTextView.swift` — in readonly mode, render the value in a `ScrollView { Text(...) }` (identifier `MultilineReadonlyTextIdentifier`) instead of a `TextEditor`. Edit mode keeps the existing `TextEditor` + focus/debounce logic.
- `Sources/JoyfillUI/View/FormView.swift` — removed the outer `.disabled(... == .readonly)` on `MultiLineTextView`, which was a second source of the bug.
- `JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTestData.json` — added a large-text readonly field (`field_readonly_large_multiline`, `disabled: true`, 40-line value) plus its `fieldPosition` so the suite actually exercises scrolling of long readonly content.
- `JoyfillSwiftUIExample/JoyfillUITests/MultilineTextField/MultilineTextFieldUITestCases.swift` — added a scroll-not-editable test and updated existing assertions (see Tests).

## Why this approach
The root cause is `.disabled()`: SwiftUI's `disabled` freezes **all** gestures, including scrolling, and it was applied in two places (the view itself and in `FormView`). `TextEditor` only scrolls its overflow while it's first responder, which would present a keyboard — unacceptable for readonly. A `ScrollView + Text` scrolls freely and shows no keyboard. (Readonly text is intentionally non-selectable, matching the previous disabled `TextEditor` behavior. A `UITextView` wrapper would also work but we deliberately kept this pure SwiftUI.)

## Public API
No public API change. `Mode` and all signatures are unchanged. No docs update needed.

## Tests
- New `testReadonlyLargeMultilineIsScrollableNotEditable` — scrolls the large readonly field into view, asserts no keyboard appears on tap, and asserts the content moves up on swipe (proving it scrolls).
- The readonly field is now a `ScrollView`, not a `UITextView`, so `app.textViews.count` assertions dropped by 1.
- Adding the large readonly field introduces a second element with identifier `MultilineReadonlyTextIdentifier`; existing identifier-based tests were updated to use `matching(identifier:).element(boundBy:)` / count checks to avoid duplicate-match failures (`testMultilineFieldHeaderRendering`, `testMultilineReadonlyFieldBehavior`, `testMultilineFieldConditionalLogicBehavior`).
- Verified on iPhone 17 simulator: the two updated collision tests pass; the new scroll test passes after scrolling the field into view (it sits near the bottom of the form and isn't in the accessibility tree until scrolled).

## Screenshot / video
Not captured — reviewer to verify visually with a long readonly value.

## Notes for reviewer
- Editable-field `textView` indices (0, 1) are unchanged since the editable fields come first.
- Both `.disabled` removals are required; reinstating either reintroduces the bug.

---
🤖 PR opened with AI assistance (Claude Code).

