### PR TITLE
NO-2213: Move change-event handler into DocumentEditorConfig.events

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift
@@ -211,8 +211,7 @@ final class DocumentEditorConfigTests: XCTestCase {
     func testConfigInit_validateSchemaTrue_invalidDoc_setsErrorAndFiresOnError() {
         let events = MockFormChangeEvent()
         let editor = DocumentEditor(document: invalidDocument(),
-                                    events: events,
-                                    config: DocumentEditorConfig(validateSchema: true))
+                                    config: DocumentEditorConfig(events: events, validateSchema: true))
 
         XCTAssertNotNil(editor.schemaError)
         XCTAssertEqual(editor.schemaError?.code, "ERROR_SCHEMA_VALIDATION")
@@ -229,8 +228,7 @@ final class DocumentEditorConfigTests: XCTestCase {
     func testConfigInit_validateSchemaFalse_invalidDoc_skipsValidation() {
         let events = MockFormChangeEvent()
         let editor = DocumentEditor(document: invalidDocument(),
-                                    events: events,
-                                    config: DocumentEditorConfig(validateSchema: false))
+                                    config: DocumentEditorConfig(events: events, validateSchema: false))
 
         XCTAssertNil(editor.schemaError)
         XCTAssertFalse(events.didReceiveError)
@@ -268,8 +266,7 @@ final class DocumentEditorConfigTests: XCTestCase {
     func testConfigInit_eventsArePassedThrough() {
         let events = MockFormChangeEvent()
         let editor = DocumentEditor(document: JoyDoc(),
-                                    events: events,
-                                    config: DocumentEditorConfig(validateSchema: false))
+                                    config: DocumentEditorConfig(events: events, validateSchema: false))
 
         XCTAssertNotNil(editor.events)
         XCTAssertTrue((editor.events as AnyObject) === events)

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -70,14 +70,16 @@ public struct DisplayConfig: Equatable, Sendable {
     }
 }
 
-public struct DocumentEditorConfig: Equatable, Sendable {
+public struct DocumentEditorConfig {
     public var mode: Mode
     public var license: String?
     public var validateSchema: Bool
     public var page: PageConfig
     public var display: DisplayConfig
+    public var events: FormChangeEvent?
 
     public init(mode: Mode = .fill,
+                events: FormChangeEvent? = nil,
                 license: String? = nil,
                 validateSchema: Bool = true,
                 page: PageConfig = .init(),
@@ -87,6 +89,7 @@ public struct DocumentEditorConfig: Equatable, Sendable {
         self.validateSchema = validateSchema
         self.page = page
         self.display = display
+        self.events = events
     }
 }
 
@@ -130,7 +133,6 @@ public class DocumentEditor: ObservableObject {
     internal var joyDocContext: JoyfillDocContext!
 
     public init(document: JoyDoc,
-                events: FormChangeEvent? = nil,
                 config: DocumentEditorConfig = DocumentEditorConfig()) {
         // Perform schema validation first
         if config.validateSchema {
@@ -147,11 +149,11 @@ public class DocumentEditor: ObservableObject {
                 self.showPageNavigationView = config.page.navigation
                 self.singleClickRowEdit = config.display.singleClickRowEdit
                 self.currentPageID = ""
-                self.events = events
+                self.events = config.events
                 self.decoratorConfig = config.display.decorators
                 
                 // Trigger onError callback if events handler is available
-                events?.onError(error: .schemaValidationError(error: schemaError))
+                config.events?.onError(error: .schemaValidationError(error: schemaError))
                 return
             }
         }
@@ -164,7 +166,7 @@ public class DocumentEditor: ObservableObject {
         self.showPageNavigationView = config.page.navigation
         self.singleClickRowEdit = config.display.singleClickRowEdit
         self.currentPageID = ""
-        self.events = events
+        self.events = config.events
         // Set feature flags from license
         self.isCollectionFieldEnabled = LicenseValidator.isCollectionEnabled(licenseToken: config.license)
         self.decoratorConfig = config.display.decorators
@@ -185,7 +187,7 @@ public class DocumentEditor: ObservableObject {
         self.currentPageOrder = document.pageOrderForCurrentView ?? []
     }
     
-    @available(*, deprecated, message: "Use init(document:events:config:) with DocumentEditorConfig instead.")
+    @available(*, deprecated, message: "Use init(document:config:) with DocumentEditorConfig instead.")
     public convenience init(document: JoyDoc,
                             mode: Mode = .fill,
                             events: FormChangeEvent? = nil,
@@ -198,9 +200,9 @@ public class DocumentEditor: ObservableObject {
                             singleClickRowEdit: Bool = false,
                             decoratorConfig: DecoratorConfig = DecoratorConfig()) {
         self.init(document: document,
-                  events: events,
                   config: DocumentEditorConfig(
                     mode: mode,
+                    events: events,
                     license: license,
                     validateSchema: validateSchema,
                     page: PageConfig(navigation: navigation,


### PR DESCRIPTION
## Context
`DocumentEditor` used to take the `FormChangeEvent` handler as a **separate init argument**, sitting next to `DocumentEditorConfig`. That meant editor configuration was split across two places (the `events:` param and the `config:` object). This change consolidates it: the change-event handler now lives on `DocumentEditorConfig`, so there is a single configuration surface for the editor.

## What changed
- **`Sources/JoyfillUI/ViewModels/DocumentEditor.swift`**
  - Added `events: FormChangeEvent?` to `DocumentEditorConfig`.
  - Removed the `events:` parameter from the designated `init(document:config:)`; the handler is now read from `config.events`.
  - The deprecated convenience init now forwards its `events:` argument into the config (so its existing callers keep working).
  - `DocumentEditorConfig` no longer conforms to `Equatable, Sendable`.
- **`JoyfillSwiftUIExample/JoyfillTests/DocumentEditorConfigTests.swift`**
  - Updated call sites to pass `events` through `DocumentEditorConfig(events:)`.

## Decisions / why
- **Handler moved into the config, not kept as a dual path.** Keeping both an `events:` param and `config.events` would create two sources of truth with silent precedence rules. A single `config.events` is unambiguous.
- **`Equatable`/`Sendable` dropped from `DocumentEditorConfig`.** The config now holds a delegate reference (`FormChangeEvent`), which is neither `Equatable` nor `Sendable`. No SDK code compares configs or crosses concurrency boundaries with them, so dropping the conformances is safe rather than papering over it with a custom `==` + `@unchecked Sendable`.
- **Deprecated convenience init retained** so `DocumentEditor(document:events:…)` callers are not broken during migration.

## Screenshot / video
N/A — no UI or behavioral change; this is an API-shape change only.

## Public API change
**Yes.**
- `DocumentEditor.init(document:events:config:)` → `init(document:config:)`. Callers pass the handler via `DocumentEditorConfig(events:)`.
- `DocumentEditorConfig` gains `events` and drops `Equatable`/`Sendable`.
- **Docs need updating**: any SDK docs/README/snippets showing `DocumentEditor(document:events:…)` should move `events` into `DocumentEditorConfig`.

## Tests
Covered by existing `DocumentEditorConfigTests` — `events` pass-through via config, the `onError` schema-validation path, and legacy↔config parity are already asserted and updated in this PR. No new test file needed.

## Notes for the reviewer
- `DocumentEditor.events` remains a public settable `var`, so a handler can still be swapped after init; if we want config to be the only entry point we could make it `private(set)` in a follow-up.
- `DocumentEditor` does **not** retain the whole `config` (it copies out fields), so `config.events` is released after `init`; the only lasting strong reference is `editor.events` — unchanged from before.
