### PR TITLE
NO-2213: Deprecate parameter-based DocumentEditor init in favor of config-based init

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1324937A2BA570F9002C6ADC /* Joyfill in Frameworks */ = {isa = PBXBuildFile; productRef = 132493792BA570F9002C6ADC /* Joyfill */; };
 		1324937D2BAD5A42002C6ADC /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = 1324937C2BAD5A42002C6ADC /* JoyfillModel */; };
 		134FC07A2BDA82E9008B7030 /* JoyfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134FC0792BDA82E9008B7030 /* JoyfillTests.swift */; };
+		DEC0F11000000000000000F2 /* DocumentEditorConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */; };
 		136D3DBF2C103BD8008B1CA3 /* PageNavigationFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136D3DBE2C103BD8008B1CA3 /* PageNavigationFieldTest.swift */; };
 		13A3F8EA2C34171A00B0A255 /* ConditionalLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3F8E92C34171A00B0A255 /* ConditionalLogicTests.swift */; };
 		13A3F8EC2C356DB800B0A255 /* ConditinalPageLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3F8EB2C356DB800B0A255 /* ConditinalPageLogicTests.swift */; };
@@ -531,6 +532,7 @@
 		1307CF1D2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		134FC0772BDA82E9008B7030 /* JoyfillTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JoyfillTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		134FC0792BDA82E9008B7030 /* JoyfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillTests.swift; sourceTree = "<group>"; };
+		DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorConfigTests.swift; sourceTree = "<group>"; };
 		136D3DBE2C103BD8008B1CA3 /* PageNavigationFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigationFieldTest.swift; sourceTree = "<group>"; };
 		13A3F8E92C34171A00B0A255 /* ConditionalLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalLogicTests.swift; sourceTree = "<group>"; };
 		13A3F8EB2C356DB800B0A255 /* ConditinalPageLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditinalPageLogicTests.swift; sourceTree = "<group>"; };
@@ -898,6 +900,7 @@
 				E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */,
 				E27061C62E797E12006BAD18 /* OnChangeHandler */,
 				134FC0792BDA82E9008B7030 /* JoyfillTests.swift */,
+				DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */,
 				E2CC9FEC2E375DE500797331 /* SchemaValidation */,
 				DEC000A000000000000000A0 /* DecoratorAPI */,
 				E2B8E3BC2E4361DF00AC6018 /* Formula */,
@@ -2136,6 +2139,7 @@
 				E2B8E3C42E436F3300AC6018 /* FormulaTemplate_MultiSelectFieldTests.swift in Sources */,
 				0448AE092D0C45AD00754EA0 /* ValidationTestCase.swift in Sources */,
 				134FC07A2BDA82E9008B7030 /* JoyfillTests.swift in Sources */,
