### PR TITLE
NO-2202: Pin row form headers so navigation buttons stay fixed while scrolling

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/ChangeUITests/OnChangeHandlerUITests.swift
@@ -131,15 +131,15 @@ final class OnChangeHandlerUITests: JoyfillUITestsBaseClass {
     }
     
     func editSingleRowUpperButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["UpperRowButtonIdentifier"].firstMatch
+        app.buttons["UpperRowButtonIdentifier"].firstMatch
     }
     
     func editSingleRowLowerButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["LowerRowButtonIdentifier"].firstMatch
+        app.buttons["LowerRowButtonIdentifier"].firstMatch
     }
     
     func editInsertRowPlusButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["PlusTheRowButtonIdentifier"].firstMatch
+        app.buttons["PlusTheRowButtonIdentifier"].firstMatch
     }
     
     func deleteRowButton() -> XCUIElement {

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -401,11 +401,11 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
     }
     
     func editSingleRowUpperButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["UpperRowButtonIdentifier"]
+        app.buttons["UpperRowButtonIdentifier"]
     }
     
     func editSingleRowLowerButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["LowerRowButtonIdentifier"]
+        app.buttons["LowerRowButtonIdentifier"]
     }
     
     func editRowsButton() -> XCUIElement {
@@ -413,7 +413,7 @@ final class CollectionFieldSearchFilterTests: JoyfillUITestsBaseClass {
     }
     
     func editInsertRowPlusButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["PlusTheRowButtonIdentifier"]
+        app.buttons["PlusTheRowButtonIdentifier"]
     }
     
     func selectNestedRow(number: Int) {

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldTests.swift
@@ -205,15 +205,15 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
     }
     
     func editSingleRowUpperButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["UpperRowButtonIdentifier"]
+        app.buttons["UpperRowButtonIdentifier"]
     }
     
     func editSingleRowLowerButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["LowerRowButtonIdentifier"]
