### PR TITLE
NO-2234: Add file/field variant to SchemaLogicCondition and bump schema to 1.0.5

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -12,7 +12,7 @@ import Joyfill
 
 final class SchemaValidationTests: XCTestCase {
     /// The schema version expected in `SchemaValidationError.details`.
-    private let expectedSchemaVersion = "1.0.4"
+    private let expectedSchemaVersion = "1.0.5"
     private let sdkVersion = "3.0.0-rc22"
     
     func documentEditor(document: JoyDoc) -> DocumentEditor {

--- a/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift
@@ -374,6 +374,99 @@ final class SchemaValidationTests: XCTestCase {
             XCTAssertNil(err, "ChartPoint with \(label) should validate against the relaxed schema")
         }
     }
+
+    // MARK: - Schema 1.0.5: SchemaLogicCondition oneOf (collection vs field form)
+
+    /// Builds a valid document whose collection field carries a `SchemaDefinition.logic`
+    /// with a single `SchemaLogicCondition` equal to `condition`, so the `oneOf`
+    /// definition at `SchemaLogicCondition` is actually exercised.
+    private func documentWithSchemaLogicCondition(_ condition: [String: Any]) -> JoyDoc {
+        var docDict = minimalValidDocumentDictionary()
+        let collectionField: [String: Any] = [
+            "_id": "collection1",
+            "type": "collection",
+            "file": "file1",
+            "value": [],
+            "schema": [
+                "schema1": [
+                    "root": true,
+                    "tableColumns": [],
+                    "logic": [
+                        "action": "show",
+                        "eval": "and",
+                        "conditions": [condition]
+                    ]
+                ]
+            ]
+        ]
+        docDict["fields"] = [collectionField]
+        return JoyDoc(dictionary: docDict)
+    }
+
+    // (b) Collection form (schema/column/condition) still validates — regression guard.
+    func testSchemaLogicCondition_CollectionForm_ShouldValidate() {
+        let condition: [String: Any] = [
+            "_id": "cond1",
+            "schema": "schema1",
+            "column": "col1",
+            "condition": "=",
+            "value": "foo"
+        ]
+        let err = JoyfillSchemaManager().validateSchema(document: documentWithSchemaLogicCondition(condition))
+        XCTAssertNil(err, "Collection-form SchemaLogicCondition (schema/column/condition) should validate")
+    }
+
+    // (a) New field form (file/field/condition) validates.
+    func testSchemaLogicCondition_FieldForm_ShouldValidate() {
+        let condition: [String: Any] = [
+            "_id": "cond1",
+            "file": "file1",
+            "page": "page1",
+            "field": "field1",
+            "condition": "=",
+            "value": "foo"
+        ]
+        let err = JoyfillSchemaManager().validateSchema(document: documentWithSchemaLogicCondition(condition))
+        XCTAssertNil(err, "Field-form SchemaLogicCondition (file/field/condition) should validate")
+    }
+
+    // (a') Field form with optional `page` omitted still validates.
+    func testSchemaLogicCondition_FieldForm_WithoutOptionalPage_ShouldValidate() {
+        let condition: [String: Any] = [
+            "file": "file1",
+            "field": "field1",
+            "condition": "="
+        ]
+        let err = JoyfillSchemaManager().validateSchema(document: documentWithSchemaLogicCondition(condition))
+        XCTAssertNil(err, "Field-form condition without optional `page` should validate")
+    }
+
+    // (c) A mixed object matches BOTH oneOf branches → exactly-one semantics must reject it.
+    func testSchemaLogicCondition_MixedForm_ShouldFail() {
+        let condition: [String: Any] = [
+            "_id": "cond1",
+            "schema": "schema1",
+            "column": "col1",
+            "file": "file1",
+            "field": "field1",
+            "condition": "="
+        ]
+        let err = JoyfillSchemaManager().validateSchema(document: documentWithSchemaLogicCondition(condition))
+        XCTAssertEqual("ERROR_SCHEMA_VALIDATION", err?.code, "A condition satisfying both oneOf branches must fail (oneOf = exactly one)")
+        XCTAssertEqual(expectedSchemaVersion, err?.details.schemaVersion)
+    }
+
+    // (d) An object matching neither branch (missing required keys) must fail.
+    func testSchemaLogicCondition_MissingRequiredKeys_ShouldFail() {
+        // Only `field` present: satisfies neither the collection form (needs schema/column)
+        // nor the field form (needs file + condition).
+        let condition: [String: Any] = [
+            "field": "field1"
+        ]
+        let err = JoyfillSchemaManager().validateSchema(document: documentWithSchemaLogicCondition(condition))
+        XCTAssertEqual("ERROR_SCHEMA_VALIDATION", err?.code, "A condition matching neither oneOf branch must fail")
+        XCTAssertEqual(expectedSchemaVersion, err?.details.schemaVersion)
+    }
 }
 
 private class MockFormChangeEvent: FormChangeEvent {

--- a/Sources/JoyfillUI/View/joyfill-schema.swift
+++ b/Sources/JoyfillUI/View/joyfill-schema.swift
@@ -2595,26 +2595,56 @@ public var joyfillSchema = """
         ]
       },
       "SchemaLogicCondition": {
-        "type": "object",
-        "properties": {
-          "_id": {
-            "type": "string"
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "type": "string"
+              },
+              "schema": {
+                "type": "string"
+              },
+              "column": {
+                "type": "string"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "schema",
+              "column",
+              "condition"
+            ]
           },
-          "schema": {
-            "type": "string"
-          },
-          "column": {
-            "type": "string"
-          },
-          "condition": {
-            "type": "string"
-          },
-          "value": {}
-        },
-        "required": [
-          "schema",
-          "column",
-          "condition"
+          {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "type": "string"
+              },
+              "file": {
+                "type": "string"
+              },
+              "page": {
+                "type": "string"
+              },
+              "field": {
+                "type": "string"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "file",
+              "field",
+              "condition"
+            ]
+          }
         ]
       },
       "CollectionItem": {
@@ -2825,7 +2855,7 @@ public var joyfillSchema = """
         ]
       }
     },