+				DEC0F11000000000000000F2 /* DocumentEditorConfigTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
@@ -184,19 +184,24 @@ final class DocumentEditorConfigTests: XCTestCase {
         XCTAssertFalse(editor.isCollectionFieldEnabled)
     }
 
-    /// The license is routed through the same validator as the legacy init: a config
-    /// editor and a legacy editor given the same token must agree on the flag.
-    func testConfigInit_licensePassthrough_matchesLegacyInit() {
-        let token = "not-a-valid-license-token"
+    /// A *valid* license supplied through the config must actually flip
+    /// `isCollectionFieldEnabled` to `true`. Paired with the nil-license test above,
+    /// this guards the config → license mapping in both directions: dropping or
+    /// zeroing `license` on the config path would leave the flag `false` and fail here.
+    func testConfigInit_validLicense_enablesCollectionField() {
+        let license = (ProcessInfo.processInfo.environment["JOYFILL_TEST_LICENSE"] ?? licenseKey)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertFalse(license.isEmpty,
+                       "Missing license: set JOYFILL_TEST_LICENSE env var or check licenseKey")
+        XCTAssertTrue(LicenseValidator.isCollectionEnabled(licenseToken: license),
+                      "License verification failed — the token does not match the public key in LicenseValidator")
 
-        let legacy = DocumentEditor(document: JoyDoc(),
-                                    validateSchema: false,
-                                    license: token)
-        let viaConfig = DocumentEditor(document: JoyDoc(),
-                                       config: DocumentEditorConfig(license: token,
-                                                                    validateSchema: false))
+        let editor = DocumentEditor(document: JoyDoc(),
+                                    config: DocumentEditorConfig(license: license,
+                                                                 validateSchema: false))
 
-        XCTAssertEqual(legacy.isCollectionFieldEnabled, viaConfig.isCollectionFieldEnabled)
+        XCTAssertTrue(editor.isCollectionFieldEnabled,
+                      "A valid license passed via DocumentEditorConfig must enable collection fields.")
     }
 
     // MARK: - validateSchema behaviour

--- a/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
@@ -1,0 +1,308 @@
+import XCTest
+import JoyfillModel
+@testable import Joyfill
+
+/// Verifies the new `DocumentEditor.init(document:events:config:)` correctly
+/// maps a `DocumentEditorConfig` onto the editor, stays equivalent to the
+/// legacy parameter-based init, and preserves the readonly coercion rule.
+final class DocumentEditorConfigTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// Captures `onError` so schema-validation behaviour can be asserted.
+    private final class MockFormChangeEvent: FormChangeEvent {
+        private(set) var didReceiveError = false
+        private(set) var receivedError: JoyfillError?
+
+        func onChange(changes: [Change], document: JoyDoc) {}
+        func onFocus(event: Event) {}
+        func onBlur(event: Event) {}
+        func onUpload(event: UploadEvent) {}
+        func onCapture(event: CaptureEvent) {}
+        func onError(error: JoyfillError) {
+            didReceiveError = true
+            receivedError = error
+        }
+    }
+
+    /// A document that intentionally fails schema validation (missing required fields).
+    private func invalidDocument() -> JoyDoc {
+        JoyDoc(dictionary: [
+            "identifier": "test-doc",
+            "name": "Invalid Doc"
+        ])
+    }
+
+    /// A valid multi-page document built from the shared dummy-model helpers.
+    private func multiPageDocument() -> JoyDoc {
+        JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()   // page id: "6629fab320fca7c8107a6cf6"
+            .addSecondPage()              // page id: "second_page_id_12345"
+            .setHeadingText()
+            .setTextField()
+    }
+
+    // MARK: - Field mapping
+
+    /// Every config field should land on the matching editor property.
+    func testConfigInit_mapsAllValuesOntoEditor() {
+        let config = DocumentEditorConfig(
+            mode: .fill,
+            license: nil,
+            validateSchema: false,
+            page: PageConfig(navigation: false,
+                             enableDuplicates: true,
+                             enableDeletes: true,
+                             currentPageID: nil),
+            display: DisplayConfig(singleClickRowEdit: true,
+                                   decorators: DecoratorConfig(visibleLimitInFields: 5,
+                                                               visibleLimitInRows: 3))
+        )
+
+        let editor = DocumentEditor(document: JoyDoc(), config: config)
+
+        XCTAssertEqual(editor.mode, .fill)
+        XCTAssertFalse(editor.showPageNavigationView)        // page.navigation
+        XCTAssertTrue(editor.isPageDuplicateEnabled)         // page.enableDuplicates
+        XCTAssertTrue(editor.isPageDeleteEnabled)            // page.enableDeletes
+        XCTAssertTrue(editor.singleClickRowEdit)             // display.singleClickRowEdit
+        XCTAssertEqual(editor.decoratorConfig.visibleLimitInFields, 5)
+        XCTAssertEqual(editor.decoratorConfig.visibleLimitInRows, 3)
+    }
+
+    // MARK: - Readonly coercion
+
+    /// Readonly mode must force page duplicate/delete off, even if the config
+    /// asked for them — same rule the legacy init enforces.
+    func testConfigInit_readonlyForcesPageEditingOff() {
+        let config = DocumentEditorConfig(
+            mode: .readonly,
+            validateSchema: false,
+            page: PageConfig(enableDuplicates: true, enableDeletes: true)
+        )
+
+        let editor = DocumentEditor(document: JoyDoc(), config: config)
+
+        XCTAssertEqual(editor.mode, .readonly)
+        XCTAssertFalse(editor.isPageDuplicateEnabled)
+        XCTAssertFalse(editor.isPageDeleteEnabled)
+    }
+
+    // MARK: - Defaults parity
+
+    /// A default config must produce the same editor as the legacy init's defaults.
+    func testConfigInit_defaultsMatchLegacyInit() {
+        let legacy = DocumentEditor(document: JoyDoc(), validateSchema: false)
+        let viaConfig = DocumentEditor(document: JoyDoc(),
+                                       config: DocumentEditorConfig(validateSchema: false))
+
+        XCTAssertEqual(legacy.mode, viaConfig.mode)
+        XCTAssertEqual(legacy.showPageNavigationView, viaConfig.showPageNavigationView)
+        XCTAssertEqual(legacy.isPageDuplicateEnabled, viaConfig.isPageDuplicateEnabled)
+        XCTAssertEqual(legacy.isPageDeleteEnabled, viaConfig.isPageDeleteEnabled)
+        XCTAssertEqual(legacy.singleClickRowEdit, viaConfig.singleClickRowEdit)
+        XCTAssertEqual(legacy.decoratorConfig.visibleLimitInFields,
+                       viaConfig.decoratorConfig.visibleLimitInFields)
+        XCTAssertEqual(legacy.decoratorConfig.visibleLimitInRows,
+                       viaConfig.decoratorConfig.visibleLimitInRows)
+    }
+
+    /// Sanity-check that the struct defaults themselves match the legacy init defaults,
+    /// independent of how the editor consumes them.
+    func testConfigDefaults_matchLegacyParameterDefaults() {
+        let config = DocumentEditorConfig()
+
+        XCTAssertEqual(config.mode, .fill)
+        XCTAssertNil(config.license)
+        XCTAssertTrue(config.validateSchema)
+        XCTAssertTrue(config.page.navigation)
+        XCTAssertFalse(config.page.enableDuplicates)
+        XCTAssertFalse(config.page.enableDeletes)
+        XCTAssertNil(config.page.currentPageID)
+        XCTAssertFalse(config.display.singleClickRowEdit)
+        XCTAssertEqual(config.display.decorators.visibleLimitInFields,
+                       DecoratorConfig().visibleLimitInFields)
+        XCTAssertEqual(config.display.decorators.visibleLimitInRows,
+                       DecoratorConfig().visibleLimitInRows)
+    }
+
+    // MARK: - Non-default legacy ↔ config equivalence
+
+    /// With NON-default values the config init must produce the same editor as the
+    /// legacy init given the equivalent parameters — this guards the delegation mapping.
+    func testConfigInit_matchesLegacyInit_withNonDefaultValues() {
+        let decorators = DecoratorConfig(visibleLimitInFields: 7, visibleLimitInRows: 4)
+
+        let legacy = DocumentEditor(
+            document: JoyDoc(),
+            mode: .fill,
+            events: nil,
+            pageID: nil,
+            navigation: false,
+            isPageDuplicateEnabled: true,
+            isPageDeleteEnabled: true,
+            validateSchema: false,
+            license: nil,
+            singleClickRowEdit: true,
+            decoratorConfig: decorators
+        )
+
+        let viaConfig = DocumentEditor(
+            document: JoyDoc(),
+            config: DocumentEditorConfig(
+                mode: .fill,
+                license: nil,
+                validateSchema: false,
+                page: PageConfig(navigation: false,
+                                 enableDuplicates: true,
+                                 enableDeletes: true,
+                                 currentPageID: nil),
+                display: DisplayConfig(singleClickRowEdit: true, decorators: decorators)
+            )
+        )
+
+        XCTAssertEqual(legacy.mode, viaConfig.mode)
+        XCTAssertEqual(legacy.showPageNavigationView, viaConfig.showPageNavigationView)
+        XCTAssertEqual(legacy.isPageDuplicateEnabled, viaConfig.isPageDuplicateEnabled)
+        XCTAssertEqual(legacy.isPageDeleteEnabled, viaConfig.isPageDeleteEnabled)
+        XCTAssertEqual(legacy.singleClickRowEdit, viaConfig.singleClickRowEdit)
+        XCTAssertEqual(legacy.decoratorConfig.visibleLimitInFields,
+                       viaConfig.decoratorConfig.visibleLimitInFields)
+        XCTAssertEqual(legacy.decoratorConfig.visibleLimitInRows,
+                       viaConfig.decoratorConfig.visibleLimitInRows)
+    }
+
+    // MARK: - License → isCollectionFieldEnabled
+
+    /// A nil license must leave collection fields disabled.
+    func testConfigInit_nilLicense_keepsCollectionDisabled() {
+        let editor = DocumentEditor(document: JoyDoc(),
+                                    config: DocumentEditorConfig(license: nil,
+                                                                 validateSchema: false))
+        XCTAssertFalse(editor.isCollectionFieldEnabled)
+    }
+
+    /// The license is routed through the same validator as the legacy init: a config
+    /// editor and a legacy editor given the same token must agree on the flag.
+    func testConfigInit_licensePassthrough_matchesLegacyInit() {
+        let token = "not-a-valid-license-token"
+
+        let legacy = DocumentEditor(document: JoyDoc(),
+                                    validateSchema: false,
+                                    license: token)
+        let viaConfig = DocumentEditor(document: JoyDoc(),
+                                       config: DocumentEditorConfig(license: token,
+                                                                    validateSchema: false))
+
+        XCTAssertEqual(legacy.isCollectionFieldEnabled, viaConfig.isCollectionFieldEnabled)
+    }
+
+    // MARK: - validateSchema behaviour
+
+    /// validateSchema = true on an invalid document must record a schema error
+    /// and fire `onError` through the events handler.
+    func testConfigInit_validateSchemaTrue_invalidDoc_setsErrorAndFiresOnError() {
+        let events = MockFormChangeEvent()
+        let editor = DocumentEditor(document: invalidDocument(),
+                                    events: events,
+                                    config: DocumentEditorConfig(validateSchema: true))
+
+        XCTAssertNotNil(editor.schemaError)
+        XCTAssertEqual(editor.schemaError?.code, "ERROR_SCHEMA_VALIDATION")
+        XCTAssertTrue(events.didReceiveError)
+        if case .schemaValidationError = events.receivedError {
+            // expected
+        } else {
+            XCTFail("Expected a schemaValidationError, got \(String(describing: events.receivedError))")
+        }
+    }
+
+    /// validateSchema = false must skip validation entirely — no error even on an
+    /// otherwise-invalid document.
+    func testConfigInit_validateSchemaFalse_invalidDoc_skipsValidation() {
+        let events = MockFormChangeEvent()
+        let editor = DocumentEditor(document: invalidDocument(),
+                                    events: events,
+                                    config: DocumentEditorConfig(validateSchema: false))
+
+        XCTAssertNil(editor.schemaError)
+        XCTAssertFalse(events.didReceiveError)
+    }
+
+    // MARK: - currentPageID
+
+    /// A `currentPageID` pointing at a real page must resolve to that page.
+    func testConfigInit_currentPageID_resolvesToRequestedPage() {
+        let config = DocumentEditorConfig(
+            validateSchema: false,
+            page: PageConfig(currentPageID: "second_page_id_12345")
+        )
+
+        let editor = DocumentEditor(document: multiPageDocument(), config: config)
+
+        XCTAssertEqual(editor.currentPageID, "second_page_id_12345")
+    }
+
+    /// A nil `currentPageID` must fall back to the document's first valid page,
+    /// matching the legacy init with `pageID: nil`.
+    func testConfigInit_nilCurrentPageID_matchesLegacyFirstValidPage() {
+        let legacy = DocumentEditor(document: multiPageDocument(),
+                                    pageID: nil,
+                                    validateSchema: false)
+        let viaConfig = DocumentEditor(document: multiPageDocument(),
+                                       config: DocumentEditorConfig(validateSchema: false))
+
+        XCTAssertEqual(legacy.currentPageID, viaConfig.currentPageID)
+    }
+
+    // MARK: - events passthrough
+
+    /// The events handler passed alongside the config must be retained on the editor.
+    func testConfigInit_eventsArePassedThrough() {
+        let events = MockFormChangeEvent()
+        let editor = DocumentEditor(document: JoyDoc(),
+                                    events: events,
+                                    config: DocumentEditorConfig(validateSchema: false))
+
+        XCTAssertNotNil(editor.events)
+        XCTAssertTrue((editor.events as AnyObject) === events)
+    }
+
+    // MARK: - Independence / swap
+
+    /// Two different configs applied to the same document must produce two
+    /// independent editors — supporting the "hold and swap config" use case.
+    func testConfigInit_distinctConfigs_produceIndependentEditors() {
+        let fillConfig = DocumentEditorConfig(
+            mode: .fill,
+            validateSchema: false,
+            page: PageConfig(navigation: true, enableDuplicates: true, enableDeletes: true),
+            display: DisplayConfig(singleClickRowEdit: true)
+        )
+        let readonlyConfig = DocumentEditorConfig(
+            mode: .readonly,
+            validateSchema: false,
+            page: PageConfig(navigation: false, enableDuplicates: true, enableDeletes: true),
+            display: DisplayConfig(singleClickRowEdit: false)
+        )
+
+        let fillEditor = DocumentEditor(document: JoyDoc(), config: fillConfig)
+        let readonlyEditor = DocumentEditor(document: JoyDoc(), config: readonlyConfig)
+
+        // Fill editor honours the requested values.
+        XCTAssertEqual(fillEditor.mode, .fill)
+        XCTAssertTrue(fillEditor.showPageNavigationView)
+        XCTAssertTrue(fillEditor.isPageDuplicateEnabled)
+        XCTAssertTrue(fillEditor.isPageDeleteEnabled)
+        XCTAssertTrue(fillEditor.singleClickRowEdit)
+
+        // Readonly editor is independent and applies the readonly coercion.
+        XCTAssertEqual(readonlyEditor.mode, .readonly)
+        XCTAssertFalse(readonlyEditor.showPageNavigationView)
+        XCTAssertFalse(readonlyEditor.isPageDuplicateEnabled)
+        XCTAssertFalse(readonlyEditor.isPageDeleteEnabled)
+        XCTAssertFalse(readonlyEditor.singleClickRowEdit)
+    }
+}

--- a/Sources/JoyfillUI/View/Types.swift
+++ b/Sources/JoyfillUI/View/Types.swift
@@ -115,7 +115,7 @@ public struct PageEvent {
     }
 }
 
-public enum Mode {
+public enum Mode: Equatable, Sendable {
     case fill
     case readonly
 }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor+Decorators.swift
@@ -739,7 +739,7 @@ private extension DocumentEditor {
     }
 }
 
-public struct DecoratorConfig {
+public struct DecoratorConfig: Equatable, Sendable {
     /// Maximum number of field-level decorators (`field.decorators`) shown
     /// inline next to the field title before the rest move into a kebab menu.
     public var visibleLimitInFields: Int

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -42,7 +42,7 @@ public extension DocumentEditorDelegate {
     func decoratorsDidChange() {}
 }
 
-public struct PageConfig {
+public struct PageConfig: Equatable, Sendable {
     public var navigation: Bool          // was `navigation`
     public var enableDuplicates: Bool    // was `isPageDuplicateEnabled`
     public var enableDeletes: Bool       // was `isPageDeleteEnabled`
@@ -59,7 +59,7 @@ public struct PageConfig {
     }
 }
 
-public struct DisplayConfig {
+public struct DisplayConfig: Equatable, Sendable {
     public var singleClickRowEdit: Bool         // was `singleClickRowEdit`
     public var decorators: DecoratorConfig      // was `decoratorConfig`
 
@@ -70,7 +70,7 @@ public struct DisplayConfig {
     }
 }
 
-public struct DocumentEditorConfig {
+public struct DocumentEditorConfig: Equatable, Sendable {
     public var mode: Mode
     public var license: String?
     public var validateSchema: Bool

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -42,6 +42,54 @@ public extension DocumentEditorDelegate {
     func decoratorsDidChange() {}
 }
 
+public struct PageConfig {
+    public var navigation: Bool          // was `navigation`
+    public var enableDuplicates: Bool    // was `isPageDuplicateEnabled`
+    public var enableDeletes: Bool       // was `isPageDeleteEnabled`
+    public var currentPageID: String?    // was `pageID`
+
+    public init(navigation: Bool = true,
+                enableDuplicates: Bool = false,
+                enableDeletes: Bool = false,
+                currentPageID: String? = nil) {
+        self.navigation = navigation
+        self.enableDuplicates = enableDuplicates
+        self.enableDeletes = enableDeletes
+        self.currentPageID = currentPageID
+    }
+}
+
+public struct DisplayConfig {
+    public var singleClickRowEdit: Bool         // was `singleClickRowEdit`
+    public var decorators: DecoratorConfig      // was `decoratorConfig`
+
+    public init(singleClickRowEdit: Bool = false,
+                decorators: DecoratorConfig = DecoratorConfig()) {
+        self.singleClickRowEdit = singleClickRowEdit
+        self.decorators = decorators
+    }
+}
+
+public struct DocumentEditorConfig {
+    public var mode: Mode
+    public var license: String?
+    public var validateSchema: Bool
+    public var page: PageConfig
+    public var display: DisplayConfig
+
+    public init(mode: Mode = .fill,
+                license: String? = nil,
+                validateSchema: Bool = true,
+                page: PageConfig = .init(),
+                display: DisplayConfig = .init()) {
+        self.mode = mode
+        self.license = license
+        self.validateSchema = validateSchema
+        self.page = page
+        self.display = display
+    }
+}
+
 public class DocumentEditor: ObservableObject {
     private(set) public var document: JoyDoc
     public var schemaError: SchemaValidationError?
@@ -145,6 +193,22 @@ public class DocumentEditor: ObservableObject {
         self.currentPageOrder = document.pageOrderForCurrentView ?? []
     }
     
+    public convenience init(document: JoyDoc,
+                            events: FormChangeEvent? = nil,
+                            config: DocumentEditorConfig = DocumentEditorConfig()) {
+        self.init(document: document,
+                  mode: config.mode,
+                  events: events,
+                  pageID: config.page.currentPageID,
+                  navigation: config.page.navigation,
+                  isPageDuplicateEnabled: config.page.enableDuplicates,
+                  isPageDeleteEnabled: config.page.enableDeletes,
+                  validateSchema: config.validateSchema,
+                  license: config.license,
+                  singleClickRowEdit: config.display.singleClickRowEdit,
+                  decoratorConfig: config.display.decorators)
+    }
+
     public func registerDelegate(_ delegate: DocumentEditorDelegate, for fieldID: String) {
         delegateMap[fieldID] = WeakDocumentEditorDelegate(delegate)
     }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -130,18 +130,10 @@ public class DocumentEditor: ObservableObject {
     private var JoyfillDocContext: JoyfillDocContext!
 
     public init(document: JoyDoc,
-                mode: Mode = .fill,
                 events: FormChangeEvent? = nil,
-                pageID: String? = nil,
-                navigation: Bool = true,
-                isPageDuplicateEnabled: Bool = false,
-                isPageDeleteEnabled: Bool = false,
-                validateSchema: Bool = true,
-                license: String? = nil,
-                singleClickRowEdit: Bool = false,
-                decoratorConfig: DecoratorConfig = DecoratorConfig()) {
+                config: DocumentEditorConfig = DocumentEditorConfig()) {
         // Perform schema validation first
-        if validateSchema {
+        if config.validateSchema {
             // Check for schema validation errors
             let schemaManager = JoyfillSchemaManager()
             if let schemaError = schemaManager.validateSchema(document: document) {
@@ -149,14 +141,14 @@ public class DocumentEditor: ObservableObject {
                 self.schemaError = schemaError
                 // Set empty document
                 self.document = JoyDoc()
-                self.mode = mode
-                self.isPageDuplicateEnabled = isPageDuplicateEnabled
-                self.isPageDeleteEnabled = isPageDeleteEnabled
-                self.showPageNavigationView = navigation
-                self.singleClickRowEdit = singleClickRowEdit
+                self.mode = config.mode
+                self.isPageDuplicateEnabled = config.page.enableDuplicates
+                self.isPageDeleteEnabled = config.page.enableDeletes
+                self.showPageNavigationView = config.page.navigation
+                self.singleClickRowEdit = config.display.singleClickRowEdit
                 self.currentPageID = ""
                 self.events = events
-                self.decoratorConfig = decoratorConfig
+                self.decoratorConfig = config.display.decorators
                 
                 // Trigger onError callback if events handler is available
                 events?.onError(error: .schemaValidationError(error: schemaError))
@@ -166,16 +158,16 @@ public class DocumentEditor: ObservableObject {
         
         // Schema validation passed - proceed with normal initialization
         self.document = document
-        self.mode = mode
-        self.isPageDuplicateEnabled = mode == .readonly ? false : isPageDuplicateEnabled
-        self.isPageDeleteEnabled = mode == .readonly ? false : isPageDeleteEnabled
-        self.showPageNavigationView = navigation
-        self.singleClickRowEdit = singleClickRowEdit
+        self.mode = config.mode
+        self.isPageDuplicateEnabled = config.mode == .readonly ? false : config.page.enableDuplicates
+        self.isPageDeleteEnabled = config.mode == .readonly ? false : config.page.enableDeletes
+        self.showPageNavigationView = config.page.navigation
+        self.singleClickRowEdit = config.display.singleClickRowEdit
         self.currentPageID = ""
         self.events = events
         // Set feature flags from license
-        self.isCollectionFieldEnabled = LicenseValidator.isCollectionEnabled(licenseToken: license)
-        self.decoratorConfig = decoratorConfig
+        self.isCollectionFieldEnabled = LicenseValidator.isCollectionEnabled(licenseToken: config.license)
+        self.decoratorConfig = config.display.decorators
         updateFieldMap()
         updateFieldPositionMap()
         self.conditionalLogicHandler = ConditionalLogicHandler(documentEditor: self)
@@ -188,25 +180,35 @@ public class DocumentEditor: ObservableObject {
             updatePageFieldModels(page, pageID, fileID)
         }
         self.validationHandler = ValidationHandler(documentEditor: self)
-        self.currentPageID = document.firstValidPageID(for: pageID, conditionalLogicHandler: conditionalLogicHandler)
+        self.currentPageID = document.firstValidPageID(for: config.page.currentPageID, conditionalLogicHandler: conditionalLogicHandler)
         self.JoyfillDocContext = Joyfill.JoyfillDocContext(docProvider: self)
         self.currentPageOrder = document.pageOrderForCurrentView ?? []
     }
     
+    @available(*, deprecated, message: "Use init(document:events:config:) with DocumentEditorConfig instead.")
     public convenience init(document: JoyDoc,
+                            mode: Mode = .fill,
                             events: FormChangeEvent? = nil,
-                            config: DocumentEditorConfig = DocumentEditorConfig()) {
+                            pageID: String? = nil,
+                            navigation: Bool = true,
+                            isPageDuplicateEnabled: Bool = false,
+                            isPageDeleteEnabled: Bool = false,
+                            validateSchema: Bool = true,
+                            license: String? = nil,
+                            singleClickRowEdit: Bool = false,
+                            decoratorConfig: DecoratorConfig = DecoratorConfig()) {
         self.init(document: document,
-                  mode: config.mode,
                   events: events,
-                  pageID: config.page.currentPageID,
-                  navigation: config.page.navigation,
-                  isPageDuplicateEnabled: config.page.enableDuplicates,
-                  isPageDeleteEnabled: config.page.enableDeletes,
-                  validateSchema: config.validateSchema,
-                  license: config.license,
-                  singleClickRowEdit: config.display.singleClickRowEdit,
-                  decoratorConfig: config.display.decorators)
+                  config: DocumentEditorConfig(
+                    mode: mode,
+                    license: license,
+                    validateSchema: validateSchema,
+                    page: PageConfig(navigation: navigation,
+                                     enableDuplicates: isPageDuplicateEnabled,
+                                     enableDeletes: isPageDeleteEnabled,
+                                     currentPageID: pageID),
+                    display: DisplayConfig(singleClickRowEdit: singleClickRowEdit,
+                                           decorators: decoratorConfig)))
     }
 
     public func registerDelegate(_ delegate: DocumentEditorDelegate, for fieldID: String) {


### PR DESCRIPTION
## Context
`DocumentEditor` historically exposed a single initializer with 10+ flat parameters (`mode`, `pageID`, `navigation`, `isPageDuplicateEnabled`, `isPageDeleteEnabled`, `validateSchema`, `license`, `singleClickRowEdit`, `decoratorConfig`, …). This is hard to read at call sites, hard to extend without churning the signature, and doesn't let consumers hold/pass around a reusable configuration object. This PR introduces a grouped config-object API and deprecates the flat one — additively, with zero breakage.

## What changed
- **`Sources/JoyfillUI/ViewModels/DocumentEditor.swift`**
  - New config value types: `PageConfig`, `DisplayConfig`, `DocumentEditorConfig` (each with a `public init` and defaults identical to the old parameter defaults). Field-level `// was \`oldName\`` comments map each new field to the legacy parameter for cross-reference (and Kotlin/Swift naming parity).
  - All config types conform to `Equatable` + `Sendable` (cascaded to `Mode` in `Types.swift` and `DecoratorConfig` in `DocumentEditor+Decorators.swift`). Synthesized automatically — every member is trivially conformable.
  - The **config-based initializer is now the designated init**: `init(document:events:config:)` holds the real initialization body.
  - The **old flat initializer is now a deprecated `convenience init`** that builds a `DocumentEditorConfig` and delegates to the designated init. Marked `@available(*, deprecated, message: "Use init(document:events:config:) with DocumentEditorConfig instead.")`.
- **`JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift`** — new test file (13 tests).
- **`JoyfillExample.xcodeproj/project.pbxproj`** — registers the new test file in the `JoyfillTests` target.

## Key decisions
- **Delegation direction flipped (config init = designated, old init = convenience).** This keeps all real logic in one place (the new API) and makes the deprecated path a thin adapter. The alternative — keeping the old init designated and having config delegate to it — would leave the deprecated code as the source of truth and emit deprecation warnings inside the SDK.
- **No internal deprecation warnings.** The only in-SDK caller of the old init is `Form.init(document:mode:events:pageID:navigation:)`, which is itself already deprecated; Swift suppresses deprecation warnings for calls made from within a deprecated declaration, so the framework builds clean.
- **Readonly coercion preserved exactly.** `mode == .readonly` still forces `isPageDuplicateEnabled`/`isPageDeleteEnabled` to `false` on the normal path, and the schema-failure early-return branch keeps its original (non-coerced) behavior — unchanged from before.
- **Additive / backward compatible.** Old call sites compile and run identically; they only get a deprecation hint.

## Public API change
**Yes.** Adds public `PageConfig`, `DisplayConfig`, `DocumentEditorConfig` and a new `DocumentEditor.init(document:events:config:)`. The old initializer remains public but is now deprecated. The config types (plus `Mode` and `DecoratorConfig`) now conform to `Equatable` + `Sendable` — additive, so it enables config diffing for the swap use case and keeps the types clean under strict concurrency without affecting existing callers.

**Docs:** SDK init docs / README examples should be updated to show the config-based init as the recommended path and note the old one is deprecated. Kotlin SDK should mirror these names for parity.

### Usage
```swift
// New (recommended)
let editor = DocumentEditor(
    document: doc,
    events: changeManager,
    config: DocumentEditorConfig(
        mode: .fill,
        license: licenseToken,
        page: PageConfig(navigation: true, enableDuplicates: true, enableDeletes: true, currentPageID: "page_id"),
        display: DisplayConfig(singleClickRowEdit: true, decorators: DecoratorConfig(visibleLimitInFields: 5, visibleLimitInRows: 3))
    )
)

// Old (still works, now deprecated)
let editor = DocumentEditor(document: doc, mode: .fill, events: changeManager, pageID: "page_id", navigation: true, ...)
```

## Tests
Covered in this PR — 13 tests in `DocumentEditorConfigTests`:
- Field mapping (config → editor properties) and struct defaults match legacy defaults
- Readonly coercion forces page duplicate/delete off
- Default config == legacy default init; non-default config == legacy init with equivalent params (guards the delegation mapping)
- `license` → `isCollectionFieldEnabled` mapping guarded both ways: a *valid* token via config enables collection fields (absolute assertion), and a nil license keeps them disabled — so dropping/zeroing `license` on the config path would fail the test
- `validateSchema` true on invalid doc sets `schemaError` + fires `onError`; false skips
- `currentPageID` resolves to the requested page; nil falls back to first valid page (matches legacy)
- `events` passthrough; two distinct configs produce independent editors (hold/swap use case)

Full `JoyfillTests` suite: **1094 tests, 0 failures.** (The legacy/deprecated init path is exercised by existing tests, confirming no behavior change.)

## Notes for reviewer
- No UI change — nothing to screenshot/record (initializer/API-shape only).
- The `init(document:events:config:)` body is a 1:1 port of the previous designated init with parameters replaced by `config.*`; diff is best read as "extract params into config struct" rather than logic changes.
- Heads-up: the example app's `licenseKey` (in `JoyfillExampleApp.swift`) is intentionally kept out of this PR; collection-field tests assert that token verifies against `LicenseValidator`'s public key.