+        app.buttons["LowerRowButtonIdentifier"]
     }
     
     func editInsertRowPlusButton() -> XCUIElement {
-        app.scrollViews.otherElements.buttons["PlusTheRowButtonIdentifier"]
+        app.buttons["PlusTheRowButtonIdentifier"]
     }
     
     func deleteRowButton() -> XCUIElement {
@@ -1432,4 +1432,87 @@ final class CollectionFieldTests: JoyfillUITestsBaseClass {
         app.buttons["SaveSignatureIdentifier"].firstMatch.tap()
     }
     
+    // MARK: - Pinned row form header tests
+
+    private func scrollRowFormUp() {
+        app.swipeUp()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+    }
+
+    /// The collection single-row form's navigation header (chevrons + close) must stay pinned while the fields scroll.
+    func testRowFormHeaderStaysPinnedWhileScrolling() throws {
+        goToCollectionDetailField()
+        selectRow(number: 1)
+        tapOnMoreButton()
+        editRowsButton().tap()
+
+        let closeButton = app.buttons["DismissEditSingleRowSheetButtonIdentifier"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5), "Single-row form should open")
+        XCTAssertTrue(app.buttons["UpperRowButtonIdentifier"].exists, "Up nav button should be in the pinned header")
+        XCTAssertTrue(app.buttons["LowerRowButtonIdentifier"].exists, "Down nav button should be in the pinned header")
+
+        let field = app.textFields["EditRowsTextFieldIdentifier"].firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "A scrollable field should be present")
+
+        let headerYBefore = closeButton.frame.minY
+        let fieldYBefore = field.frame.minY
+
+        scrollRowFormUp()
+        scrollRowFormUp()
+
+        XCTAssertTrue(closeButton.exists && closeButton.isHittable,
+                      "Header close button should stay visible and tappable after scrolling")
+        XCTAssertEqual(closeButton.frame.minY, headerYBefore, accuracy: 5.0,
+                       "Collection row form header should stay pinned, not scroll with the fields")
+        XCTAssertLessThan(field.frame.minY, fieldYBefore,
+                          "Fields should scroll underneath the pinned header")
+
+        // The pinned buttons must still be functional after scrolling.
+        let upButton = app.buttons["UpperRowButtonIdentifier"]
+        let downButton = app.buttons["LowerRowButtonIdentifier"]
+        XCTAssertFalse(upButton.isEnabled, "Up should be disabled on the first row")
+        XCTAssertTrue(downButton.isEnabled, "Down should be enabled while rows exist below")
+        downButton.tap()
+        XCTAssertTrue(waitUntil(3) { upButton.isEnabled },
+                      "Up should become enabled after the Down button navigates to the next row")
+
+        closeButton.tap()
+        XCTAssertTrue(waitUntil(3) { !closeButton.exists },
+                      "Row form should dismiss when the pinned close button is tapped")
+    }
+
+    /// The collection bulk-edit form's "Apply All" header must stay pinned while the fields scroll.
+    func testBulkEditRowFormHeaderStaysPinnedWhileScrolling() throws {
+        goToCollectionDetailField()
+        selectRow(number: 1)
+        selectRow(number: 2)
+        tapOnMoreButton()
+        editRowsButton().tap()
+
+        let applyAll = app.buttons["ApplyAllButtonIdentifier"]
+        XCTAssertTrue(applyAll.waitForExistence(timeout: 5), "Bulk-edit form should open with Apply All header")
+
+        let field = app.textFields["EditRowsTextFieldIdentifier"].firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "A scrollable field should be present")
+
+        let headerYBefore = applyAll.frame.minY
+        let fieldYBefore = field.frame.minY
+
+        scrollRowFormUp()
+        scrollRowFormUp()
+
+        XCTAssertTrue(applyAll.exists && applyAll.isHittable,
+                      "Apply All header button should stay visible and tappable after scrolling")
+        XCTAssertEqual(applyAll.frame.minY, headerYBefore, accuracy: 5.0,
+                       "Collection bulk-edit header should stay pinned, not scroll with the fields")
+        XCTAssertLessThan(field.frame.minY, fieldYBefore,
+                          "Fields should scroll underneath the pinned header")
+
+        // The pinned Apply All button must still be functional after scrolling.
+        XCTAssertTrue(applyAll.isHittable, "Apply All should be tappable after scrolling")
+        applyAll.tap()
+        XCTAssertTrue(waitUntil(3) { !applyAll.exists },
+                      "Bulk-edit form should dismiss after tapping the pinned Apply All button")
+    }
+
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldUITestCases.swift
@@ -1122,4 +1122,89 @@ extension TableFieldUITestCases {
         assertFocusBlurFieldEvent(in: results, expectedFieldEvent: blurEvent, expectedAbsentFieldEventKeys: ["type", "target"], file: file, line: line)
     }
 
