### PR TITLE
NO-2228: Preserve required value key on table/collection fields when copying a page without values

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
@@ -315,6 +315,116 @@ final class PageDeletableCopyableValidationTests: XCTestCase {
         XCTAssertTrue(hasValue, "copyWithValues=true should preserve at least one field value on the duplicated page.")
     }
 
+    /// Regression: copying "without values" must NOT drop the `value` key on table/collection
+    /// fields. The JSON schema marks `value` as required for those types, so nilling it out
+    /// (which removes the key) makes the duplicated document fail schema validation. They must
+    /// instead be cleared to an empty array so the key survives.
+    func testDuplicatePage_WithoutValues_TableFieldKeepsEmptyValueArray() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+
+        // Add a table field (with rows) positioned on the page that will be duplicated.
+        var tableField = JoyDocField()
+        tableField.id = "regression_table_field"
+        tableField.type = "table"
+        tableField.file = "6629fab3c0ba3fb775b4a55c"
+        tableField.rowOrder = ["regression_row_1"]
+        tableField.value = .valueElementArray([ValueElement(id: "regression_row_1")])
+        document.fields.append(tableField)
+
+        let tablePosition = FieldPosition(dictionary: [
+            "field": "regression_table_field",
+            "displayType": "original",
+            "width": 12, "height": 8, "x": 0, "y": 16,
+            "_id": "regression_table_position",
+            "type": "table"
+        ])
+        document.files[0].pages?[0].fieldPositions?.append(tablePosition)
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let editor = makeEditor(document: document)
+
+        editor.duplicatePage(pageID: pageID, copyWithValues: false)
+
+        // Locate the duplicated page and its table field.
+        let firstFile = editor.document.files.first
+        guard let duplicatedPageID = firstFile?.pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+        let duplicatedFieldIDs = Set(duplicatedPage.fieldPositions?.compactMap { $0.field } ?? [])
+        let duplicatedFields = editor.document.fields.filter { duplicatedFieldIDs.contains($0.id ?? "") }
+        guard let duplicatedTable = duplicatedFields.first(where: { $0.fieldType == .table }) else {
+            XCTFail("Duplicated table field not found on the duplicated page.")
+            return
+        }
+
+        // The required `value` key must still exist and be an (empty) array, not absent.
+        XCTAssertNotNil(duplicatedTable.dictionary["value"],
+                        "Table field must keep its required `value` key when copied without values.")
+        let valueArray = duplicatedTable.dictionary["value"] as? [Any]
+        XCTAssertNotNil(valueArray, "Table field `value` must be an array when copied without values.")
+        XCTAssertTrue(valueArray?.isEmpty ?? false, "Table field rows must be cleared when copied without values.")
+        XCTAssertEqual(duplicatedTable.rowOrder ?? ["non-empty"], [],
+                       "Table field rowOrder must be cleared to stay consistent with the emptied value.")
+    }
+
+    /// Regression: same as the table case, but for collection fields. The schema marks
+    /// `value` as required for collections too, so copying "without values" must clear it to
+    /// an empty array (keeping the key) rather than nilling it out (dropping the key).
+    func testDuplicatePage_WithoutValues_CollectionFieldKeepsEmptyValueArray() {
+        var document = JoyDoc()
+            .setDocument()
+            .setFile()
+            .setPageWithFieldPosition()
+
+        // Add a collection field (with items) positioned on the page that will be duplicated.
+        var collectionField = JoyDocField()
+        collectionField.id = "regression_collection_field"
+        collectionField.type = "collection"
+        collectionField.file = "6629fab3c0ba3fb775b4a55c"
+        collectionField.value = .valueElementArray([ValueElement(id: "regression_item_1")])
+        document.fields.append(collectionField)
+
+        let collectionPosition = FieldPosition(dictionary: [
+            "field": "regression_collection_field",
+            "displayType": "original",
+            "width": 12, "height": 10, "x": 0, "y": 24,
+            "_id": "regression_collection_position",
+            "type": "collection"
+        ])
+        document.files[0].pages?[0].fieldPositions?.append(collectionPosition)
+
+        let pageID = "6629fab320fca7c8107a6cf6"
+        let editor = makeEditor(document: document)
+
+        editor.duplicatePage(pageID: pageID, copyWithValues: false)
+
+        // Locate the duplicated page and its collection field.
+        let firstFile = editor.document.files.first
+        guard let duplicatedPageID = firstFile?.pageOrder?.first(where: { $0 != pageID }),
+              let duplicatedPage = firstFile?.pages?.first(where: { $0.id == duplicatedPageID }) else {
+            XCTFail("Duplicated page not found.")
+            return
+        }
+        let duplicatedFieldIDs = Set(duplicatedPage.fieldPositions?.compactMap { $0.field } ?? [])
+        let duplicatedFields = editor.document.fields.filter { duplicatedFieldIDs.contains($0.id ?? "") }
+        guard let duplicatedCollection = duplicatedFields.first(where: { $0.fieldType == .collection }) else {
+            XCTFail("Duplicated collection field not found on the duplicated page.")
+            return
+        }
+
+        // The required `value` key must still exist and be an (empty) array, not absent.
+        XCTAssertNotNil(duplicatedCollection.dictionary["value"],
+                        "Collection field must keep its required `value` key when copied without values.")
+        let valueArray = duplicatedCollection.dictionary["value"] as? [Any]
+        XCTAssertNotNil(valueArray, "Collection field `value` must be an array when copied without values.")
+        XCTAssertTrue(valueArray?.isEmpty ?? false, "Collection field items must be cleared when copied without values.")
+    }
+
     // MARK: - copyWithValues=false: original page fields untouched
 
     /// `copyWithValues=false` must only clear the NEW page's fields — the original page's