-    "$joyfillSchemaVersion": "1.0.4"
+    "$joyfillSchemaVersion": "1.0.5"
   }
 
 """


### PR DESCRIPTION
## Context
`SchemaLogicCondition` previously modeled only *schema/collection*-scoped conditional logic (`schema` + `column`). Conditional logic also needs to target regular *page fields* (`file` + `page` + `field`), which the schema had no way to express. This PR widens the schema definition to cover both shapes.

## What changed
- **`Sources/JoyfillUI/View/joyfill-schema.swift`**
  - `SchemaLogicCondition` is now a `oneOf` of two object variants:
    - existing collection form — required: `schema`, `column`, `condition`
    - new field form — required: `file`, `field`, `condition` (plus optional `page`, `_id`, `value`)
  - Bumped `$joyfillSchemaVersion` from `1.0.4` → `1.0.5`.
- **`JoyfillSwiftUIExample/JoyfillTests/SchemaValidation/SchemaValidationTests.swift`**
  - Updated `expectedSchemaVersion` constant `1.0.4` → `1.0.5` to match the bumped schema.

## Decisions
- Used `oneOf` rather than merging all keys into one loosened object so each variant keeps its own `required` set — a field condition can't accidentally validate with a `column`, and vice versa.
- Kept `_id` and `value` optional in both variants to preserve backward compatibility with existing documents.
- No source changes needed for the version bump: the SDK reads `$joyfillSchemaVersion` dynamically via `JoyfillSchemaManager.currentSchemaVersion()`, so only the schema JSON and the test's hardcoded expectation required edits.

## Media
N/A — schema/validation-only change, no UI surface to screenshot.

## Public API / docs
- No public Swift API signature changes.
- The schema contract *is* a public interface: consumers relying on the schema version string will now see `1.0.5`, and the new file/field condition shape should be reflected in schema docs. **Schema docs likely need updating** to document the two condition variants.

## Tests
- Existing `SchemaValidationTests` pass with the updated expected version.
- No new positive/negative test was added for the file/field variant specifically — can add coverage asserting a `file`/`field` condition validates and that mixing keys fails, if reviewers want it in this PR.

## Notes for reviewers
- Please confirm the required-key set for the field variant (`file`, `field`, `condition`) matches the platform/Kotlin schema so cross-SDK behavior stays aligned.