+    // MARK: - Pinned row form header tests
+
+    private func scrollRowFormUp() {
+        app.swipeUp()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+    }
+
+    /// The single-row form's navigation header (chevrons + close) must stay pinned while the fields scroll.
+    func testRowFormHeaderStaysPinnedWhileScrolling() throws {
+        goToTableDetailPage()
+
+        // Open the single-row edit form for the first row.
+        let rowSelector = app.images.matching(identifier: "MyButton").element(boundBy: 0)
+        XCTAssertTrue(rowSelector.waitForExistence(timeout: 5), "Row selector should exist")
+        rowSelector.tap()
+        app.buttons["TableMoreButtonIdentifier"].tap()
+        app.buttons["TableEditRowsIdentifier"].tap()
+
+        let closeButton = app.buttons["DismissEditSingleRowSheetButtonIdentifier"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 5), "Single-row form should open")
+        XCTAssertTrue(app.buttons["UpperRowButtonIdentifier"].exists, "Up nav button should be in the pinned header")
+        XCTAssertTrue(app.buttons["LowerRowButtonIdentifier"].exists, "Down nav button should be in the pinned header")
+
+        let field = app.textFields["EditRowsTextFieldIdentifier"].firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "A scrollable field should be present")
+
+        let headerYBefore = closeButton.frame.minY
+        let fieldYBefore = field.frame.minY
+
+        scrollRowFormUp()
+        scrollRowFormUp()
+
+        XCTAssertTrue(closeButton.exists && closeButton.isHittable,
+                      "Header close button should stay visible and tappable after scrolling")
+        XCTAssertEqual(closeButton.frame.minY, headerYBefore, accuracy: 5.0,
+                       "Row form header should stay pinned, not scroll with the fields")
+        XCTAssertLessThan(field.frame.minY, fieldYBefore,
+                          "Fields should scroll underneath the pinned header")
+
+        // The pinned buttons must still be functional after scrolling.
+        let upButton = app.buttons["UpperRowButtonIdentifier"]
+        let downButton = app.buttons["LowerRowButtonIdentifier"]
+        XCTAssertFalse(upButton.isEnabled, "Up should be disabled on the first row")
+        XCTAssertTrue(downButton.isEnabled, "Down should be enabled while rows exist below")
+        downButton.tap()
+        XCTAssertTrue(waitUntil(3) { upButton.isEnabled },
+                      "Up should become enabled after the Down button navigates to the next row")
+
+        closeButton.tap()
+        XCTAssertTrue(waitUntil(3) { !closeButton.exists },
+                      "Row form should dismiss when the pinned close button is tapped")
+    }
+
+    /// The bulk-edit form's "Apply All" header must stay pinned while the fields scroll.
+    func testBulkEditRowFormHeaderStaysPinnedWhileScrolling() throws {
+        goToTableDetailPage()
+        tapOnMoreButton()
+        app.buttons["TableEditRowsIdentifier"].tap()
+
+        let applyAll = app.buttons["ApplyAllButtonIdentifier"]
+        XCTAssertTrue(applyAll.waitForExistence(timeout: 5), "Bulk-edit form should open with Apply All header")
+
+        let field = app.textFields["EditRowsTextFieldIdentifier"].firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "A scrollable field should be present")
+
+        let headerYBefore = applyAll.frame.minY
+        let fieldYBefore = field.frame.minY
+
+        scrollRowFormUp()
+        scrollRowFormUp()
+
+        XCTAssertTrue(applyAll.exists && applyAll.isHittable,
+                      "Apply All header button should stay visible and tappable after scrolling")
+        XCTAssertEqual(applyAll.frame.minY, headerYBefore, accuracy: 5.0,
+                       "Bulk-edit header should stay pinned, not scroll with the fields")
+        XCTAssertLessThan(field.frame.minY, fieldYBefore,
+                          "Fields should scroll underneath the pinned header")
+
+        // The pinned Apply All button must still be functional after scrolling.
+        XCTAssertTrue(applyAll.isHittable, "Apply All should be tappable after scrolling")
+        applyAll.tap()
+        XCTAssertTrue(waitUntil(3) { !applyAll.exists },
+                      "Bulk-edit form should dismiss after tapping the pinned Apply All button")
+    }
+
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -323,9 +323,7 @@ struct CollectionEditMultipleRowsSheetView: View {
     }
 
     var body: some View {
-        ScrollViewReader { scrollProxy in
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 0) {
                 if viewModel.tableDataModel.selectedRows.count == 1 {
                     HStack(alignment: .top) {
                         if !viewModel.tableDataModel.navigationIntent.rowFormOpenedViaGoto {
@@ -398,6 +396,8 @@ struct CollectionEditMultipleRowsSheetView: View {
                         })
                         .accessibilityIdentifier("DismissEditSingleRowSheetButtonIdentifier")
                     }
+                    .padding([.horizontal, .top], 16)
+                    .padding(.bottom, 8)
                 }
                 
                 HStack(alignment: .top) {
@@ -461,7 +461,11 @@ struct CollectionEditMultipleRowsSheetView: View {
                         })
                     }
                 }