--- a/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift
@@ -425,6 +425,74 @@ final class PageDeletableCopyableValidationTests: XCTestCase {
         XCTAssertTrue(valueArray?.isEmpty ?? false, "Collection field items must be cleared when copied without values.")
     }
 
+    /// End-to-end regression: build a fully schema-valid document containing both a table and a
+    /// collection field, copy the page WITHOUT values, then run the real JSON-schema validation
+    /// (`JoyfillSchemaManager.validateSchema`) on the resulting document. This guards the actual
+    /// bug this fix addresses — the mechanism tests above only assert the `value` key survives,
+    /// they never run schema validation (they use `validateSchema: false`).
+    ///
+    /// The fixture is intentionally schema-complete: `TableField` requires
+    /// `tableColumns`/`tableColumnOrder` and `CollectionField` requires `schema`, so those keys
+    /// are all present here.
+    func testDuplicatePage_WithoutValues_PassesRealSchemaValidation() {
+        let documentDictionary: [String: Any] = [
+            "_id": "schema_e2e_doc",
+            "type": "document",
+            "stage": "published",
+            "identifier": "schema_e2e_identifier",
+            "name": "Schema E2E Doc",
+            "files": [[
+                "_id": "schema_e2e_file",
+                "pageOrder": ["schema_e2e_page"],
+                "pages": [[
+                    "_id": "schema_e2e_page",
+                    "name": "Page 1",
+                    "width": 816, "height": 1056, "cols": 24, "rowHeight": 8,
+                    "layout": "grid", "presentation": "normal",
+                    "fieldPositions": [
+                        ["_id": "pos_table", "field": "e2e_table_field", "displayType": "original",
+                         "width": 12, "height": 8, "x": 0, "y": 0, "type": "table"],
+                        ["_id": "pos_collection", "field": "e2e_collection_field", "displayType": "original",
+                         "width": 12, "height": 10, "x": 0, "y": 8, "type": "collection"]
+                    ]
+                ]]
+            ]],
+            "fields": [
+                [
+                    "_id": "e2e_table_field",
+                    "type": "table",
+                    "file": "schema_e2e_file",
+                    "rowOrder": ["e2e_row_1"],
+                    "tableColumnOrder": ["e2e_col_1"],
+                    "tableColumns": [["_id": "e2e_col_1", "type": "text"]],
+                    "value": [["_id": "e2e_row_1"]]
+                ],
+                [
+                    "_id": "e2e_collection_field",
+                    "type": "collection",
+                    "file": "schema_e2e_file",
+                    "schema": [String: Any](),
+                    "value": [["_id": "e2e_item_1"]]
+                ]
+            ]
+        ]
+
+        let document = JoyDoc(dictionary: documentDictionary)
+        let schemaManager = JoyfillSchemaManager()
+
+        // Sanity: the hand-built base document must itself be schema-valid, otherwise the
+        // post-copy assertion below would be meaningless.
+        XCTAssertNil(schemaManager.validateSchema(document: document),
+                     "Base fixture must be schema-valid before exercising the copy.")
+
+        let editor = makeEditor(document: document)
+        editor.duplicatePage(pageID: "schema_e2e_page", copyWithValues: false)
+
+        // The whole point of the fix: the duplicated document still passes real schema validation.
+        XCTAssertNil(schemaManager.validateSchema(document: editor.document),
+                     "Document must remain schema-valid after copying a page without values.")
+    }
+
     // MARK: - copyWithValues=false: original page fields untouched
 
     /// `copyWithValues=false` must only clear the NEW page's fields — the original page's

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -1147,7 +1147,17 @@ extension DocumentEditor {
                 let isReadonly = newFields[i].disabled == true
                 let isDisplayText = newFields[i].fieldType == .block
                 if isReadonly || isDisplayText { continue }
-                newFields[i].value = nil
+                // Table and collection fields mark `value` as required in the schema, so clearing
+                // them to nil (which drops the key) would fail validation. Empty them instead.
+                switch newFields[i].fieldType {
+                case .table:
+                    newFields[i].value = .valueElementArray([])
+                    newFields[i].rowOrder = []
+                case .collection:
+                    newFields[i].value = .valueElementArray([])
+                default:
+                    newFields[i].value = nil
+                }
             }
         }
 


