### PR TITLE
NO-2206: Live-refresh open row-edit form on Change-API row updates (table + collection)

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		36CFA05B2CE4936100B7DE34 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 36CFA05A2CE4936100B7DE34 /* JoyfillAPIService */; };
 		36DEC0DA2E30000000F23702 /* DecoratorRowUpdateDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DEC0DA2E30000000F23701 /* DecoratorRowUpdateDemoView.swift */; };
 		36F4DB782E6F394500C9AD4A /* LicenseValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */; };
+		95288E7E2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95288E7D2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift */; };
 		9EAAC7C02E979A20000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
 		9EAAC7C12E979A20000B6F3C /* TimeZoneUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */; };
 		9EAAC7C22E979BC8000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
@@ -589,6 +590,7 @@
 		36CE14682DB7F90100799B25 /* JoyDoc+helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JoyDoc+helper.swift"; sourceTree = "<group>"; };
 		36DEC0DA2E30000000F23701 /* DecoratorRowUpdateDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorRowUpdateDemoView.swift; sourceTree = "<group>"; };
 		36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseValidatorTests.swift; sourceTree = "<group>"; };
+		95288E7D2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorRowUpdateUITests.swift; sourceTree = "<group>"; };
 		9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TimeZoneTestData.json; sourceTree = "<group>"; };
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
@@ -1032,6 +1034,7 @@
 			isa = PBXGroup;
 			children = (
 				E2B4CFD22F99F54500F2128D /* DecoratorAPIUITests.swift */,
+				95288E7D2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift */,
 				E2B4CFD82F9A060700F2128D /* DecoratorUITestSupport.swift */,
 				BA2352F12F99E9F4002D9345 /* Decorator.json */,
 			);
@@ -2032,6 +2035,7 @@
 				E2F568752E2A4594005216A6 /* ImageFieldUITestCases.swift in Sources */,
 				E2F568762E2A4594005216A6 /* ImageFieldTests.swift in Sources */,
 				E2B4CFD92F9A060700F2128D /* DecoratorUITestSupport.swift in Sources */,
+				95288E7E2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift in Sources */,
 				E2408A022F7CF023005C4885 /* NavigationGotoUITests.swift in Sources */,
 				E29FF8822F2527790079A614 /* TestMobileViewDuplicateLogic.swift in Sources */,
 				1307CF1E2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -70,7 +70,6 @@
 		36294F1D2BD67FC4006C03A6 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 36294F1C2BD67FC4006C03A6 /* JoyfillAPIService */; };
 		362A560D2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362A560C2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift */; };
 		363A34CB2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */; };
-		DA7EFA0011111111111111B1 /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7EFA0011111111111111A1 /* DateFormattingTests.swift */; };
 		363AEF702C510DF00082359B /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 363AEF6F2C510DF00082359B /* JoyfillAPIService */; };
 		363B43F62E29593D0027FFB9 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 363B43F52E29593D0027FFB9 /* JoyfillAPIService */; };
 		364300ED2C510BEC00BA870F /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 364300EC2C510BEC00BA870F /* JoyfillAPIService */; };
@@ -168,6 +167,7 @@
 		36CE14692DB7F90B00799B25 /* JoyDoc+helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36CE14682DB7F90100799B25 /* JoyDoc+helper.swift */; };
 		36CFA0532CE2068300B7DE34 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = 36CFA0522CE2068300B7DE34 /* JoyfillModel */; };
 		36CFA05B2CE4936100B7DE34 /* JoyfillAPIService in Frameworks */ = {isa = PBXBuildFile; productRef = 36CFA05A2CE4936100B7DE34 /* JoyfillAPIService */; };
+		36DEC0DA2E30000000F23702 /* DecoratorRowUpdateDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DEC0DA2E30000000F23701 /* DecoratorRowUpdateDemoView.swift */; };
 		36F4DB782E6F394500C9AD4A /* LicenseValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */; };
 		9EAAC7C02E979A20000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
 		9EAAC7C12E979A20000B6F3C /* TimeZoneUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */; };
@@ -184,6 +184,7 @@
 		BA2353C12FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2353C42FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift */; };
 		BA2353C22FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */; };
 		BA2353C32FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json in Resources */ = {isa = PBXBuildFile; fileRef = BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */; };
+		DA7EFA0011111111111111B1 /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7EFA0011111111111111A1 /* DateFormattingTests.swift */; };
 		DEC000B100000000000000A1 /* DecoratorTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F100000000000000A1 /* DecoratorTestSupport.swift */; };
 		DEC000B200000000000000A2 /* DecoratorPathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */; };
 		DEC000B300000000000000A3 /* DecoratorPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */; };
@@ -362,6 +363,7 @@
 		E28D10AD2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
 		E28D10AE2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
 		E28D10AF2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json in Resources */ = {isa = PBXBuildFile; fileRef = E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */; };
+		E28F3D4A2FE180CC007C7F35 /* DecoratorToRowUpdate.json in Resources */ = {isa = PBXBuildFile; fileRef = E28F3D492FE180CC007C7F35 /* DecoratorToRowUpdate.json */; };
 		E295FA7A2F73DAEF00C3C8C1 /* FooterExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295FA782F73DAEF00C3C8C1 /* FooterExampleView.swift */; };
 		E295FA7B2F73DAEF00C3C8C1 /* footer-form.json in Resources */ = {isa = PBXBuildFile; fileRef = E295FA772F73DAEF00C3C8C1 /* footer-form.json */; };
 		E29D5CDF2FC6FCE000993290 /* DocumentEditor+ChangeHandlerChartAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29D5CDE2FC6FCE000993290 /* DocumentEditor+ChangeHandlerChartAxisTests.swift */; };