-
+                .padding(.horizontal, 16)
+                .padding(.top, viewModel.tableDataModel.selectedRows.count == 1 ? 0 : 16)
+            ScrollViewReader { scrollProxy in
+            ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
                 if !viewModel.tableDataModel.selectedRows.isEmpty {
                     selectedRowsHeaderColumns
                 }
@@ -485,6 +489,7 @@ struct CollectionEditMultipleRowsSheetView: View {
         }))
         .onTapGesture {
             viewModel.tableDataModel.navigationIntent.focusColumnId = nil
+        }
         }
         }
         .safeAreaInset(edge: .bottom) {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -257,9 +257,7 @@ struct EditMultipleRowsSheetView: View {
     }
 
     var body: some View {
-        ScrollViewReader { scrollProxy in
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 0) {
                     if viewModel.tableDataModel.selectedRows.count == 1 {
                         HStack(alignment: .top) {
                             if !viewModel.tableDataModel.navigationIntent.rowFormOpenedViaGoto {
@@ -332,7 +330,12 @@ struct EditMultipleRowsSheetView: View {
                             })
                             .accessibilityIdentifier("DismissEditSingleRowSheetButtonIdentifier")
                         }
+                        .padding([.horizontal, .top], 16)
+                        .padding(.bottom, 8)
                     }
+            ScrollViewReader { scrollProxy in
+            ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
                 HStack(alignment: .top) {
                     if let title = viewModel.tableDataModel.title {
                         VStack(alignment: .leading) {
@@ -635,6 +638,7 @@ struct EditMultipleRowsSheetView: View {
         }))
         .onTapGesture {
             viewModel.tableDataModel.navigationIntent.focusColumnId = nil
+        }
         }
         }
         .safeAreaInset(edge: .bottom) {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -333,9 +333,6 @@ struct EditMultipleRowsSheetView: View {
                         .padding([.horizontal, .top], 16)
                         .padding(.bottom, 8)
                     }
-            ScrollViewReader { scrollProxy in
-            ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
                 HStack(alignment: .top) {
                     if let title = viewModel.tableDataModel.title {
                         VStack(alignment: .leading) {
@@ -392,7 +389,11 @@ struct EditMultipleRowsSheetView: View {
                         })
                     }
                 }
-
+                .padding(.horizontal, 16)
+                .padding(.top, viewModel.tableDataModel.selectedRows.count == 1 ? 0 : 16)
+            ScrollViewReader { scrollProxy in
+            ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
                 ForEach(Array(viewModel.tableDataModel.tableColumns.enumerated()), id: \.offset) { colIndex, col in
                     let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
                     VStack(alignment: .leading, spacing: 16) {


### PR DESCRIPTION
## Context
In the table and collection **row form** (the per-row edit sheet) and its **bulk-edit** variant, the header — back/next chevrons, `+` insert, close `X`, and the bulk "Apply All" button — was scrolling away together with the form fields. The header should remain fixed at the top so those actions are always reachable, no matter how far the user scrolls through the columns.

## What changed
- **`TableModalTopNavigationView.swift`** (`EditMultipleRowsSheetView`) and **`CollectionModalTopNavigationView.swift`** (`CollectionEditMultipleRowsSheetView`):
  - Wrapped the view in an outer `VStack` and moved the single-row navigation header **and** the title + "Apply All" bulk-edit header **out of** the `ScrollView`. Only the field list scrolls now; the headers are pinned.
- **New UI tests (4):**
  - `TableFieldUITestCases`: `testRowFormHeaderStaysPinnedWhileScrolling`, `testBulkEditRowFormHeaderStaysPinnedWhileScrolling`
  - `CollectionFieldTests`: `testRowFormHeaderStaysPinnedWhileScrolling`, `testBulkEditRowFormHeaderStaysPinnedWhileScrolling`
  - Each opens the form, records the header button's Y and a field's Y, scrolls the fields, then asserts the header's Y is unchanged (pinned), the field moved (content scrolled), and the buttons are still **functional** (Down navigates rows / Close dismisses / Apply All applies + dismisses).
- **Test helper fix:** `editSingleRow{Upper,Lower}Button()` / `editInsertRowPlusButton()` in `OnChangeHandlerUITests`, `CollectionFieldTests`, and `CollectionFieldSearchFilterTests` looked the buttons up via `app.scrollViews.otherElements.buttons[...]`. Since the buttons are no longer inside the `ScrollView`, those queries were updated to `app.buttons[...]`.

## Implementation notes / decisions
- The single-row header keeps `.padding(.bottom, 8)`; the title header uses a conditional top padding (`count == 1 ? 0 : 16`) so spacing stays correct whether or not the chevron row is shown above it.
- Headers were pulled out rather than using `pinnedViews`/sticky-section tricks to keep the structure simple and identical between the table and collection implementations.

## Public API
- None. This is an internal view-layout change; no public API surface changed and no docs need updating.

## Test coverage
- Covered by the 4 new UI tests above. All 4 pass locally (iPhone 17 simulator). The pre-existing nav-button helpers were updated so dependent tests keep passing after the layout change.

## Notes for reviewers
- Behavior is identical across the table and collection forms — the two source diffs mirror each other.
- A demo screen recording will be added as a comment.