### PR DESCRIPTION
## Context
When a user copies a page **without values**, the duplicated page must keep its structure but drop field data. The copied document is later run through JSON-schema validation. For most field types omitting the field value is fine, but `table` and `collection` mark `value` as **required** in the schema — so dropping that key produced an invalid document and schema validation failed.

## What changed
- `Sources/JoyfillUI/ViewModels/DocumentEditor.swift` — in `duplicatePage(..., copyWithValues: false)`, the value-stripping loop now special-cases `table` and `collection`:
  - `table` → `value = .valueElementArray([])` and `rowOrder = []`
  - `collection` → `value = .valueElementArray([])`
  - all other field types → unchanged (`value = nil`)
- `JoyfillSwiftUIExample/JoyfillTests/PageDeletableCopyableValidationTests.swift` — added two regression tests covering the table and collection cases.

## Why this approach
- Setting `value = nil` removes the key entirely (the setter does `dictionary["value"] = newValue?.dictionary`), which is what broke schema validation. Clearing to an empty array preserves the required key while still discarding the data.
- Only `table` and `collection` list `value` in their schema `required` array (verified across all field definitions); every other array-valued type (`image`, `file`, `multiSelect`, `dropdown`, `chart`, …) leaves `value` optional, so omitting it stays valid — hence no change for them.
- A field's business `required: true` flag does not affect this — the schema has no conditional (`if/then`/`dependentRequired`) rules, so it cannot promote `value` into a `required` array. Business-required is enforced separately by `Validator`, not schema validation.
- `rowOrder` is cleared for tables so it stays consistent with the now-empty rows.

## Screenshots / video
N/A — no visual change. The fix is that copying a page without values no longer fails schema validation; behavior is verified via automated tests.

## Public API
No public API changes. `duplicatePage(pageID:copyWithValues:)` signature is unchanged. No docs update required.

## Test coverage
Covered now. Added in `PageDeletableCopyableValidationTests`:
- `testDuplicatePage_WithoutValues_TableFieldKeepsEmptyValueArray` and `testDuplicatePage_WithoutValues_CollectionFieldKeepsEmptyValueArray` — mechanism checks: the `value` key stays present as an empty array (and table `rowOrder` is cleared).
- `testDuplicatePage_WithoutValues_PassesRealSchemaValidation` — end-to-end: builds a fully schema-valid document (table + collection), copies the page without values, and asserts `JoyfillSchemaManager().validateSchema(...) == nil`. The fixture is schema-complete and the test also asserts the base document is valid before the copy.

Verified the e2e test actually guards the bug: temporarily reverting the fix to `value = nil` makes it fail. Full unit suite passes (1083 tests, 0 failures).

## Notes for reviewer
- Test layering: mechanism tests pinpoint the cause (fast, robust); the end-to-end test exercises the real JSON-schema validation this PR fixes.
- Scope is intentionally minimal: only the `copyWithValues == false` branch is touched; the `copyWithValues == true` path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)