@@ -547,7 +549,6 @@
 		362746752E26E266005B0FA7 /* FormulaTemplate_DateFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_DateFieldTests.swift; sourceTree = "<group>"; };
 		362A560C2BEE304500B54C14 /* JoyfillUITestsBaseClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillUITestsBaseClass.swift; sourceTree = "<group>"; };
 		363A34CA2ED82AD800B578B2 /* ValueUnionNSNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueUnionNSNumberTests.swift; sourceTree = "<group>"; };
-		DA7EFA0011111111111111A1 /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		364615A92E29692D00F237F6 /* DeficiencyTableDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeficiencyTableDemoView.swift; sourceTree = "<group>"; };
 		364615AA2E29692D00F237F6 /* OnChangeHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChangeHandlerTest.swift; sourceTree = "<group>"; };
 		364615AD2E29694800F237F6 /* SchemaValidationExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationExampleView.swift; sourceTree = "<group>"; };
@@ -586,6 +587,7 @@
 		36BCD3722E0BFA0600F5DA4B /* FormulaTemplate_TableField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_TableField.swift; sourceTree = "<group>"; };
 		36CE14662DB6680000799B25 /* LiveViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveViewTest.swift; sourceTree = "<group>"; };
 		36CE14682DB7F90100799B25 /* JoyDoc+helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JoyDoc+helper.swift"; sourceTree = "<group>"; };
+		36DEC0DA2E30000000F23701 /* DecoratorRowUpdateDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorRowUpdateDemoView.swift; sourceTree = "<group>"; };
 		36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseValidatorTests.swift; sourceTree = "<group>"; };
 		9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TimeZoneTestData.json; sourceTree = "<group>"; };
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
@@ -596,6 +598,7 @@
 		BA2353372FA1DFEF002D9345 /* PageDeletableCopyableUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableUITests.swift; sourceTree = "<group>"; };
 		BA2353C42FA1DFEF002D9345 /* PageDeletableCopyableMobileViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableMobileViewUITests.swift; sourceTree = "<group>"; };
 		BA2353C52FA1DFEF002D9345 /* PageDeletableCopyableMobileView.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageDeletableCopyableMobileView.json; sourceTree = "<group>"; };
+		DA7EFA0011111111111111A1 /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		DEC000F100000000000000A1 /* DecoratorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorTestSupport.swift; sourceTree = "<group>"; };
 		DEC000F200000000000000A2 /* DecoratorPathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPathResolutionTests.swift; sourceTree = "<group>"; };
 		DEC000F300000000000000A3 /* DecoratorPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorPublicAPITests.swift; sourceTree = "<group>"; };
@@ -669,6 +672,7 @@
 		E28D10A42E2E08E100E59B5F /* EncapsulatedCircularReference_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = EncapsulatedCircularReference_FormulaTemplate.json; sourceTree = "<group>"; };
 		E28D10A82E2E08F700E59B5F /* ImplicitCircularReferenceObjectArrayConstruction_FormulaTemplate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ImplicitCircularReferenceObjectArrayConstruction_FormulaTemplate.json; sourceTree = "<group>"; };
 		E28D10AC2E2E090800E59B5F /* FormulaTemplate_ConditionalEvaluationCircularReference.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FormulaTemplate_ConditionalEvaluationCircularReference.json; sourceTree = "<group>"; };
+		E28F3D492FE180CC007C7F35 /* DecoratorToRowUpdate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DecoratorToRowUpdate.json; sourceTree = "<group>"; };
 		E295FA772F73DAEF00C3C8C1 /* footer-form.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "footer-form.json"; sourceTree = "<group>"; };
 		E295FA782F73DAEF00C3C8C1 /* FooterExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterExampleView.swift; sourceTree = "<group>"; };
 		E29D5CDE2FC6FCE000993290 /* DocumentEditor+ChangeHandlerChartAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DocumentEditor+ChangeHandlerChartAxisTests.swift"; sourceTree = "<group>"; };
@@ -1218,6 +1222,15 @@
 			path = optionalPropertiesRemovedTemplate;
 			sourceTree = "<group>";
 		};
+		E28F3D482FE18099007C7F35 /* DecoratorToRowUpdate */ = {
+			isa = PBXGroup;
+			children = (
+				E28F3D492FE180CC007C7F35 /* DecoratorToRowUpdate.json */,
+				36DEC0DA2E30000000F23701 /* DecoratorRowUpdateDemoView.swift */,
+			);
+			path = DecoratorToRowUpdate;
+			sourceTree = "<group>";
+		};
 		E295FA792F73DAEF00C3C8C1 /* Footer Example */ = {
 			isa = PBXGroup;
 			children = (
@@ -1492,6 +1505,7 @@
 				048149FE2CDA901F0061FBDC /* UserAccessTokenTextFieldView.swift */,
 				E20E53012F876E500088A4E4 /* Decorator Example */,
 				E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */,
+				E28F3D482FE18099007C7F35 /* DecoratorToRowUpdate */,
 				E295FA792F73DAEF00C3C8C1 /* Footer Example */,
 				E22516822E8B9C610089E2D2 /* Public Apis Example */,
 				E2E3E7772E856105002A10C2 /* Simple Form Example */,
@@ -1922,6 +1936,7 @@
 				36A5EF472E29725B0059C2A6 /* testrow.json in Resources */,
 				E2F568C92E2A4A99005216A6 /* ChartFieldTestData.json in Resources */,
 				36A5EF482E29725B0059C2A6 /* hint_and_deficiency_demo.json in Resources */,
+				E28F3D4A2FE180CC007C7F35 /* DecoratorToRowUpdate.json in Resources */,
 				9EAAC7E22EAB3F89000B6F3C /* PageNavigationTest.json in Resources */,
 				36A5EF4A2E29725B0059C2A6 /* CollectionFilter.json in Resources */,
 				E29FF87F2F2527540079A614 /* TestMobileViewDuplicateLogic.json in Resources */,
@@ -2136,6 +2151,7 @@
 				13B544442BE37410008AF9BC /* JoyDoc+DummyModel.swift in Sources */,
 				364615AB2E29692D00F237F6 /* OnChangeHandlerTest.swift in Sources */,
 				364615AC2E29692D00F237F6 /* DeficiencyTableDemoView.swift in Sources */,
+				36DEC0DA2E30000000F23702 /* DecoratorRowUpdateDemoView.swift in Sources */,
 				E2E3E7762E855F1B002A10C2 /* SimpleFormExampleView.swift in Sources */,
 				E2A683F22DC8FC3A00385FE1 /* FormContainerTestView.swift in Sources */,
 				E24089F52F7C28ED005C4885 /* SampleFormFooter.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
@@ -118,7 +118,7 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
         // tapped cell's row + column. Ordinary cell focus uses target "focus"/"blur",
         // which won't match any column decorator, so those are ignored below.
         guard let action = f.target,
-              let rowID = f.rowIds?.first,
+              let rowIDs = f.rowIds, !rowIDs.isEmpty,
               let columnID = f.columnId else { return }
 
         // Resolve the column — and, for collection fields, the schema it lives in.
@@ -144,7 +144,7 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
             fileID: f.fileID ?? "",
             pageID: f.pageID ?? "",
             fieldPositionID: f.fieldPositionId ?? "",
-            rowID: rowID,
+            rowIDs: rowIDs,
             columnID: columnID,
             columnTitle: column.title.isEmpty ? (column.type?.rawValue ?? "column") : column.title,
             schemaKey: resolved.schemaKey
@@ -224,35 +224,38 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
         guard let editor = editor else { return }
         let doc = editor.document
 
-        var payload: [String: Any] = [
-            "rowId": target.rowID,
-            "row": [
-                "_id": target.rowID,
-                "cells": [target.columnID: cellValue]
+        // One rowUpdate per selected row — covers single edit (1 row) and bulk edit (N rows).
+        let changes: [Change] = target.rowIDs.map { rowID in
+            var payload: [String: Any] = [
+                "rowId": rowID,
+                "row": [
+                    "_id": rowID,
+                    "cells": [target.columnID: cellValue]
+                ]
             ]
-        ]
-        // Collection rows carry their schema id so the change resolves to the right schema.
-        if let schemaKey = target.schemaKey {
-            payload["schemaId"] = schemaKey
+            // Collection rows carry their schema id so the change resolves to the right schema.
+            if let schemaKey = target.schemaKey {
+                payload["schemaId"] = schemaKey
+            }
+            return Change(
+                v: 1,
+                sdk: "swift",
+                target: "field.value.rowUpdate",
+                _id: doc.id ?? "",
+                identifier: doc.identifier ?? "",
+                fileId: target.fileID,
+                pageId: target.pageID,
+                fieldId: target.fieldID,
+                fieldIdentifier: target.fieldIdentifier,
+                fieldPositionId: target.fieldPositionID,
+                change: payload,
+                createdOn: Date().timeIntervalSince1970
+            )
         }
 
-        let change = Change(
-            v: 1,
-            sdk: "swift",
-            target: "field.value.rowUpdate",
-            _id: doc.id ?? "",
-            identifier: doc.identifier ?? "",
-            fileId: target.fileID,
-            pageId: target.pageID,
-            fieldId: target.fieldID,
-            fieldIdentifier: target.fieldIdentifier,
-            fieldPositionId: target.fieldPositionID,
-            change: payload,
-            createdOn: Date().timeIntervalSince1970
-        )
-
-        editor.change(changes: [change])
-        report("Set \(target.columnTitle) → \(summary)")
+        editor.change(changes: changes)
+        let scope = target.rowIDs.count == 1 ? "" : " (\(target.rowIDs.count) rows)"
+        report("Set \(target.columnTitle) → \(summary)\(scope)")
     }
 
     // MARK: Helpers
@@ -263,7 +266,7 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
         let fileID: String
         let pageID: String
         let fieldPositionID: String
-        let rowID: String
+        let rowIDs: [String]
         let columnID: String
         let columnTitle: String
         let schemaKey: String?   // nil for table fields; schema key for collection rows

--- a/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
@@ -49,7 +49,7 @@ struct DecoratorRowUpdateDemoView: View {
     }
 
     private var instructions: some View {
-        Text("Open a row, then tap any column’s decorator (Comment, Camera, Import, Image, File, Download, Claud, Filter, Share). The app catches onFocus and sets that column’s cell for the open row via the Change API — watch the editor update.")
+        Text("Open a row in the Table or Collection (including nested rows), then tap any column’s decorator. The app catches onFocus and sets that column’s cell for the open row via the Change API — watch the editor update live.")
             .font(.footnote)
             .foregroundColor(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -109,31 +109,26 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
     weak var editor: DocumentEditor?
     var onStatus: ((String) -> Void)?
 
-    // Valid decorator action strings in the doc (built once). Lets us react to
-    // decorator taps and ignore ordinary cell focus/blur (target == "focus"/"blur").
-    private var decoratorActions: Set<String>?
-
     // Per-column tap counter so repeated taps produce a visibly different value.
     private var tapCounts: [String: Int] = [:]
 
     func onFocus(event: Event) {
         guard let editor = editor, let f = event.fieldEvent else { return }
+        // A decorator tap arrives via onFocus with the action in `target` and the
+        // tapped cell's row + column. Ordinary cell focus uses target "focus"/"blur",
+        // which won't match any column decorator, so those are ignored below.
+        guard let action = f.target,
+              let rowID = f.rowIds?.first,
+              let columnID = f.columnId else { return }
 
-        if decoratorActions == nil {
-            decoratorActions = Self.collectDecoratorActions(editor: editor, fieldID: f.fieldID)
-        }
-        // Only react to decorator taps, not normal cell focus/blur events.
-        guard let action = f.target, decoratorActions?.contains(action) == true else { return }
-
-        guard let rowID = f.rowIds?.first, let columnID = f.columnId else {
-            report("“\(f.target ?? "?")” fired but event lacked rowId/columnId")
+        // Resolve the column — and, for collection fields, the schema it lives in.
+        guard let resolved = Self.resolveColumn(editor: editor, fieldID: f.fieldID, columnID: columnID) else {
             return
         }
-        guard let column = (editor.field(fieldID: f.fieldID)?.tableColumns ?? [])
-            .first(where: { $0.id == columnID }) else {
-            report("Column \(columnID) not found")
-            return
-        }
+        let column = resolved.column
+
+        // Confirm this column actually carries a decorator with this action.
+        guard (column.decorators ?? []).contains(where: { $0.action == action }) else { return }
 
         let tap = tapCounts[columnID] ?? 0
         tapCounts[columnID] = tap + 1
@@ -151,7 +146,8 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
             fieldPositionID: f.fieldPositionId ?? "",
             rowID: rowID,
             columnID: columnID,
-            columnTitle: column.title.isEmpty ? (column.type?.rawValue ?? "column") : column.title
+            columnTitle: column.title.isEmpty ? (column.type?.rawValue ?? "column") : column.title,
+            schemaKey: resolved.schemaKey
         )
 
         report("“\(action)” on \(target.columnTitle) — calling Change API…")
@@ -228,13 +224,17 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
         guard let editor = editor else { return }
         let doc = editor.document
 
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "rowId": target.rowID,
             "row": [
                 "_id": target.rowID,
                 "cells": [target.columnID: cellValue]
             ]
         ]
+        // Collection rows carry their schema id so the change resolves to the right schema.
+        if let schemaKey = target.schemaKey {
+            payload["schemaId"] = schemaKey
+        }
 
         let change = Change(
             v: 1,
@@ -266,11 +266,24 @@ private final class DecoratorRowUpdateHandler: FormChangeEvent {
         let rowID: String
         let columnID: String
         let columnTitle: String
+        let schemaKey: String?   // nil for table fields; schema key for collection rows
     }
 
-    private static func collectDecoratorActions(editor: DocumentEditor, fieldID: String) -> Set<String> {
-        let columns = editor.field(fieldID: fieldID)?.tableColumns ?? []
-        return Set(columns.flatMap { $0.decorators ?? [] }.compactMap { $0.action })
+    /// Resolves the tapped column and, for collection fields, the schema key it lives in.
+    private static func resolveColumn(editor: DocumentEditor, fieldID: String, columnID: String) -> (column: FieldTableColumn, schemaKey: String?)? {
+        guard let field = editor.field(fieldID: fieldID) else { return nil }
+        if field.fieldType == .collection {
+            for (key, schema) in field.schema ?? [:] {
+                if let col = schema.tableColumns?.first(where: { $0.id == columnID }) {
+                    return (col, key)
+                }
+            }
+            return nil
+        }
+        if let col = field.tableColumns?.first(where: { $0.id == columnID }) {
+            return (col, nil)
+        }
+        return nil
     }
 
     private static func randomObjectID() -> String {

--- a/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift
@@ -1,0 +1,290 @@
+//
+//  DecoratorRowUpdateDemoView.swift
+//  JoyfillExample
+//
+//  Purpose
+//  -------
+//  Verify that the open row-edit form updates live when a row's cell is changed
+//  via the Change API *while that row form is still open* — across every column
+//  type, not just dropdown.
+//
+//  Scenario (no SDK change — app side only):
+//    1. `DecoratorToRowUpdate.json` has one table with a column of each type
+//       (dropdown, text, multiSelect, image, number, date, block, barcode,
+//       signature). Every column carries its own column-level decorator
+//       (Comment, Camera, Import, Image, File, Download, Claud, Filter, Share).
+//    2. The user opens a row and taps one column's decorator.
+//    3. The SDK fires `onFocus(event:)` with the decorator action in
+//       `fieldEvent.target`, the open row in `fieldEvent.rowIds`, and the
+//       tapped column in `fieldEvent.columnId`.
+//    4. We catch it here and "call the API" — i.e. push a
+//       `field.value.rowUpdate` Change that sets that column's cell with a
+//       type-appropriate value (values vary per tap so the change is visible).
+//    5. Watch the still-open row form: does that column's editor reflect it?
+//
+//  The Change-API usage mirrors `DeficiencyTableDemoView`.
+//
+
+import Foundation
+import SwiftUI
+import Joyfill
+import JoyfillModel
+
+struct DecoratorRowUpdateDemoView: View {
+    @StateObject private var box = DecoratorRowUpdateBox()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            instructions
+            Form(documentEditor: box.editor)
+        }
+        .navigationTitle("Decorator → Row Change")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .bottom) {
+            if let status = box.lastStatus {
+                statusBanner(status).padding(.bottom, 24)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: box.lastStatus)
+    }
+
+    private var instructions: some View {
+        Text("Open a row, then tap any column’s decorator (Comment, Camera, Import, Image, File, Download, Claud, Filter, Share). The app catches onFocus and sets that column’s cell for the open row via the Change API — watch the editor update.")
+            .font(.footnote)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color(uiColor: .secondarySystemBackground))
+    }
+
+    private func statusBanner(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+            Text(text).font(.subheadline.weight(.medium))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(.black.opacity(0.82))
+        .cornerRadius(14)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+}
+
+// MARK: - Editor box (owns the DocumentEditor + the change handler)
+
+private final class DecoratorRowUpdateBox: ObservableObject {
+    let editor: DocumentEditor
+    @Published var lastStatus: String?
+
+    private let handler = DecoratorRowUpdateHandler()
+
+    init() {
+        let document = DecoratorRowUpdateBox.loadDoc(named: "DecoratorToRowUpdate")
+        editor = DocumentEditor(
+            document: document,
+            mode: .fill,
+            events: handler,
+            validateSchema: false,
+            license: licenseKey,
+            singleClickRowEdit: true
+        )
+        handler.editor = editor
+        handler.onStatus = { [weak self] text in
+            self?.lastStatus = text
+        }
+    }
+
+    static func loadDoc(named name: String) -> JoyDoc {
+        let url = Bundle.main.url(forResource: name, withExtension: "json")!
+        let data = try! Data(contentsOf: url)
+        let dict = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        return JoyDoc(dictionary: dict)
+    }
+}
+
+// MARK: - Change handler: onFocus(decorator) -> Change API rowUpdate, any column type
+
+private final class DecoratorRowUpdateHandler: FormChangeEvent {
+    weak var editor: DocumentEditor?
+    var onStatus: ((String) -> Void)?
+
+    // Valid decorator action strings in the doc (built once). Lets us react to
+    // decorator taps and ignore ordinary cell focus/blur (target == "focus"/"blur").
+    private var decoratorActions: Set<String>?
+
+    // Per-column tap counter so repeated taps produce a visibly different value.
+    private var tapCounts: [String: Int] = [:]
+
+    func onFocus(event: Event) {
+        guard let editor = editor, let f = event.fieldEvent else { return }
+
+        if decoratorActions == nil {
+            decoratorActions = Self.collectDecoratorActions(editor: editor, fieldID: f.fieldID)
+        }
+        // Only react to decorator taps, not normal cell focus/blur events.
+        guard let action = f.target, decoratorActions?.contains(action) == true else { return }
+
+        guard let rowID = f.rowIds?.first, let columnID = f.columnId else {
+            report("“\(f.target ?? "?")” fired but event lacked rowId/columnId")
+            return
+        }
+        guard let column = (editor.field(fieldID: f.fieldID)?.tableColumns ?? [])
+            .first(where: { $0.id == columnID }) else {
+            report("Column \(columnID) not found")
+            return
+        }
+
+        let tap = tapCounts[columnID] ?? 0
+        tapCounts[columnID] = tap + 1
+
+        guard let (cellValue, summary) = cellPayloadValue(for: column, tap: tap) else {
+            report("“\(action)” — \(column.type?.rawValue ?? "?") column not supported here")
+            return
+        }
+
+        let target = ChangeTarget(
+            fieldID: f.fieldID,
+            fieldIdentifier: f.fieldIdentifier,
+            fileID: f.fileID ?? "",
+            pageID: f.pageID ?? "",
+            fieldPositionID: f.fieldPositionId ?? "",
+            rowID: rowID,
+            columnID: columnID,
+            columnTitle: column.title.isEmpty ? (column.type?.rawValue ?? "column") : column.title
+        )
+
+        report("“\(action)” on \(target.columnTitle) — calling Change API…")
+
+        // Simulate the round-trip of "calling an API" that returns the new
+        // value, then applying it via the Change API. The async hop also keeps
+        // us out of the SDK's focus-dispatch call stack.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            self?.applyChange(target: target, cellValue: cellValue, summary: summary)
+        }
+    }
+
+    // MARK: Value generation per column type
+
+    /// Builds a `cells` payload value (already in the dictionary form the SDK
+    /// emits) plus a short human summary for the status banner. Returns nil for
+    /// column types that have no editable cell in the row form.
+    private func cellPayloadValue(for column: FieldTableColumn, tap n: Int) -> (value: Any, summary: String)? {
+        switch column.type ?? .unknown {
+        case .text, .barcode:
+            let v = "Updated #\(n + 1)"
+            return (v, "“\(v)”")
+
+        case .signature:
+            // Signature cell value is a string (image URL / data URL).
+            let v = "https://picsum.photos/seed/sig\(n + 1)/300/120"
+            return (v, "sample signature image")
+
+        case .number:
+            let v = Double((n + 1) * 10)
+            return (v, "\(Int(v))")
+
+        case .date:
+            // Date cells store epoch milliseconds as a Double.
+            let millis = Date().timeIntervalSince1970 * 1000
+            return (millis, "today")
+
+        case .dropdown:
+            guard let opt = nextOption(column, tap: n) else { return nil }
+            return (opt.id, "“\(opt.value)”")
+
+        case .multiSelect:
+            guard let opt = nextOption(column, tap: n) else { return nil }
+            return ([opt.id], "“\(opt.value)”")
+
+        case .image:
+            let element: [String: Any] = [
+                "_id": Self.randomObjectID(),
+                "url": "https://picsum.photos/seed/img\(n + 1)/300/200"
+            ]
+            return ([element], "1 image")
+
+        case .block:
+            // Block columns are display-only — no editor in the row form, so this
+            // won't visibly refresh; included so the action is still acknowledged.
+            let v = "Block #\(n + 1)"
+            return (v, "“\(v)” (block is display-only)")
+
+        case .progress, .table, .unknown:
+            return nil
+        }
+    }
+
+    private func nextOption(_ column: FieldTableColumn, tap n: Int) -> (id: String, value: String)? {
+        let opts = (column.options ?? []).filter { !($0.deleted ?? false) }
+        guard !opts.isEmpty else { return nil }
+        let o = opts[n % opts.count]
+        return (o.id ?? "", o.value ?? "")
+    }
+
+    // MARK: Change application
+
+    private func applyChange(target: ChangeTarget, cellValue: Any, summary: String) {
+        guard let editor = editor else { return }
+        let doc = editor.document
+
+        let payload: [String: Any] = [
+            "rowId": target.rowID,
+            "row": [
+                "_id": target.rowID,
+                "cells": [target.columnID: cellValue]
+            ]
+        ]
+
+        let change = Change(
+            v: 1,
+            sdk: "swift",
+            target: "field.value.rowUpdate",
+            _id: doc.id ?? "",
+            identifier: doc.identifier ?? "",
+            fileId: target.fileID,
+            pageId: target.pageID,
+            fieldId: target.fieldID,
+            fieldIdentifier: target.fieldIdentifier,
+            fieldPositionId: target.fieldPositionID,
+            change: payload,
+            createdOn: Date().timeIntervalSince1970
+        )
+
+        editor.change(changes: [change])
+        report("Set \(target.columnTitle) → \(summary)")
+    }
+
+    // MARK: Helpers
+
+    private struct ChangeTarget {
+        let fieldID: String
+        let fieldIdentifier: String?
+        let fileID: String
+        let pageID: String
+        let fieldPositionID: String
+        let rowID: String
+        let columnID: String
+        let columnTitle: String
+    }
+
+    private static func collectDecoratorActions(editor: DocumentEditor, fieldID: String) -> Set<String> {
+        let columns = editor.field(fieldID: fieldID)?.tableColumns ?? []
+        return Set(columns.flatMap { $0.decorators ?? [] }.compactMap { $0.action })
+    }
+
+    private static func randomObjectID() -> String {
+        let chars = Array("0123456789abcdef")
+        return String((0..<24).map { _ in chars.randomElement()! })
+    }
+
+    private func report(_ text: String) {
+        DispatchQueue.main.async { [weak self] in self?.onStatus?(text) }
+    }
+
+    func onChange(changes: [Change], document: JoyDoc) {}
+    func onBlur(event: Event) {}
+    func onUpload(event: UploadEvent) {}
+    func onCapture(event: CaptureEvent) {}
+    func onError(error: JoyfillError) {}
+}

--- a/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorToRowUpdate.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorToRowUpdate.json
@@ -31,6 +31,16 @@
               "width": 8,
               "height": 15,
               "field": "6a313d862372abbb3635f6cf"
+            },
+            {
+              "_id": "6a317df7587195e4f2dc3723",
+              "type": "collection",
+              "displayType": "original",
+              "x": 0,
+              "y": 15,
+              "width": 8,
+              "height": 29,
+              "field": "6a317df785e63c7788ff5ad5"
             }
           ],
           "hidden": false,
@@ -281,6 +291,278 @@
         "6a2f8df96db27802eadf2863",
         "6a2f8df992e40d2d6d551821"
       ]
+    },
+    {
+      "file": "68d101cf56b1d0b1393bb36a",
+      "_id": "6a317df785e63c7788ff5ad5",
+      "type": "collection",
+      "title": "Collection",
+      "value": [
+        {
+          "_id": "6a317e07f5a0a2c074ad1a33",
+          "cells": {},
+          "children": {
+            "level1Table1": {
+              "value": [
+                {
+                  "_id": "6a317e6068ce87bd8d4897a8",
+                  "cells": {},
+                  "children": {
+                    "level2Table1": {
+                      "value": [
+                        {
+                          "_id": "6a317e681184d4c2dd99552b",
+                          "cells": {},
+                          "children": {}
+                        },
+                        {
+                          "_id": "6a317e69cba959dfd316d8ee",
+                          "cells": {},
+                          "children": {}
+                        },
+                        {
+                          "_id": "6a317e6a3a5b924687b04519",
+                          "cells": {},
+                          "children": {}
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "_id": "6a317e6337f92d73d48c3673",
+                  "cells": {},
+                  "children": {}
+                },
+                {
+                  "_id": "6a317e642e6edd3fdfaf0aa0",
+                  "cells": {},
+                  "children": {}
+                }
+              ]
+            }
+          }
+        },
+        {
+          "_id": "6a317e5c298dd8d4c2bbceb2",
+          "cells": {},
+          "children": {}
+        },
+        {
+          "_id": "6a317e5d5c6b1ecde6362778",
+          "cells": {},
+          "children": {}
+        }
+      ],
+      "schema": {
+        "collectionSchemaId": {
+          "title": "Main Collection",
+          "root": true,
+          "children": [
+            "level1Table1"
+          ],
+          "tableColumns": [
+            {
+              "_id": "6813008e76da519a97819c69",
+              "type": "text",
+              "title": "Text",
+              "identifier": "6a317df785e63c7788ff5ad5_column_6813008e76da519a97819c69",
+              "width": 0,
+              "decorators": [
+                {
+                  "_id": "6a317e6e264868234365e987",
+                  "icon": "flag",
+                  "label": "flag",
+                  "action": "flag",
+                  "color": "#71352b"
+                }
+              ]
+            },
+            {
+              "_id": "6813008e36be88d98ed5a90a",
+              "type": "dropdown",
+              "title": "Dropdown",
+              "options": [
+                {
+                  "_id": "6813008e634fdf79fe013b42",
+                  "value": "High"
+                },
+                {
+                  "_id": "6813008efb95416fd9326038",
+                  "value": "Medium"
+                },
+                {
+                  "_id": "6813008e095af24f0f0b32f2",
+                  "value": "Low"
+                }
+              ],
+              "identifier": "6a317df785e63c7788ff5ad5_column_6813008e36be88d98ed5a90a",
+              "width": 0,
+              "decorators": [
+                {
+                  "_id": "6a317e948fe8459748620436",
+                  "icon": "plus",
+                  "label": "plus",
+                  "action": "plus",
+                  "color": "#d7d01d"
+                }
+              ]
+            },
+            {
+              "_id": "6813008ea26d706f2a5db2d5",
+              "type": "image",
+              "title": "Image",
+              "identifier": "6a317df785e63c7788ff5ad5_column_6813008ea26d706f2a5db2d5",
+              "width": 0,
+              "decorators": [
+                {
+                  "_id": "6a317ea8344e306e83349492",
+                  "icon": "circle-info",
+                  "label": "info",
+                  "action": "info",
+                  "color": "#1bb1a0"
+                }
+              ]
+            }
+          ]
+        },
+        "level1Table1": {
+          "title": "New Table",
+          "children": [
+            "level2Table1"
+          ],
+          "hidden": false,
+          "tableColumns": [
+            {
+              "_id": "6a317e24f9e79ac5d161dc65",
+              "type": "multiSelect",
+              "title": "MultiSelect Column",
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a317e24909df704788ee5f1",
+                  "value": "Option 1",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a317e2454f86a60012073b6",
+                  "value": "Option 2",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a317e24dd08a3986595389a",
+                  "value": "Option 3",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e24f9e79ac5d161dc65",
+              "decorators": [
+                {
+                  "_id": "6a317ebbaadaf129019e0e14",
+                  "icon": "eye",
+                  "label": "eye",
+                  "action": "eye",
+                  "color": "#1a567e"
+                }
+              ]
+            },
+            {
+              "_id": "6a317e316d2da50f698c4652",
+              "type": "number",
+              "title": "Number Column",
+              "deleted": false,
+              "width": 0,
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e316d2da50f698c4652",
+              "decorators": [
+                {
+                  "_id": "6a317ed0473f343cfba33d13",
+                  "icon": "magnet",
+                  "label": "magnet",
+                  "action": "magnet",
+                  "color": "#8733be"
+                }
+              ]
+            },
+            {
+              "_id": "6a317e340190b92f973ca8d9",
+              "type": "date",
+              "title": "Date Column",
+              "deleted": false,
+              "width": 0,
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e340190b92f973ca8d9",
+              "decorators": [
+                {
+                  "_id": "6a317eebd5fd3010f6952f21",
+                  "icon": "folder-open",
+                  "label": "folder open",
+                  "action": "folderopen",
+                  "color": "#3f2d54"
+                }
+              ]
+            }
+          ]
+        },
+        "level2Table1": {
+          "title": "New Table",
+          "children": [],
+          "hidden": false,
+          "tableColumns": [
+            {
+              "_id": "6a317e405e2f8eb7ebce253c",
+              "type": "signature",
+              "title": "Signature Column",
+              "width": 0,
+              "deleted": false,
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e405e2f8eb7ebce253c",
+              "decorators": [
+                {
+                  "_id": "6a317f00fc4609a5c2ca0bcd",
+                  "icon": "paper-plane",
+                  "label": "paper",
+                  "action": "paper",
+                  "color": "#1fbe75"
+                }
+              ]
+            },
+            {
+              "_id": "6a317e48f3c62f60451ac148",
+              "type": "barcode",
+              "title": "Barcode Column",
+              "width": 0,
+              "deleted": false,
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e48f3c62f60451ac148",
+              "decorators": [
+                {
+                  "_id": "6a317f169cd3d5ba05181c86",
+                  "icon": "filter",
+                  "label": "filter",
+                  "action": "filter",
+                  "color": "#564e5c"
+                }
+              ]
+            },
+            {
+              "_id": "6a317e57d183652cf12449cf",
+              "type": "block",
+              "title": "Label Column",
+              "width": 0,
+              "deleted": false,
+              "identifier": "6a317df785e63c7788ff5ad5_column_6a317e57d183652cf12449cf",
+              "decorators": [
+                {
+                  "_id": "6a317f294e06d3a0cee1de5b",
+                  "icon": "rotate",
+                  "label": "rotate",
+                  "action": "rotate",
+                  "color": "#ad1c90"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "identifier": "field_6a317df785e63c7788ff5ad5"
     }
   ],
   "_id": "68d101ee8f5793b7cd6031fc",

--- a/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorToRowUpdate.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/DecoratorToRowUpdate/DecoratorToRowUpdate.json
@@ -1,0 +1,290 @@
+{
+  "files": [
+    {
+      "_id": "68d101cf56b1d0b1393bb36a",
+      "styles": {
+        "margin": 4
+      },
+      "pages": [
+        {
+          "padding": 24,
+          "layout": "grid",
+          "deletable": true,
+          "metadata": {},
+          "width": 816,
+          "_id": "68d101cf609190215b11e750",
+          "presentation": "normal",
+          "cols": 8,
+          "margin": 0,
+          "borderWidth": 0,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ],
+          "fieldPositions": [
+            {
+              "_id": "6a313d864e24b43684cd3794",
+              "type": "table",
+              "displayType": "original",
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 15,
+              "field": "6a313d862372abbb3635f6cf"
+            }
+          ],
+          "hidden": false,
+          "height": 1056,
+          "rowHeight": 8,
+          "name": "Survey Form"
+        }
+      ],
+      "pageOrder": [
+        "68d101cf609190215b11e750"
+      ],
+      "version": 1,
+      "views": [],
+      "metadata": {},
+      "name": "New File"
+    }
+  ],
+  "metadata": {},
+  "stage": "published",
+  "deleted": false,
+  "type": "template",
+  "source": "template_68d101cff84d57b1b3466679",
+  "fields": [
+    {
+      "file": "68d101cf56b1d0b1393bb36a",
+      "_id": "6a313d862372abbb3635f6cf",
+      "type": "table",
+      "title": "Table",
+      "tableColumns": [
+        {
+          "_id": "6a2f8df94368bf03f840d993",
+          "type": "dropdown",
+          "title": "Dropdown Column",
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "6a2f8df9bee9a9fa2d659d3f",
+              "value": "Yes",
+              "deleted": false
+            },
+            {
+              "_id": "6a2f8df92f5d205149a81cf2",
+              "value": "No",
+              "deleted": false
+            },
+            {
+              "_id": "6a2f8df9359c931017ab2cad",
+              "value": "N/A",
+              "deleted": false
+            }
+          ],
+          "identifier": "6a313d862372abbb3635f6cf_column_6a2f8df94368bf03f840d993",
+          "decorators": [
+            {
+              "_id": "6a3140a8889eb55cc3e66c16",
+              "icon": "comment",
+              "label": "comment",
+              "action": "Comment",
+              "color": "#4a018f"
+            }
+          ]
+        },
+        {
+          "_id": "6a2f8df9a0e2bdba1341ea03",
+          "type": "text",
+          "title": "Text Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a2f8df9a0e2bdba1341ea03",
+          "decorators": [
+            {
+              "_id": "6a3147d907e1fc3b56218cb6",
+              "icon": "camera",
+              "label": "Camera",
+              "action": "Camera",
+              "color": "#a44d1c"
+            }
+          ]
+        },
+        {
+          "_id": "6a3147def8cfe74d2e38597f",
+          "type": "multiSelect",
+          "title": "MultiSelect Column",
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "6a3147de8f50c344d0eecf84",
+              "value": "Option 1",
+              "deleted": false
+            },
+            {
+              "_id": "6a3147deb2913c1615de2330",
+              "value": "Option 2",
+              "deleted": false
+            },
+            {
+              "_id": "6a3147de7b009f981b80b152",
+              "value": "Option 3",
+              "deleted": false
+            }
+          ],
+          "identifier": "6a313d862372abbb3635f6cf_column_6a3147def8cfe74d2e38597f",
+          "decorators": [
+            {
+              "_id": "6a3147efed761e5e541c96a0",
+              "icon": "import",
+              "label": "Import",
+              "action": "Import",
+              "color": "#5c8b12"
+            }
+          ]
+        },
+        {
+          "_id": "6a3147f2d0a36d3df3b9f0b8",
+          "type": "image",
+          "title": "Image Column",
+          "deleted": false,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a3147f2d0a36d3df3b9f0b8",
+          "decorators": [
+            {
+              "_id": "6a3148011fd190bc4940efb7",
+              "icon": "image",
+              "label": "Image",
+              "action": "Image",
+              "color": "#b53822"
+            }
+          ]
+        },
+        {
+          "_id": "6a31480657d219ed143d005c",
+          "type": "number",
+          "title": "Number Column",
+          "deleted": false,
+          "width": 0,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a31480657d219ed143d005c",
+          "decorators": [
+            {
+              "_id": "6a31481747a185c44a549628",
+              "icon": "file",
+              "label": "File",
+              "action": "File",
+              "color": "#2594b5"
+            }
+          ]
+        },
+        {
+          "_id": "6a31481bafd339dd92cb2de0",
+          "type": "date",
+          "title": "Date Column",
+          "deleted": false,
+          "width": 0,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a31481bafd339dd92cb2de0",
+          "decorators": [
+            {
+              "_id": "6a31483728ffec83e743277b",
+              "icon": "download",
+              "label": "Download",
+              "action": "Download",
+              "color": "#a019be"
+            }
+          ]
+        },
+        {
+          "_id": "6a31481c63508bbc9f978741",
+          "type": "block",
+          "title": "Block Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a31481c63508bbc9f978741",
+          "decorators": [
+            {
+              "_id": "6a314849954cf6698c5b3018",
+              "icon": "cloud",
+              "label": "Claud",
+              "action": "Claud",
+              "color": "#0d4b3f"
+            }
+          ]
+        },
+        {
+          "_id": "6a31481e11b16a15b119ce55",
+          "type": "barcode",
+          "title": "Barcode Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a31481e11b16a15b119ce55",
+          "decorators": [
+            {
+              "_id": "6a3148591569ce160ca900ab",
+              "icon": "filter",
+              "label": "Filter",
+              "action": "Filter",
+              "color": "#a92170"
+            }
+          ]
+        },
+        {
+          "_id": "6a31481f73b6d006304084d4",
+          "type": "signature",
+          "title": "Signature Column",
+          "width": 0,
+          "deleted": false,
+          "identifier": "6a313d862372abbb3635f6cf_column_6a31481f73b6d006304084d4",
+          "decorators": [
+            {
+              "_id": "6a3148691c3f45586270041e",
+              "icon": "share",
+              "label": "Share",
+              "action": "Share",
+              "color": "#b5a922"
+            }
+          ]
+        }
+      ],
+      "value": [
+        {
+          "_id": "6a2f8df910ebe1b7a93ca1be",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "6a2f8df96db27802eadf2863",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "6a2f8df992e40d2d6d551821",
+          "deleted": false,
+          "cells": {}
+        }
+      ],
+      "identifier": "field_6a313d862372abbb3635f6cf",
+      "tableColumnOrder": [
+        "6a2f8df94368bf03f840d993",
+        "6a2f8df9a0e2bdba1341ea03",
+        "6a3147def8cfe74d2e38597f",
+        "6a3147f2d0a36d3df3b9f0b8",
+        "6a31480657d219ed143d005c",
+        "6a31481bafd339dd92cb2de0",
+        "6a31481c63508bbc9f978741",
+        "6a31481e11b16a15b119ce55",
+        "6a31481f73b6d006304084d4"
+      ],
+      "rowOrder": [
+        "6a2f8df910ebe1b7a93ca1be",
+        "6a2f8df96db27802eadf2863",
+        "6a2f8df992e40d2d6d551821"
+      ]
+    }
+  ],
+  "_id": "68d101ee8f5793b7cd6031fc",
+  "identifier": "doc_68d101ee8f5793b7cd6031fc",
+  "createdOn": 1758527982824,
+  "name": "New Template"
+}

--- a/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
+++ b/JoyfillSwiftUIExample/JoyfillExample/UserAccessTokenTextFieldView.swift
@@ -508,6 +508,7 @@ struct OptionSelectionView: View {
         case createRowUISample
         case metadataChangeAPIDemo
         case decoratorAPIDemo
+        case decoratorRowUpdateDemo
         case simpleForm
         case simpleNavigationTest
         case footerExample
@@ -542,6 +543,8 @@ struct OptionSelectionView: View {
                 return "Metadata Change API Demo"
             case .decoratorAPIDemo:
                 return "Decorator API Demo"
+            case .decoratorRowUpdateDemo:
+                return "Decorator → Row Change"
             case .simpleForm:
                 return "Simple example Form"
             case .simpleNavigationTest:
@@ -581,6 +584,8 @@ struct OptionSelectionView: View {
                 return "Set field and row metadata via Change API (field.update, rowCreate, rowUpdate)"
             case .decoratorAPIDemo:
                 return "Add, remove and update decorators on any field at runtime"
+            case .decoratorRowUpdateDemo:
+                return "Tap a column decorator in an open row, set its dropdown via the Change API, and watch the UI update"
             case .simpleForm:
                 return "Simple example Form"
             case .simpleNavigationTest:
@@ -620,6 +625,8 @@ struct OptionSelectionView: View {
                 return "tag.fill"
             case .decoratorAPIDemo:
                 return "paintbrush.pointed.fill"
+            case .decoratorRowUpdateDemo:
+                return "arrow.triangle.2.circlepath"
             case .simpleForm:
                 return "slider.horizontal.3"
             case .simpleNavigationTest:
@@ -659,6 +666,8 @@ struct OptionSelectionView: View {
                 return .orange
             case .decoratorAPIDemo:
                 return .blue
+            case .decoratorRowUpdateDemo:
+                return .purple
             case .simpleForm:
                 return .blue
             case .simpleNavigationTest:
@@ -810,6 +819,8 @@ struct OptionSelectionView: View {
             MetadataChangeAPIDemoView()
         case .decoratorAPIDemo:
             DecoratorAPIDemoView()
+        case .decoratorRowUpdateDemo:
+            DecoratorRowUpdateDemoView()
         case .simpleForm:
             SimpleFormExampleView()
         case .simpleNavigationTest:

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
@@ -529,6 +529,82 @@ final class TableViewModelDocumentEditorDelegateTests: XCTestCase {
         XCTAssertEqual(rowOrderForDocument, 3, "Value should be equal")
     }
 
+    // Regression: applyRowEditChanges must bump the target cell's id in cellModels
+    // (via isBulkEdit: true) so the updated value survives the next filterRowsIfNeeded()
+    // call (e.g. Insert Below). Without the id bump, SwiftUI reuses the old cell view
+    // and the value appears to vanish from the grid after a row operation.
+    func testApplyRowEditChanges_CellIdIsBumpedAndValueSurvivesFilterRowsIfNeeded() {
+        // Arrange
+        let document = createTestDocument()
+        let documentEditor = DocumentEditor(document: document, validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        let rowID = "684c3fedfed2b76677110b19"
+        let colID = "684c3fedce82027a49234dd3"
+        let newValue = "CellIdBumpTest"
+
+        guard let rowIndex = viewModel.tableDataModel.rowOrder.firstIndex(of: rowID) else {
+            XCTFail("Row '\(rowID)' not found in rowOrder"); return
+        }
+        guard let colIndex = viewModel.tableDataModel.tableColumns.firstIndex(where: { $0.id == colID }) else {
+            XCTFail("Column '\(colID)' not found in tableColumns"); return
+        }
+
+        // Snapshot cell id before the change
+        let cellIDBefore = viewModel.tableDataModel.cellModels[rowIndex].cells[colIndex].id
+
+        let changeDict: [String: Any] = [
+            "target": "field.value.rowUpdate",
+            "pageId": pageID,
+            "fileId": fileID,
+            "fieldId": tableFieldID,
+            "fieldIdentifier": "field_6857510f0b31d28d169b83d8",
+            "fieldPositionId": "6857510f4313cfbfb43c516c",
+            "_id": "685750eff3216b45ffe73c80",
+            "identifier": "doc_685750eff3216b45ffe73c80",
+            "sdk": "swift",
+            "v": 1,
+            "createdOn": 1756788529.0,
+            "change": [
+                "rowId": rowID,
+                "row": [
+                    "_id": rowID,
+                    "cells": [colID: newValue]
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+
+        // Act — applyRowEditChanges is the path taken when the row edit form is open
+        viewModel.applyRowEditChanges(change: Change(dictionary: changeDict))
+
+        // Assert 1: cellModels cell id was bumped (isBulkEdit: true → UUID())
+        let cellIDAfter = viewModel.tableDataModel.cellModels[rowIndex].cells[colIndex].id
+        XCTAssertNotEqual(cellIDBefore, cellIDAfter,
+            "applyRowEditChanges should bump cell id in cellModels (isBulkEdit: true)")
+
+        // Assert 2: value updated in cellModels
+        XCTAssertEqual(viewModel.tableDataModel.cellModels[rowIndex].cells[colIndex].data.title, newValue,
+            "cellModels should reflect the Change-API value after applyRowEditChanges")
+
+        // Assert 3: simulate a row operation (Insert Below / move) — filterRowsIfNeeded()
+        // for table fields sets filteredcellModels = cellModels; the bumped id + value must survive
+        viewModel.tableDataModel.filterRowsIfNeeded()
+
+        guard let filteredIndex = viewModel.tableDataModel.filteredcellModels.firstIndex(where: { $0.rowID == rowID }) else {
+            XCTFail("Row '\(rowID)' not found in filteredcellModels after filterRowsIfNeeded()"); return
+        }
+
+        XCTAssertEqual(
+            viewModel.tableDataModel.filteredcellModels[filteredIndex].cells[colIndex].id,
+            cellIDAfter,
+            "filteredcellModels should carry the bumped cell id after filterRowsIfNeeded()")
+
+        XCTAssertEqual(
+            viewModel.tableDataModel.filteredcellModels[filteredIndex].cells[colIndex].data.title,
+            newValue,
+            "filteredcellModels should retain the Change-API value after filterRowsIfNeeded()")
+    }
+
     // Regression: insertBelow() previously left tableDataModel.valueToValueElements
     // stale relative to rowOrder. The fix appends the new element to the in-memory
     // value array; this test pins the invariant so a future revert is caught here

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
@@ -1,0 +1,310 @@
+import XCTest
+
+// Table column decorator actions (from DecoratorToRowUpdate.json, tableColumnOrder)
+private let tableDropdownAction    = "Comment"   // dropdown   → "Yes"
+private let tableTextAction        = "Camera"    // text       → "Updated #1"
+private let tableMultiSelectAction = "Import"    // multiSelect → "Option 1"
+private let tableImageAction       = "Image"     // image      → 1 image added
+private let tableNumberAction      = "File"      // number     → 10
+private let tableDateAction        = "Download"  // date       → current epoch
+private let tableBlockAction       = "Claud"     // block      → display-only
+private let tableBarcodeAction     = "Filter"    // barcode    → "Updated #1"
+private let tableSignatureAction   = "Share"     // signature  → image URL
+
+// Collection root-level decorator actions (collectionSchemaId: text, dropdown, image)
+private let collRootTextAction     = "flag"      // text       → "Updated #1"
+private let collRootDropdownAction = "plus"      // dropdown   → "High"
+private let collRootImageAction    = "info"      // image      → 1 image added
+
+// Collection level-1 decorator actions (level1Table1: multiSelect, number, date)
+private let collL1MultiSelectAction = "eye"        // multiSelect → "Option 1"
+private let collL1NumberAction      = "magnet"     // number      → 10
+private let collL1DateAction        = "folderopen" // date        → current epoch
+
+// Collection level-2 decorator actions (level2Table1: signature, barcode, block)
+private let collL2SignatureAction = "paper"    // signature → image URL
+private let collL2BarcodeAction   = "filter"   // barcode   → "Updated #1"
+private let collL2BlockAction     = "rotate"   // block     → display-only
+
+// MARK: - DecoratorRowUpdateUITests
+
+final class DecoratorRowUpdateUITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+        app.launchArguments = ["--disable-animations"]
+        addUIInterruptionMonitor(withDescription: "System Alerts") { alert in
+            for label in ["Allow", "OK", "Continue", "Don't Allow"] {
+                if alert.buttons[label].exists { alert.buttons[label].tap(); return true }
+            }
+            return false
+        }
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15), "App did not launch")
+
+        // Navigate from OptionSelectionView → DecoratorRowUpdateDemoView
+        let card = app.staticTexts["Decorator → Row Change"]
+        if !card.waitForExistence(timeout: 5) {
+            app.swipeUp()
+            _ = card.waitForExistence(timeout: 3)
+        }
+        XCTAssertTrue(card.exists, "Decorator → Row Change card not found in OptionSelectionView")
+        card.tap()
+        spinRunloop(0.2)
+
+        let continueBtn = app.buttons["Continue"]
+        XCTAssertTrue(continueBtn.waitForExistence(timeout: 3), "Continue button not found")
+        continueBtn.tap()
+        spinRunloop(0.5)
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        app = nil
+    }
+
+    // MARK: - Table
+
+    /// Opens table row 1's edit form, taps every column decorator once,
+    /// verifies each field updates live, then dismisses and checks the grid.
+    func testTableDecoratorUpdatesRowFormAndGrid() {
+        typealias S = DecoratorUITestSupport
+
+        S.openTableDetailView(in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        // Dropdown → "Yes" (first option)
+        tapDecoratorAndAssertStaticText(action: tableDropdownAction, expected: "Yes")
+        // Text → "Updated #1" (TextField inside TableTextRowFormView)
+        tapDecoratorAndAssertTextField(action: tableTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        // MultiSelect → "Option 1" (first option shown as Text inside button)
+        tapDecoratorAndAssertStaticText(action: tableMultiSelectAction, expected: "Option 1")
+        // Image → cell receives one image (container exists)
+        tapDecoratorAndAssertExists(action: tableImageAction, identifier: "EditRowsImageFieldIdentifier")
+        // Number → "10" (TextField inside TableNumberView, identifier "TabelNumberFieldIdentifier")
+        tapDecoratorAndAssertTextField(action: tableNumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        // Date → inner ChangeCellDateIdentifier button has a non-empty label
+        tapDecoratorAndAssertButtonHasValue(action: tableDateAction, identifier: "ChangeCellDateIdentifier")
+        // Block → display-only, no row-form editor
+        tapDecoratorDisplayOnly(action: tableBlockAction)
+        // Barcode → "Updated #1" (TextEditor inside TableBarcodeView, identifier "TableBarcodeFieldIdentifier")
+        tapDecoratorAndAssertTextView(action: tableBarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        // Signature → field container renders after URL is set
+        tapDecoratorAndAssertExists(action: tableSignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+
+        S.dismissRowEditForm(in: app)
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "Yes")
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+    }
+
+    // MARK: - Collection root level
+
+    /// Opens collection root row 1's edit form, taps all 3 decorators (text, dropdown,
+    /// image), verifies live updates, then dismisses and checks the grid cells.
+    func testCollectionRootDecoratorUpdatesRowFormAndGrid() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        // Text → "Updated #1"
+        tapDecoratorAndAssertTextField(action: collRootTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        // Dropdown → "High" (first option)
+        tapDecoratorAndAssertStaticText(action: collRootDropdownAction, expected: "High")
+        // Image → container exists
+        tapDecoratorAndAssertExists(action: collRootImageAction, identifier: "EditRowsImageFieldIdentifier")
+
+        S.dismissRowEditForm(in: app)
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "High")
+    }
+
+    // MARK: - Collection level 1
+
+    /// Expands root row 1, opens L1 row 1's edit form, taps all 3 decorators
+    /// (multiSelect, number, date), verifies live updates, then dismisses and checks the grid.
+    func testCollectionLevel1DecoratorUpdatesRowFormAndGrid() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+
+        // MultiSelect → "Option 1"
+        tapDecoratorAndAssertStaticText(action: collL1MultiSelectAction, expected: "Option 1")
+        // Number → "10"
+        tapDecoratorAndAssertTextField(action: collL1NumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        // Date → inner button has a non-empty label
+        tapDecoratorAndAssertButtonHasValue(action: collL1DateAction, identifier: "ChangeCellDateIdentifier")
+
+        S.dismissRowEditForm(in: app)
+
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+    }
+
+    // MARK: - Collection level 2
+
+    /// Expands root row 1 → L1 row 1, opens L2 row 1's edit form, taps all 3 decorators
+    /// (signature, barcode, block), verifies live updates, then dismisses and checks the grid.
+    func testCollectionLevel2DecoratorUpdatesRowFormAndGrid() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.expandCollectionNestedRow(at: 1, in: app)
+        // L2 row shares "SingleClickEditNestedButton1" with L1; boundBy:1 picks L2
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+
+        // Signature → container renders after URL is set
+        tapDecoratorAndAssertExists(action: collL2SignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+        // Barcode → "Updated #1" (TextEditor, identifier "TableBarcodeFieldIdentifier")
+        tapDecoratorAndAssertTextView(action: collL2BarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        // Block → display-only, no row-form editor
+        tapDecoratorDisplayOnly(action: collL2BlockAction)
+
+        S.dismissRowEditForm(in: app)
+
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+        assertGridTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+    }
+
+    // MARK: - Row-form tap + assert helpers
+
+    /// Taps decorator, waits for a SwiftUI TextField (→ .textField) to show expected value.
+    /// Used for: text column (EditRowsTextFieldIdentifier), number (TabelNumberFieldIdentifier).
+    private func tapDecoratorAndAssertTextField(action: String, identifier: String, expected: String) {
+        tapDecorator(action: action)
+        let field = app.textFields.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { field.exists && field.value as? String == expected },
+            "'\(identifier)' should show '\(expected)' after tapping '\(action)' decorator"
+        )
+    }
+
+    /// Taps decorator, waits for a SwiftUI TextEditor (→ .textView) to show expected value.
+    /// Used for: barcode column (TableBarcodeFieldIdentifier).
+    private func tapDecoratorAndAssertTextView(action: String, identifier: String, expected: String) {
+        tapDecorator(action: action)
+        let field = app.textViews.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { field.exists && field.value as? String == expected },
+            "'\(identifier)' should show '\(expected)' after tapping '\(action)' decorator"
+        )
+    }
+
+    /// Taps decorator, waits for a static text with the given label to appear.
+    /// Used for: dropdown and multiSelect (selected option value is rendered as Text).
+    private func tapDecoratorAndAssertStaticText(action: String, expected: String) {
+        tapDecorator(action: action)
+        XCTAssertTrue(
+            waitUntil(3) { self.app.staticTexts[expected].exists },
+            "'\(expected)' should appear as static text after tapping '\(action)' decorator"
+        )
+    }
+
+    /// Taps decorator, waits for a button with the given identifier to have a non-empty label.
+    /// Used for: date column (ChangeCellDateIdentifier shows the formatted date).
+    private func tapDecoratorAndAssertButtonHasValue(action: String, identifier: String) {
+        tapDecorator(action: action)
+        let button = app.buttons.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { button.exists && !button.label.isEmpty },
+            "'\(identifier)' button should have a value after tapping '\(action)' decorator"
+        )
+    }
+
+    /// Taps decorator, waits for any element with the given identifier to exist.
+    /// Used for: image and signature containers that render once a value is present.
+    private func tapDecoratorAndAssertExists(action: String, identifier: String) {
+        tapDecorator(action: action)
+        let element = app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { element.exists },
+            "'\(identifier)' should exist after tapping '\(action)' decorator"
+        )
+    }
+
+    /// Taps a display-only column decorator (e.g. block) and waits for the
+    /// async Change API round-trip to complete before the next assertion.
+    private func tapDecoratorDisplayOnly(action: String) {
+        tapDecorator(action: action)
+        spinRunloop(1.5)
+    }
+
+    // MARK: - Grid cell assert helpers
+
+    /// Grid text cell (UITextView wrapper, identifier "TabelTextFieldIdentifier").
+    private func assertGridTextView(identifier: String, expected: String) {
+        let cell = app.textViews.matching(identifier: identifier).element(boundBy: 0)
+        XCTAssertTrue(
+            waitUntil(2) { cell.exists && cell.value as? String == expected },
+            "Grid '\(identifier)'[0] should show '\(expected)'"
+        )
+    }
+
+    /// Grid number/text cell backed by a SwiftUI TextField (identifier "TabelNumberFieldIdentifier").
+    private func assertGridTextField(identifier: String, expected: String) {
+        let cell = app.textFields.matching(identifier: identifier).element(boundBy: 0)
+        XCTAssertTrue(
+            waitUntil(2) { cell.exists && cell.value as? String == expected },
+            "Grid '\(identifier)'[0] should show '\(expected)'"
+        )
+    }
+
+    /// Grid dropdown / multiSelect button whose label contains the selected option.
+    private func assertGridButtonContains(identifier: String, text: String) {
+        let cell = app.buttons.matching(identifier: identifier).element(boundBy: 0)
+        XCTAssertTrue(
+            waitUntil(2) { cell.exists && cell.label.contains(text) },
+            "Grid '\(identifier)'[0] label should contain '\(text)'"
+        )
+    }
+
+    /// Grid date button: just verifies a formatted date is displayed (non-empty label).
+    private func assertGridButtonHasValue(identifier: String) {
+        let cell = app.buttons.matching(identifier: identifier).element(boundBy: 0)
+        XCTAssertTrue(
+            waitUntil(2) { cell.exists && !cell.label.isEmpty },
+            "Grid '\(identifier)'[0] should have a non-empty value"
+        )
+    }
+
+    /// Grid cell that exists as a tappable button once any value is set (e.g. signature).
+    private func assertGridButtonExists(identifier: String) {
+        let cell = app.buttons.matching(identifier: identifier).element(boundBy: 0)
+        XCTAssertTrue(
+            cell.waitForExistence(timeout: 2),
+            "Grid '\(identifier)'[0] should exist"
+        )
+    }
+
+    // MARK: - Decorator tap helper
+
+    /// Taps a cell decorator button inside the open row form.
+    /// Scrolls up once if the button isn't immediately visible.
+    private func tapDecorator(action: String) {
+        typealias S = DecoratorUITestSupport
+        let button = app.buttons[S.fieldDecoratorID(action: action)]
+        if !button.waitForExistence(timeout: 1) {
+            app.swipeUp()
+            _ = button.waitForExistence(timeout: 2)
+        }
+        if button.exists {
+            button.tap()
+        } else {
+            XCTFail("Decorator button '\(action)' not found in row form")
+        }
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
@@ -281,6 +281,216 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         assertGridTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
     }
 
+    // MARK: - Collection Add Row / Insert Below persistence
+
+    // MARK: Root level
+
+    /// Root row 1 form → tap text/dropdown/image decorators → dismiss →
+    /// Add Row → re-open root row 1 → all values survive.
+    func testCollectionRootDecoratorValuesPreservedAfterAddRow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        tapDecoratorAndAssertTextField(action: collRootTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertStaticText(action: collRootDropdownAction, expected: "High")
+        tapDecoratorAndAssertExists(action: collRootImageAction, identifier: "EditRowsImageFieldIdentifier")
+
+        dismissSheet()
+        spinRunloop(0.3)
+
+        let addRowBtn = app.buttons["TableAddRowIdentifier"]
+        XCTAssertTrue(addRowBtn.waitForExistence(timeout: 3), "Collection Add Row button not found")
+        addRowBtn.tap()
+        spinRunloop(0.5)
+
+        // Root row 1 is still at index 1 (SingleClickEditButton1)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        assertRowFormTextField(identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        assertRowFormStaticText("High")
+        assertRowFormExists(identifier: "EditRowsImageFieldIdentifier")
+
+        dismissSheet()
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "High")
+    }
+
+    /// Root row 1 form → tap text/dropdown/image decorators → Insert Below ("+") →
+    /// navigate back (←) → all values survive.
+    func testCollectionRootDecoratorValuesPreservedAfterInsertBelow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app)
+
+        tapDecoratorAndAssertTextField(action: collRootTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertStaticText(action: collRootDropdownAction, expected: "High")
+        tapDecoratorAndAssertExists(action: collRootImageAction, identifier: "EditRowsImageFieldIdentifier")
+
+        let plusBtn = app.buttons["PlusTheRowButtonIdentifier"]
+        XCTAssertTrue(plusBtn.waitForExistence(timeout: 3), "Plus button not found in row form")
+        plusBtn.tap()
+        spinRunloop(0.5)
+
+        let upperBtn = app.buttons["UpperRowButtonIdentifier"]
+        XCTAssertTrue(upperBtn.waitForExistence(timeout: 3), "Upper row (←) button not found")
+        upperBtn.tap()
+        spinRunloop(0.5)
+
+        assertRowFormTextField(identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        assertRowFormStaticText("High")
+        assertRowFormExists(identifier: "EditRowsImageFieldIdentifier")
+
+        dismissSheet()
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "High")
+    }
+
+    // MARK: Level 1
+
+    /// L1 row 1 form → tap multiSelect/number/date decorators → dismiss →
+    /// Add Row (L1 schema button) → re-open L1 row 1 → all values survive.
+    func testCollectionLevel1DecoratorValuesPreservedAfterAddRow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+
+        tapDecoratorAndAssertStaticText(action: collL1MultiSelectAction, expected: "Option 1")
+        tapDecoratorAndAssertTextField(action: collL1NumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        tapDecoratorAndAssertButtonHasValue(action: collL1DateAction, identifier: "ChangeCellDateIdentifier")
+
+        dismissSheet()
+        spinRunloop(0.3)
+
+        // "collectionSchemaAddRowButton" (firstMatch) is the L1 schema add-row button
+        let addRowBtn = app.buttons.matching(identifier: "collectionSchemaAddRowButton").firstMatch
+        XCTAssertTrue(addRowBtn.waitForExistence(timeout: 3), "L1 schema Add Row button not found")
+        addRowBtn.tap()
+        spinRunloop(0.5)
+
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+
+        assertRowFormStaticText("Option 1")
+        assertRowFormTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertRowFormButtonHasValue(identifier: "ChangeCellDateIdentifier")
+
+        dismissSheet()
+
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+    }
+
+    /// L1 row 1 form → tap multiSelect/number/date decorators → Insert Below ("+") →
+    /// navigate back (←) → all values survive.
+    func testCollectionLevel1DecoratorValuesPreservedAfterInsertBelow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app)
+
+        tapDecoratorAndAssertStaticText(action: collL1MultiSelectAction, expected: "Option 1")
+        tapDecoratorAndAssertTextField(action: collL1NumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        tapDecoratorAndAssertButtonHasValue(action: collL1DateAction, identifier: "ChangeCellDateIdentifier")
+
+        let plusBtn = app.buttons["PlusTheRowButtonIdentifier"]
+        XCTAssertTrue(plusBtn.waitForExistence(timeout: 3), "Plus button not found in row form")
+        plusBtn.tap()
+        spinRunloop(0.5)
+
+        let upperBtn = app.buttons["UpperRowButtonIdentifier"]
+        XCTAssertTrue(upperBtn.waitForExistence(timeout: 3), "Upper row (←) button not found")
+        upperBtn.tap()
+        spinRunloop(0.5)
+
+        assertRowFormStaticText("Option 1")
+        assertRowFormTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertRowFormButtonHasValue(identifier: "ChangeCellDateIdentifier")
+
+        dismissSheet()
+
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+    }
+
+    // MARK: Level 2
+
+    /// L2 row 1 form → tap signature/barcode/block decorators → dismiss →
+    /// Add Row (L2 schema button, boundBy:1) → re-open L2 row 1 → all values survive.
+    func testCollectionLevel2DecoratorValuesPreservedAfterAddRow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.expandCollectionNestedRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+
+        tapDecoratorAndAssertExists(action: collL2SignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+        tapDecoratorAndAssertTextView(action: collL2BarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        tapDecoratorDisplayOnly(action: collL2BlockAction)
+
+        dismissSheet()
+        spinRunloop(0.3)
+
+        // With root row 1 + L1 row 1 expanded, two "collectionSchemaAddRowButton" appear:
+        // boundBy:0 = L1 schema, boundBy:1 = L2 schema
+        let addRowBtn = app.buttons.matching(identifier: "collectionSchemaAddRowButton").element(boundBy: 1)
+        XCTAssertTrue(addRowBtn.waitForExistence(timeout: 3), "L2 schema Add Row button not found")
+        addRowBtn.tap()
+        spinRunloop(0.5)
+
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+
+        assertRowFormExists(identifier: "EditRowsSignatureFieldIdentifier")
+        assertRowFormTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+
+        dismissSheet()
+
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+        assertGridTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+    }
+
+    /// L2 row 1 form → tap signature/barcode/block decorators → Insert Below ("+") →
+    /// navigate back (←) → all values survive.
+    func testCollectionLevel2DecoratorValuesPreservedAfterInsertBelow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openCollectionDetailView(in: app)
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.expandCollectionNestedRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 1, in: app)
+
+        tapDecoratorAndAssertExists(action: collL2SignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+        tapDecoratorAndAssertTextView(action: collL2BarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        tapDecoratorDisplayOnly(action: collL2BlockAction)
+
+        let plusBtn = app.buttons["PlusTheRowButtonIdentifier"]
+        XCTAssertTrue(plusBtn.waitForExistence(timeout: 3), "Plus button not found in row form")
+        plusBtn.tap()
+        spinRunloop(0.5)
+
+        let upperBtn = app.buttons["UpperRowButtonIdentifier"]
+        XCTAssertTrue(upperBtn.waitForExistence(timeout: 3), "Upper row (←) button not found")
+        upperBtn.tap()
+        spinRunloop(0.5)
+
+        assertRowFormExists(identifier: "EditRowsSignatureFieldIdentifier")
+        assertRowFormTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+
+        dismissSheet()
+
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+        assertGridTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+    }
+
     // MARK: - Row-form tap + assert helpers
 
     /// Taps decorator, waits for a SwiftUI TextField (→ .textField) to show expected value.

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
@@ -96,7 +96,108 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         // Signature → field container renders after URL is set
         tapDecoratorAndAssertExists(action: tableSignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
 
-        S.dismissRowEditForm(in: app)
+        dismissSheet()
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "Yes")
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+    }
+    
+    // MARK: - Add Row / Insert Below persistence
+
+    /// Opens row 1's form, sets every column via decorator taps, dismisses,
+    /// taps Add Row, then re-opens row 1 and verifies all values survive.
+    func testTableDecoratorValuesPreservedAfterAddRow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openTableDetailView(in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        tapDecoratorAndAssertStaticText(action: tableDropdownAction, expected: "Yes")
+        tapDecoratorAndAssertTextField(action: tableTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertStaticText(action: tableMultiSelectAction, expected: "Option 1")
+        tapDecoratorAndAssertExists(action: tableImageAction, identifier: "EditRowsImageFieldIdentifier")
+        tapDecoratorAndAssertTextField(action: tableNumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        tapDecoratorAndAssertButtonHasValue(action: tableDateAction, identifier: "ChangeCellDateIdentifier")
+        tapDecoratorDisplayOnly(action: tableBlockAction)
+        tapDecoratorAndAssertTextView(action: tableBarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertExists(action: tableSignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+
+        dismissSheet()
+
+        // Add Row is in the table view (accessible once the row-form sheet is dismissed)
+        let addRowBtn = app.buttons["TableAddRowIdentifier"]
+        XCTAssertTrue(addRowBtn.waitForExistence(timeout: 3), "Add Row button not found")
+        addRowBtn.tap()
+        spinRunloop(0.5)
+
+        // Row 1 is still at index 0 (new row was appended at the end)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        assertRowFormStaticText("Yes")
+        assertRowFormTextField(identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        assertRowFormStaticText("Option 1")
+        assertRowFormExists(identifier: "EditRowsImageFieldIdentifier")
+        assertRowFormTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertRowFormButtonHasValue(identifier: "ChangeCellDateIdentifier")
+        assertRowFormTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        assertRowFormExists(identifier: "EditRowsSignatureFieldIdentifier")
+
+        dismissSheet()
+
+        assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
+        assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "Yes")
+        assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
+        assertGridButtonHasValue(identifier: "ChangeCellDateIdentifier")
+        assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
+    }
+
+    /// Opens row 1's form, sets every column via decorator taps, then taps the
+    /// "+" (Insert Below) button — which inserts a row below and navigates to it.
+    /// Navigates back to row 1 and verifies all values survive.
+    func testTableDecoratorValuesPreservedAfterInsertBelow() {
+        typealias S = DecoratorUITestSupport
+
+        S.openTableDetailView(in: app)
+        S.openTableRowEditForm(rowIndex: 1, in: app)
+
+        tapDecoratorAndAssertStaticText(action: tableDropdownAction, expected: "Yes")
+        tapDecoratorAndAssertTextField(action: tableTextAction, identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertStaticText(action: tableMultiSelectAction, expected: "Option 1")
+        tapDecoratorAndAssertExists(action: tableImageAction, identifier: "EditRowsImageFieldIdentifier")
+        tapDecoratorAndAssertTextField(action: tableNumberAction, identifier: "TabelNumberFieldIdentifier", expected: "10")
+        tapDecoratorAndAssertButtonHasValue(action: tableDateAction, identifier: "ChangeCellDateIdentifier")
+        tapDecoratorDisplayOnly(action: tableBlockAction)
+        tapDecoratorAndAssertTextView(action: tableBarcodeAction, identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        tapDecoratorAndAssertExists(action: tableSignatureAction, identifier: "EditRowsSignatureFieldIdentifier")
+
+        // "+" button inserts a row below and navigates the form to the new row
+        let plusBtn = app.buttons["PlusTheRowButtonIdentifier"]
+        XCTAssertTrue(plusBtn.waitForExistence(timeout: 3), "Plus (Insert Below) button not found in row form")
+        plusBtn.tap()
+        spinRunloop(0.5)
+
+        // Navigate back to row 1 (the < chevron goes to the row above the newly-selected one)
+        let upperBtn = app.buttons["UpperRowButtonIdentifier"]
+        XCTAssertTrue(upperBtn.waitForExistence(timeout: 3), "Upper row (←) button not found")
+        upperBtn.tap()
+        spinRunloop(0.5)
+
+        // All values must survive the insert-below + row-navigation cycle
+        assertRowFormStaticText("Yes")
+        assertRowFormTextField(identifier: "EditRowsTextFieldIdentifier", expected: "Updated #1")
+        assertRowFormStaticText("Option 1")
+        assertRowFormExists(identifier: "EditRowsImageFieldIdentifier")
+        assertRowFormTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
+        assertRowFormButtonHasValue(identifier: "ChangeCellDateIdentifier")
+        assertRowFormTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
+        assertRowFormExists(identifier: "EditRowsSignatureFieldIdentifier")
+
+        dismissSheet()
 
         assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
         assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
@@ -123,7 +224,7 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         // Image → container exists
         tapDecoratorAndAssertExists(action: collRootImageAction, identifier: "EditRowsImageFieldIdentifier")
 
-        S.dismissRowEditForm(in: app)
+        dismissSheet()
 
         assertGridTextView(identifier: "TabelTextFieldIdentifier", expected: "Updated #1")
         assertGridButtonContains(identifier: "TableDropdownIdentifier", text: "High")
@@ -147,7 +248,7 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         // Date → inner button has a non-empty label
         tapDecoratorAndAssertButtonHasValue(action: collL1DateAction, identifier: "ChangeCellDateIdentifier")
 
-        S.dismissRowEditForm(in: app)
+        dismissSheet()
 
         assertGridButtonContains(identifier: "TableMultiSelectionFieldIdentifier", text: "Option 1")
         assertGridTextField(identifier: "TabelNumberFieldIdentifier", expected: "10")
@@ -174,7 +275,7 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         // Block → display-only, no row-form editor
         tapDecoratorDisplayOnly(action: collL2BlockAction)
 
-        S.dismissRowEditForm(in: app)
+        dismissSheet()
 
         assertGridButtonExists(identifier: "TableSignatureOpenSheetButton")
         assertGridTextView(identifier: "TableBarcodeFieldIdentifier", expected: "Updated #1")
@@ -243,6 +344,47 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         spinRunloop(1.5)
     }
 
+    // MARK: - Row-form assert helpers (no decorator tap — used after add/insert row)
+
+    private func assertRowFormTextField(identifier: String, expected: String) {
+        let field = app.textFields.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { field.exists && field.value as? String == expected },
+            "Row form '\(identifier)' should show '\(expected)'"
+        )
+    }
+
+    private func assertRowFormTextView(identifier: String, expected: String) {
+        let field = app.textViews.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { field.exists && field.value as? String == expected },
+            "Row form '\(identifier)' should show '\(expected)'"
+        )
+    }
+
+    private func assertRowFormStaticText(_ expected: String) {
+        XCTAssertTrue(
+            waitUntil(3) { self.app.staticTexts[expected].exists },
+            "Row form should show '\(expected)' as static text"
+        )
+    }
+
+    private func assertRowFormButtonHasValue(identifier: String) {
+        let btn = app.buttons.matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { btn.exists && !btn.label.isEmpty },
+            "Row form '\(identifier)' button should have a non-empty value"
+        )
+    }
+
+    private func assertRowFormExists(identifier: String) {
+        let el = app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        XCTAssertTrue(
+            waitUntil(3) { el.exists },
+            "Row form '\(identifier)' should exist"
+        )
+    }
+
     // MARK: - Grid cell assert helpers
 
     /// Grid text cell (UITextView wrapper, identifier "TabelTextFieldIdentifier").
@@ -289,6 +431,14 @@ final class DecoratorRowUpdateUITests: XCTestCase {
             "Grid '\(identifier)'[0] should exist"
         )
     }
+    
+    private func dismissSheet() {
+        let bottomCoordinate = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+        let topCoordinate = app.windows.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+        topCoordinate.press(forDuration: 0, thenDragTo: bottomCoordinate)
+    }
+
+
 
     // MARK: - Decorator tap helper
 

--- a/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift
@@ -525,14 +525,16 @@ final class DecoratorRowUpdateUITests: XCTestCase {
         )
     }
 
-    /// Taps decorator, waits for a button with the given identifier to have a non-empty label.
+    /// Taps decorator, waits for a button with the given identifier to have a non-empty label
+    /// that also differs from its pre-tap label (guards against a non-empty placeholder passing).
     /// Used for: date column (ChangeCellDateIdentifier shows the formatted date).
     private func tapDecoratorAndAssertButtonHasValue(action: String, identifier: String) {
-        tapDecorator(action: action)
         let button = app.buttons.matching(identifier: identifier).firstMatch
+        let labelBefore = button.exists ? button.label : ""
+        tapDecorator(action: action)
         XCTAssertTrue(
-            waitUntil(3) { button.exists && !button.label.isEmpty },
-            "'\(identifier)' button should have a value after tapping '\(action)' decorator"
+            waitUntil(3) { button.exists && !button.label.isEmpty && button.label != labelBefore },
+            "'\(identifier)' button label should change and be non-empty after tapping '\(action)' decorator"
         )
     }
 

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -285,6 +285,10 @@ struct CollectionEditMultipleRowsSheetView: View {
     init(viewModel: CollectionViewModel) {
         self.viewModel = viewModel
     }
+
+    private func refreshViewID() {
+        viewID = UUID()
+    }
     
     @ViewBuilder
     private func fieldTitle(_ col: FieldTableColumn, isCellFilled: Bool, schemaKey: String) -> some View {
@@ -473,15 +477,18 @@ struct CollectionEditMultipleRowsSheetView: View {
             }
             .padding(.all, 16)
             .environment(\.navigationFocusColumnId, viewModel.tableDataModel.navigationIntent.focusColumnId)
+            .id(viewID)
         }
-        .id(viewID)
         .onAppear {
             if let columnId = viewModel.tableDataModel.navigationIntent.scrollToColumnId {
                 scrollProxy.scrollTo(columnId, anchor: .top)
             }
         }
-        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ newValue in
-            viewID = UUID()
+        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ _ in
+            refreshViewID()
+        }
+        .onChange(of: viewModel.uuid) { _ in
+            refreshViewID()
         }
         .simultaneousGesture(DragGesture().onChanged({ _ in
             dismissKeyboard()

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -231,6 +231,10 @@ struct EditMultipleRowsSheetView: View {
         self.viewModel =  viewModel
     }
 
+    private func refreshViewID() {
+        viewID = UUID()
+    }
+
     @ViewBuilder
     private func columnTitle(_ col: FieldTableColumn, isCellFilled: Bool) -> some View {
         HStack(alignment: .center, spacing: 4) {
@@ -623,15 +627,18 @@ struct EditMultipleRowsSheetView: View {
             }
             .padding(.all, 16)
             .environment(\.navigationFocusColumnId, viewModel.tableDataModel.navigationIntent.focusColumnId)
+            .id(viewID)
         }
-        .id(viewID)
         .onAppear {
             if let columnId = viewModel.tableDataModel.navigationIntent.scrollToColumnId {
                 scrollProxy.scrollTo(columnId, anchor: .top)
             }
         }
-        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ newValue in
-            viewID = UUID()
+        .onChange(of: viewModel.tableDataModel.selectedRows.first ){ _ in
+            refreshViewID()
+        }
+        .onChange(of: viewModel.uuid) { _ in
+            refreshViewID()
         }
         .simultaneousGesture(DragGesture().onChanged({ _ in
             dismissKeyboard()

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -390,11 +390,11 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         return cellValues
     }
 
-    func cellDidChange(rowId: String, colIndex: Int, cellDataModel: CellDataModel, isNestedCell: Bool, callOnChange: Bool = true, metadata: Metadata? = nil) -> [ValueElement] {
+    func cellDidChange(rowId: String, colIndex: Int, cellDataModel: CellDataModel, isNestedCell: Bool, callOnChange: Bool = true, metadata: Metadata? = nil, isBulkEdit: Bool = false) -> [ValueElement] {
         if isNestedCell {
-            tableDataModel.updateCellModelForNested(rowId: rowId, colIndex: colIndex, cellDataModel: cellDataModel, isBulkEdit: false)
+            tableDataModel.updateCellModelForNested(rowId: rowId, colIndex: colIndex, cellDataModel: cellDataModel, isBulkEdit: isBulkEdit)
         } else {
-            tableDataModel.updateCellModel(rowIndex: tableDataModel.rowOrder.firstIndex(of: rowId) ?? 0, rowId: rowId, colIndex: colIndex, cellDataModel: cellDataModel, isBulkEdit: false)
+            tableDataModel.updateCellModel(rowIndex: tableDataModel.rowOrder.firstIndex(of: rowId) ?? 0, rowId: rowId, colIndex: colIndex, cellDataModel: cellDataModel, isBulkEdit: isBulkEdit)
         }
         
         return tableDataModel.documentEditor?.cellDidChange(rowId: rowId, cellDataModel: cellDataModel, fieldIdentifier: tableDataModel.fieldIdentifier, callOnChange: callOnChange, metadata: metadata) ?? []
@@ -641,7 +641,8 @@ extension TableViewModel: DocumentEditorDelegate {
                 cellDataModel: cell,
                 isNestedCell: false,
                 callOnChange: false,
-                metadata: row.metadata
+                metadata: row.metadata,
+                isBulkEdit: true
             )
         }
     }


### PR DESCRIPTION
## 1. Context / Spec
When a table/collection row's cell is updated programmatically via `DocumentEditor.change(changes:)` **while that row's edit form is open**, the open editor did not reflect the new value. Concretely: an app catches `onFocus` from a column decorator and fires a `field.value.rowUpdate` Change; the underlying model updates, but the open editor (e.g. a dropdown) stays stale on its old value ("Select Option"). Reported by a customer (ST).

A second, related symptom: even once the value showed in the grid, a subsequent row operation (Insert Below / move / delete) dropped it from the grid until the field was re-navigated.

Root cause (both): the row-edit sheet's cell editors snapshot their value into local SwiftUI `@State`, and the grid's displayed cell models can keep a stale identity, so an external model change isn't reflected until the view is forced to rebuild. The document model itself was always correct (hence re-navigation restored the value).

## 2. What changed (files / code)
**SDK — open row form refreshes on external Change-API updates** (internal views only):
- `TableModalTopNavigationView.swift` (`EditMultipleRowsSheetView`) and `CollectionModalTopNavigationView.swift` (`CollectionEditMultipleRowsSheetView`):
  - Added `refreshViewID()`; moved `.id(viewID)` from the `ScrollView` onto the **inner content `VStack`**; added `.onChange(of: viewModel.uuid) { refreshViewID() }`.
  - On an external Change-API update, `viewModel.uuid` bumps → the inner content re-identifies → editors re-init from the fresh model. `.id` on the content (not the `ScrollView`) preserves the scroll offset.

**SDK — grid value persists through row operations:**
- `TableViewModel.swift`: threaded `isBulkEdit` through `cellDidChange` and pass `true` from `updateUIModels`, so `updateCellModel` bumps `cells[colIndex].id = UUID()`. The new cell identity forces the grid cell to rebuild from fresh data, so a Change-API value survives `filterRowsIfNeeded()` (`filteredcellModels = cellModels`) on Insert Below / move / delete.

**Example app — repro / manual harness:**
- `DecoratorToRowUpdate/DecoratorRowUpdateDemoView.swift` + `DecoratorToRowUpdate.json`: a form with one table and one 3-level nested collection, every column carrying its own decorator; tapping one catches `onFocus` and pushes a `field.value.rowUpdate` for the tapped column on the selected row(s).
- `UserAccessTokenTextFieldView.swift`: "Decorator → Row Change" entry in `OptionSelectionView`; `project.pbxproj` registers the new file + JSON resource.

**Tests:**
- `JoyfillUITests/DecoratorUITests/DecoratorRowUpdateUITests.swift`: UI tests asserting a decorator tap → Change API updates both the open row form and the grid, for table and for collection root / level-1 / level-2 nested rows.

## 3. Implementation decisions
- **Central rebuild vs per-editor sync (sheet):** chose the single-spot `viewID` rebuild over editing all 8 cell editors. `viewModel.uuid` is bumped **only** by the `change(changes:)` path, never by user typing, so the refresh fires on external updates without interrupting an in-progress edit.
- **`.id` on inner content, not the `ScrollView`:** recreating the `ScrollView` resets scroll; re-identifying only its content preserves the offset. `col.id` is left intact so `scrollProxy.scrollTo(columnId)` keeps working.
- **Cell-id bump (grid):** the displayed rows are rebuilt from `cellModels` on row ops, and SwiftUI reuses a cell view whose identity is unchanged — so the master cell needed a fresh `id` (via `isBulkEdit: true`) to force a rebuild with the new value. Collection didn't need this: its `updateUIModels` already bumps the displayed cell id and its `filterRowsIfNeeded()` doesn't reset `filteredcellModels` from `cellModels` (verified).

## 4. Visuals
UI behavior change. **Before:** the open row's dropdown stays on "Select Option" after a Change-API `rowUpdate`, and a Change-API value disappears from the grid after Insert Below. **After:** the open editor updates live (scroll preserved) and the grid value persists through row ops.

_Screen recording from the "Decorator → Row Change" demo to be attached._

## 5. Public API / Docs
No public API changes — the edited types are internal, no `init` signatures changed, no data-model changes. No documentation update required.

## 6. Tests
- **Automated (UI tests)** — `DecoratorRowUpdateUITests`: `testTableDecoratorUpdatesRowFormAndGrid`, `testCollectionRootDecoratorUpdatesRowFormAndGrid`, `testCollectionLevel1DecoratorUpdatesRowFormAndGrid`, `testCollectionLevel2DecoratorUpdatesRowFormAndGrid`. Each taps a column decorator and asserts the open row form **and** the grid reflect the Change-API value. (UI tests are skipped in CI; run locally.)
- **Manual** — validated across all column types for table and collection (incl. nested), single-row and bulk edit: live refresh, preserved scroll, and value persistence through Insert Below.

## 7. Notes for reviewers
- Two focused SDK changes: (a) `.id(viewID)` placement + `refreshViewID()` in the two sheets; (b) the `isBulkEdit` threading in `TableViewModel.cellDidChange` / `updateUIModels`.
- `viewModel.uuid` changes only on the external `change()` path → typing is never interrupted.
- The grid fix is table-specific because only the table's `filterRowsIfNeeded()` does `filteredcellModels = cellModels`; collection was verified to already hold the value.
- Bulk-edit fields are intentionally empty (one value → many rows); the live-refresh visual is meaningful for single-row editing. The demo's bulk path still writes all selected rows.
- The `DecoratorToRowUpdate` example is test scaffolding (example app only), not shipping SDK code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
