### PR TITLE
NO-2260: Default table/collection multiSelect columns to single-select

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
@@ -8,7 +8,8 @@
       "pageOrder": [
         "685750efeb612f4fac5819dd",
         "68f20e45b90bb7914a6b967a",
-        "68f8a5d17f82d5a7f6f36b3f"
+        "68f8a5d17f82d5a7f6f36b3f",
+        "6a57a455d1ea9e0dd246d472"
       ],
       "pages": [
         {
@@ -52,7 +53,12 @@
           "presentation": "normal",
           "padding": 24,
           "name": "New Page",
-          "rowHeight": 8
+          "rowHeight": 8,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         },
         {
           "_id": "68f20e45b90bb7914a6b967a",
@@ -95,7 +101,12 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         },
         {
           "_id": "68f8a5d17f82d5a7f6f36b3f",
@@ -118,7 +129,39 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
+        },
+        {
+          "_id": "6a57a455d1ea9e0dd246d472",
+          "name": "Multiselect",
+          "width": 816,
+          "height": 1056,
+          "rowHeight": 8,
+          "cols": 8,
+          "fieldPositions": [
+            {
+              "_id": "6a57a45f8a09d2bd321f8f52",
+              "type": "collection",
+              "displayType": "original",
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 29,
+              "field": "6a57a45fbc641c7c1a041ecd"
+            }
+          ],
+          "layout": "grid",
+          "presentation": "normal",
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values"
+          ]
         }
       ],
       "_id": "685750ef698da1ab427761ba",
@@ -1777,6 +1820,116 @@
         }
       },
       "identifier": "field_68f8a5de7d9ea2acad2e5f62"
+    },
+    {
+      "file": "685750ef698da1ab427761ba",
+      "_id": "6a57a45fbc641c7c1a041ecd",
+      "type": "collection",
+      "title": "Collection",
+      "value": [
+        {
+          "_id": "6a57a47e8d5858696f91e9ed",
+          "cells": {},
+          "children": {}
+        },
+        {
+          "_id": "6a57a47fd8c8d5dfccaf9eef",
+          "cells": {},
+          "children": {}
+        },
+        {
+          "_id": "6a57a4882d236f1aa6462935",
+          "cells": {},
+          "children": {}
+        }
+      ],
+      "schema": {
+        "collectionSchemaId": {
+          "title": "Main Collection",
+          "root": true,
+          "children": [],
+          "tableColumns": [
+            {
+              "_id": "6a57a46a584427c53d6c447a",
+              "type": "multiSelect",
+              "title": "MultiSelect Column 1",
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a57a46ac5ffc39bdda33d80",
+                  "value": "Option 1",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a46a965b00180bc81272",
+                  "value": "Option 2",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a46ae9a711871fe76993",
+                  "value": "Option 3",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a57a45fbc641c7c1a041ecd_column_6a57a46a584427c53d6c447a"
+            },
+            {
+              "_id": "6a57a46f09bc7681d8ae9dc0",
+              "type": "multiSelect",
+              "title": "MultiSelect Column 2",
+              "multi": false,
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a57a46f7e8e72890f0b22c5",
+                  "value": "Option 1",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a46f7dcb855f05f39ba5",
+                  "value": "Option 2",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a46fb31f27780af76f70",
+                  "value": "Option 3",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a57a45fbc641c7c1a041ecd_column_6a57a46f09bc7681d8ae9dc0"
+            },
+            {
+              "_id": "6a57a4709654b82a7aec819d",
+              "type": "multiSelect",
+              "title": "MultiSelect Column 3",
+              "multi": true,
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a57a4700a91cf01e6655e5a",
+                  "value": "Option 1",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a4707f44838f35197aa9",
+                  "value": "Option 2",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a57a47012eb4fc1d4f837db",
+                  "value": "Option 3",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a57a45fbc641c7c1a041ecd_column_6a57a4709654b82a7aec819d"
+            }
+          ]
+        }
+      },
+      "identifier": "field_6a57a45fbc641c7c1a041ecd"
     }
   ]
 }

--- a/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
@@ -257,6 +257,7 @@
           "_id": "685752c9b183f6583d205cc6",
           "title": "MultiSelect Column",
           "type": "multiSelect",
+          "multi": true,
           "width": 0,
           "options": [
             {
@@ -439,6 +440,7 @@
               "title": "Multiselect Column",
               "width": 0,
               "type": "multiSelect",
+              "multi": true,
               "options": [
                 {
                   "value": "Option 1",
@@ -879,6 +881,7 @@
               "_id": "6857530158fb7edb102344fa",
               "title": "MultiSelect  D1",
               "type": "multiSelect",
+              "multi": true,
               "width": 0,
               "options": [
                 {
@@ -1572,6 +1575,7 @@
               "type": "multiSelect",
               "title": "Multiselect Column",
               "deleted": false,
+              "multi": true,
               "width": 0,
               "options": [
                 {

--- a/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/CollectionFilter.json
@@ -53,12 +53,7 @@
           "presentation": "normal",
           "padding": 24,
           "name": "New Page",
-          "rowHeight": 8,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "rowHeight": 8
         },
         {
           "_id": "68f20e45b90bb7914a6b967a",
@@ -101,12 +96,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "padding": 24
         },
         {
           "_id": "68f8a5d17f82d5a7f6f36b3f",
@@ -129,12 +119,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "padding": 24
         },
         {
           "_id": "6a57a455d1ea9e0dd246d472",
@@ -157,11 +142,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values"
-          ]
+          "padding": 24
         }
       ],
       "_id": "685750ef698da1ab427761ba",

--- a/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/Joydocjson.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/Joydocjson.json
@@ -2787,6 +2787,7 @@
                             "_id": "6805b771ab52db07a211a2f6",
                             "type": "multiSelect",
                             "title": "Multiselect Column",
+                            "multi": true,
                             "deleted": false,
                             "width": 0,
                             "options": [
@@ -2919,6 +2920,7 @@
                             "type": "multiSelect",
                             "title": "Multiselect Column",
                             "deleted": false,
+                            "multi": true,
                             "width": 0,
                             "options": [
                                 {

--- a/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/OnChangeHandler.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Sample JSONs/others/OnChangeHandler.json
@@ -806,6 +806,7 @@
               "_id": "6857530158fb7edb102344fa",
               "type": "multiSelect",
               "title": "MultiSelect  D1",
+              "multi": true,
               "deleted": false,
               "width": 0,
               "options": [
@@ -1893,6 +1894,7 @@
               "_id": "6857530158fb7edb102344fa",
               "type": "multiSelect",
               "title": "MultiSelect  D1",
+              "multi": true,
               "deleted": false,
               "width": 0,
               "options": [

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -4032,4 +4032,235 @@ extension CollectionFieldSearchFilterTests {
         )
     }
     
+    // MARK: - MultiSelect `multi` flag coverage (Multiselect page)
+
+    func goToMultiSelectCollectionPage() {
+        let pageSelectionButton = app.buttons["PageNavigationIdentifier"]
+        XCTAssertTrue(pageSelectionButton.waitForExistence(timeout: 5), "Page navigation button should exist")
+        pageSelectionButton.tap()
+        let page = app.buttons["Multiselect"].firstMatch
+        XCTAssertTrue(page.waitForExistence(timeout: 5), "Multiselect page should be listed in the page selection sheet")
+        app.swipeUp()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        page.tap()
+    }
+
+    private func setCollectionMultiSelectCell(cellIndex: Int, optionIndex: Int, multi: Bool) {
+        let cell = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier").element(boundBy: cellIndex)
+        XCTAssertTrue(cell.waitForExistence(timeout: 5), "Cell \(cellIndex) should exist")
+        for _ in 0..<5 where !cell.isHittable {
+            app.swipeLeft()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        }
+        cell.tap()
+        let optionsId = multi ? "TableMultiSelectOptionsSheetIdentifier" : "TableSingleSelectOptionsSheetIdentifier"
+        let options = app.buttons.matching(identifier: optionsId)
+        XCTAssertTrue(options.element.waitForExistence(timeout: 3), "Options sheet should appear for cell \(cellIndex)")
+        options.element(boundBy: optionIndex).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+    }
+
+    private func filterCollectionMultiSelect(column: String, option: String) {
+        app.buttons["CollectionFilterButtonIdentifier"].tap()
+        let columnSelector = app.buttons.matching(identifier: "CollectionFilterColumnSelectorIdentifier").element(boundBy: 0)
+        XCTAssertTrue(columnSelector.waitForExistence(timeout: 3), "Column selector should exist")
+        columnSelector.tap()
+        let columnOption = app.buttons[column].firstMatch
+        XCTAssertTrue(columnOption.waitForExistence(timeout: 3), "\(column) should be listed in the filter column selector")
+        columnOption.tap()
+        let searchField = app.buttons["SearchBarMultiSelectionFieldIdentifier"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 3), "MultiSelect filter search bar should appear")
+        searchField.tap()
+        XCTAssertGreaterThan(app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier").count, 0, "Filter must render single-select options")
+        XCTAssertEqual(app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier").count, 0, "Filter must not render multi-select options")
+        let optionButton = app.buttons[option].firstMatch
+        XCTAssertTrue(optionButton.waitForExistence(timeout: 3), "\(option) should be selectable in the filter")
+        optionButton.tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        tapApplyButton()
+    }
+
+    func testCollectionMultiSelectColumnWithoutMultiPropertyIsSingleSelect() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 0).waitForExistence(timeout: 5), "Column 1 cell should exist")
+        cells.element(boundBy: 0).tap() // row 0 / column 1 (no `multi` key)
+
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options")
+        XCTAssertGreaterThan(singleOptions.count, 0)
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+
+        singleOptions.element(boundBy: 0).tap()
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 2", cells.element(boundBy: 0).label)
+    }
+
+    func testCollectionMultiSelectColumnWithMultiFalseIsSingleSelect() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 1).waitForExistence(timeout: 5), "Column 2 cell should exist")
+        cells.element(boundBy: 1).tap() // row 0 / column 2 (`multi: false`)
+
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options")
+        XCTAssertGreaterThan(singleOptions.count, 0)
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+
+        singleOptions.element(boundBy: 0).tap()
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 2", cells.element(boundBy: 1).label)
+    }
+
+    func testCollectionMultiSelectColumnWithMultiTrueIsMultiSelect() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 0).waitForExistence(timeout: 5), "Collection cells should exist")
+        let col3Cell = cells.element(boundBy: 2) // row 0 / column 3 (`multi: true`)
+        for _ in 0..<5 where !col3Cell.isHittable {
+            app.swipeLeft()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        }
+        XCTAssertTrue(col3Cell.isHittable, "Column 3 cell should be reachable")
+        col3Cell.tap()
+
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options")
+        XCTAssertGreaterThan(multiOptions.count, 0)
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 1, +1", col3Cell.label)
+    }
+
+    // Row edit form (single row) must honor each column's `multi` flag.
+    func testCollectionRowFormSimpleEditMultiSelectColumnsRespectMultiFlag() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        selectRow(number: 1)
+        tapOnMoreButton()
+        editRowsButton().tap()
+
+        let formFields = app.buttons.matching(identifier: "EditRowsMultiSelecionFieldIdentifier")
+        XCTAssertTrue(formFields.element(boundBy: 0).waitForExistence(timeout: 5), "Row form multiSelect fields should exist")
+
+        // Column 1 (no `multi`): single-select.
+        formFields.element(boundBy: 0).tap()
+        var singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        var multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options in row form")
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+        singleOptions.element(boundBy: 0).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        // Column 2 (`multi: false`): single-select.
+        formFields.element(boundBy: 1).tap()
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options in row form")
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        // Column 3 (`multi: true`): multi-select.
+        formFields.element(boundBy: 2).tap()
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options in row form")
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        dismissSheet()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertEqual("Option 1", cells.element(boundBy: 0).label, "No-`multi` column should store a single value")
+        XCTAssertEqual("Option 2", cells.element(boundBy: 1).label, "`multi: false` column should store a single value")
+        XCTAssertEqual("Option 1, +1", cells.element(boundBy: 2).label, "`multi: true` column should store multiple values")
+    }
+
+    // Bulk edit form (all rows) must honor each column's `multi` flag.
+    func testCollectionRowFormBulkEditMultiSelectColumnsRespectMultiFlag() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        selectAllParentRows()
+        tapOnMoreButton()
+        editRowsButton().tap()
+
+        let formFields = app.buttons.matching(identifier: "EditRowsMultiSelecionFieldIdentifier")
+        XCTAssertTrue(formFields.element(boundBy: 0).waitForExistence(timeout: 5), "Bulk-edit multiSelect fields should exist")
+
+        // Column 1 (no `multi`): single-select.
+        formFields.element(boundBy: 0).tap()
+        var singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        var multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options in bulk edit")
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+        singleOptions.element(boundBy: 0).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        // Column 2 (`multi: false`): single-select.
+        formFields.element(boundBy: 1).tap()
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options in bulk edit")
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        // Column 3 (`multi: true`): multi-select.
+        formFields.element(boundBy: 2).tap()
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options in bulk edit")
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        app.buttons["ApplyAllButtonIdentifier"].tap()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        for row in 0..<3 {
+            XCTAssertEqual("Option 1", cells.element(boundBy: row * 3).label, "Row \(row): no-`multi` column should store a single value")
+            XCTAssertEqual("Option 2", cells.element(boundBy: row * 3 + 1).label, "Row \(row): `multi: false` column should store a single value")
+            XCTAssertEqual("Option 1, +1", cells.element(boundBy: row * 3 + 2).label, "Row \(row): `multi: true` column should store multiple values")
+        }
+    }
+
+    // Filtering each multiSelect column narrows the collection to the matching row.
+    func testCollectionMultiSelectColumnsFilterAcrossAllThreeColumns() throws {
+        goToMultiSelectCollectionPage()
+        goToCollectionDetailField()
+
+        setCollectionMultiSelectCell(cellIndex: 0, optionIndex: 0, multi: false) // row0 / col1 = Option 1
+        setCollectionMultiSelectCell(cellIndex: 4, optionIndex: 1, multi: false) // row1 / col2 = Option 2
+        setCollectionMultiSelectCell(cellIndex: 8, optionIndex: 2, multi: true)  // row2 / col3 = Option 3
+
+        filterCollectionMultiSelect(column: "MultiSelect Column 1", option: "Option 1")
+        XCTAssertEqual(1, getVisibleRowCount(), "Filtering col1 by Option 1 should leave one row")
+
+        filterCollectionMultiSelect(column: "MultiSelect Column 2", option: "Option 2")
+        XCTAssertEqual(1, getVisibleRowCount(), "Filtering col2 by Option 2 should leave one row")
+
+        filterCollectionMultiSelect(column: "MultiSelect Column 3", option: "Option 3")
+        XCTAssertEqual(1, getVisibleRowCount(), "Filtering col3 by Option 3 should leave one row")
+    }
+
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Collection/CollectionFieldSearchFilterTests.swift
@@ -4098,6 +4098,11 @@ extension CollectionFieldSearchFilterTests {
         singleOptions.element(boundBy: 1).tap()
         app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
         XCTAssertEqual("Option 2", cells.element(boundBy: 0).label)
+
+        goBack()
+        waitForAppToSettle()
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a57a46a584427c53d6c447a"]?.multiSelector)
+        XCTAssertEqual(["6a57a46a965b00180bc81272"], selected, "Single-select must keep exactly one value")
     }
 
     func testCollectionMultiSelectColumnWithMultiFalseIsSingleSelect() throws {
@@ -4118,6 +4123,11 @@ extension CollectionFieldSearchFilterTests {
         singleOptions.element(boundBy: 1).tap()
         app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
         XCTAssertEqual("Option 2", cells.element(boundBy: 1).label)
+
+        goBack()
+        waitForAppToSettle()
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a57a46f09bc7681d8ae9dc0"]?.multiSelector)
+        XCTAssertEqual(["6a57a46f7dcb855f05f39ba5"], selected, "Single-select must keep exactly one value")
     }
 
     func testCollectionMultiSelectColumnWithMultiTrueIsMultiSelect() throws {
@@ -4144,6 +4154,13 @@ extension CollectionFieldSearchFilterTests {
         multiOptions.element(boundBy: 1).tap()
         app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
         XCTAssertEqual("Option 1, +1", col3Cell.label)
+
+        goBack()
+        waitForAppToSettle()
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a57a4709654b82a7aec819d"]?.multiSelector)
+        XCTAssertEqual(2, selected.count, "Multi-select should keep both selected values")
+        XCTAssertTrue(selected.contains("6a57a4700a91cf01e6655e5a"))
+        XCTAssertTrue(selected.contains("6a57a4707f44838f35197aa9"))
     }
 
     // Row edit form (single row) must honor each column's `multi` flag.
@@ -4192,6 +4209,18 @@ extension CollectionFieldSearchFilterTests {
         XCTAssertEqual("Option 1", cells.element(boundBy: 0).label, "No-`multi` column should store a single value")
         XCTAssertEqual("Option 2", cells.element(boundBy: 1).label, "`multi: false` column should store a single value")
         XCTAssertEqual("Option 1, +1", cells.element(boundBy: 2).label, "`multi: true` column should store multiple values")
+
+        goBack()
+        waitForAppToSettle()
+        let row0 = try XCTUnwrap(onChangeResultValue().valueElements?.first)
+        let col1 = try XCTUnwrap(row0.cells?["6a57a46a584427c53d6c447a"]?.multiSelector)
+        XCTAssertEqual(["6a57a46ac5ffc39bdda33d80"], col1, "No-`multi` column should store a single value")
+        let col2 = try XCTUnwrap(row0.cells?["6a57a46f09bc7681d8ae9dc0"]?.multiSelector)
+        XCTAssertEqual(["6a57a46f7dcb855f05f39ba5"], col2, "`multi: false` column should store a single value")
+        let col3 = try XCTUnwrap(row0.cells?["6a57a4709654b82a7aec819d"]?.multiSelector)
+        XCTAssertEqual(2, col3.count, "`multi: true` column should store multiple values")
+        XCTAssertTrue(col3.contains("6a57a4700a91cf01e6655e5a"))
+        XCTAssertTrue(col3.contains("6a57a4707f44838f35197aa9"))
     }
 
     // Bulk edit form (all rows) must honor each column's `multi` flag.
@@ -4241,6 +4270,21 @@ extension CollectionFieldSearchFilterTests {
             XCTAssertEqual("Option 1", cells.element(boundBy: row * 3).label, "Row \(row): no-`multi` column should store a single value")
             XCTAssertEqual("Option 2", cells.element(boundBy: row * 3 + 1).label, "Row \(row): `multi: false` column should store a single value")
             XCTAssertEqual("Option 1, +1", cells.element(boundBy: row * 3 + 2).label, "Row \(row): `multi: true` column should store multiple values")
+        }
+
+        goBack()
+        waitForAppToSettle()
+        let rows = try XCTUnwrap(onChangeResultValue().valueElements)
+        XCTAssertEqual(3, rows.count, "All three rows should be present")
+        for (i, row) in rows.enumerated() {
+            let col1 = try XCTUnwrap(row.cells?["6a57a46a584427c53d6c447a"]?.multiSelector, "Row \(i) col1 missing")
+            XCTAssertEqual(["6a57a46ac5ffc39bdda33d80"], col1, "Row \(i): no-`multi` column should store a single value")
+            let col2 = try XCTUnwrap(row.cells?["6a57a46f09bc7681d8ae9dc0"]?.multiSelector, "Row \(i) col2 missing")
+            XCTAssertEqual(["6a57a46f7dcb855f05f39ba5"], col2, "Row \(i): `multi: false` column should store a single value")
+            let col3 = try XCTUnwrap(row.cells?["6a57a4709654b82a7aec819d"]?.multiSelector, "Row \(i) col3 missing")
+            XCTAssertEqual(2, col3.count, "Row \(i): `multi: true` column should store multiple values")
+            XCTAssertTrue(col3.contains("6a57a4700a91cf01e6655e5a"))
+            XCTAssertTrue(col3.contains("6a57a4707f44838f35197aa9"))
         }
     }
 

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
@@ -848,6 +848,119 @@
         "68e6704db5c2921b790869f1",
         "68e6704de976d53aee73a22f"
       ]
+    },
+    {
+      "file": "66a14ced9dc829a95e272506",
+      "_id": "6a5784c61e23a7ba7f5034f1",
+      "type": "table",
+      "title": "Table",
+      "tableColumns": [
+        {
+          "_id": "6a5784d1d621c682be90f314",
+          "type": "multiSelect",
+          "title": "MultiSelect Column 1",
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "6a5784d15b872c819bcaf1f0",
+              "value": "Option 1",
+              "deleted": false
+            },
+            {
+              "_id": "6a5784d17595d72edb41de4b",
+              "value": "Option 2",
+              "deleted": false
+            },
+            {
+              "_id": "6a5784d12d48637e36fdbc90",
+              "value": "Option 3",
+              "deleted": false
+            }
+          ],
+          "identifier": "6a5784c61e23a7ba7f5034f1_column_6a5784d1d621c682be90f314"
+        },
+        {
+          "_id": "6a5790cdf7cfd2863234b9f7",
+          "type": "multiSelect",
+          "title": "MultiSelect Column 2",
+          "multi": false,
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "6a5790cda74054a008b09484",
+              "value": "Option 1",
+              "deleted": false
+            },
+            {
+              "_id": "6a5790cd316f2243bfcbf84e",
+              "value": "Option 2",
+              "deleted": false
+            },
+            {
+              "_id": "6a5790cd6ad7b459750a8daf",
+              "value": "Option 3",
+              "deleted": false
+            }
+          ],
+          "identifier": "6a5784c61e23a7ba7f5034f1_column_6a5790cdf7cfd2863234b9f7"
+        },
+        {
+          "_id": "6a5790d077dfd7c217781f1f",
+          "type": "multiSelect",
+          "title": "MultiSelect Column 3",
+          "multi": true,
+          "deleted": false,
+          "width": 0,
+          "options": [
+            {
+              "_id": "6a5790d07101d73ce15483b7",
+              "value": "Option 1",
+              "deleted": false
+            },
+            {
+              "_id": "6a5790d0152220240f5f6b59",
+              "value": "Option 2",
+              "deleted": false
+            },
+            {
+              "_id": "6a5790d017c763eea28a6094",
+              "value": "Option 3",
+              "deleted": false
+            }
+          ],
+          "identifier": "6a5784c61e23a7ba7f5034f1_column_6a5790d077dfd7c217781f1f"
+        }
+      ],
+      "value": [
+        {
+          "_id": "6a549f7fc304c47d93f0d15c",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "6a549f7fff2d0bb751476a67",
+          "deleted": false,
+          "cells": {}
+        },
+        {
+          "_id": "6a549f7f10c72e6a9d7afe52",
+          "deleted": false,
+          "cells": {}
+        }
+      ],
+      "identifier": "field_6a5784c61e23a7ba7f5034f1",
+      "tableColumnOrder": [
+        "6a5784d1d621c682be90f314",
+        "6a5790cdf7cfd2863234b9f7",
+        "6a5790d077dfd7c217781f1f"
+      ],
+      "rowOrder": [
+        "6a549f7fc304c47d93f0d15c",
+        "6a549f7fff2d0bb751476a67",
+        "6a549f7f10c72e6a9d7afe52"
+      ]
     }
   ],
   "_id": "66a14cedd6e1ebcdf176a8da",
@@ -867,7 +980,8 @@
         "66a14ced15a9dc96374e091e",
         "68d7ba78321dcd7856b3735e",
         "68f1fe14279a2aab1a64e24d",
-        "68f88270495d5cc6d27273ca"
+        "68f88270495d5cc6d27273ca",
+        "6a5784894c25c8f29b905c04"
       ],
       "pages": [
         {
@@ -918,7 +1032,12 @@
           "_id": "66a14ced15a9dc96374e091e",
           "width": 816,
           "name": "Every Field Type",
-          "margin": 0
+          "margin": 0,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         },
         {
           "height": 1056,
@@ -956,7 +1075,12 @@
           "_id": "68d7ba78321dcd7856b3735e",
           "width": 816,
           "name": "Every Field Type",
-          "margin": 0
+          "margin": 0,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         },
         {
           "_id": "68f1fe14279a2aab1a64e24d",
@@ -1006,7 +1130,12 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
         },
         {
           "_id": "68f88270495d5cc6d27273ca",
@@ -1030,7 +1159,39 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values",
+            "without-values"
+          ]
+        },
+        {
+          "_id": "6a5784894c25c8f29b905c04",
+          "name": "MultiSelect",
+          "width": 816,
+          "height": 1056,
+          "rowHeight": 8,
+          "cols": 8,
+          "fieldPositions": [
+            {
+              "_id": "6a5784c64539a5a36d55b182",
+              "type": "table",
+              "displayType": "original",
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 15,
+              "field": "6a5784c61e23a7ba7f5034f1"
+            }
+          ],
+          "layout": "grid",
+          "presentation": "normal",
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values"
+          ]
         }
       ]
     }

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
@@ -1032,12 +1032,7 @@
           "_id": "66a14ced15a9dc96374e091e",
           "width": 816,
           "name": "Every Field Type",
-          "margin": 0,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "margin": 0
         },
         {
           "height": 1056,
@@ -1075,12 +1070,7 @@
           "_id": "68d7ba78321dcd7856b3735e",
           "width": 816,
           "name": "Every Field Type",
-          "margin": 0,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "margin": 0
         },
         {
           "_id": "68f1fe14279a2aab1a64e24d",
@@ -1130,12 +1120,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "padding": 24
         },
         {
           "_id": "68f88270495d5cc6d27273ca",
@@ -1159,12 +1144,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values",
-            "without-values"
-          ]
+          "padding": 24
         },
         {
           "_id": "6a5784894c25c8f29b905c04",
@@ -1187,11 +1167,7 @@
           ],
           "layout": "grid",
           "presentation": "normal",
-          "padding": 24,
-          "deletable": true,
-          "copyable": [
-            "with-values"
-          ]
+          "padding": 24
         }
       ]
     }

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldTestData.json
@@ -624,6 +624,7 @@
           "_id": "68f1fe33dd2af79db317960c",
           "type": "multiSelect",
           "title": "Multiselect Column",
+          "multi": true,
           "width": 0,
           "options": [
             {

--- a/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldUITestCases.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/TableField/TableFieldUITestCases.swift
@@ -18,6 +18,24 @@ final class TableFieldUITestCases: JoyfillUITestsBaseClass {
     func goToTableDetailPage() {
         app.buttons["TableDetailViewIdentifier"].firstMatch.tap()
     }
+
+    func goToMultiSelectPage() {
+        let pageSelectionButton = app.buttons["PageNavigationIdentifier"]
+        XCTAssertTrue(pageSelectionButton.waitForExistence(timeout: 5), "Page navigation button should exist")
+        pageSelectionButton.tap()
+
+        let multiSelectPage = app.buttons.matching(
+            NSPredicate(format: "identifier == %@ AND label CONTAINS[c] %@", "PageSelectionIdentifier", "MultiSelect")
+        ).firstMatch
+        if !multiSelectPage.waitForExistence(timeout: 3) {
+            for _ in 0..<4 where !multiSelectPage.exists {
+                app.swipeUp()
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+            }
+        }
+        XCTAssertTrue(multiSelectPage.exists, "MultiSelect page should be listed in the page selection sheet")
+        multiSelectPage.tap()
+    }
     
     func tapOnMoreButton() {
         let selectallbuttonImage = XCUIApplication().images["SelectAllRowSelectorButton"]
@@ -856,6 +874,244 @@ final class TableFieldUITestCases: JoyfillUITestsBaseClass {
         multiSelectField.tap()
         goBack()
         assertTableCellFocusBlurEvents(columnId: "6875f780cf958bc05e29aa23")
+    }
+
+    func testMultiSelectColumnWithoutMultiPropertyIsSingleSelect() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 0).waitForExistence(timeout: 5), "Column 1 cell should exist")
+        cells.element(boundBy: 0).tap() // row 0 / column 1 (no `multi` key)
+
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options")
+        XCTAssertGreaterThan(singleOptions.count, 0)
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+
+        singleOptions.element(boundBy: 0).tap()
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 2", cells.element(boundBy: 0).label)
+
+        goBack()
+        Thread.sleep(forTimeInterval: 0.5)
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a5784d1d621c682be90f314"]?.multiSelector)
+        XCTAssertEqual(["6a5784d17595d72edb41de4b"], selected, "Single-select must keep exactly one value")
+    }
+
+    func testMultiSelectColumnWithMultiFalseIsSingleSelect() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 1).waitForExistence(timeout: 5), "Column 2 cell should exist")
+        cells.element(boundBy: 1).tap() // row 0 / column 2 (`multi: false`)
+
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options")
+        XCTAssertGreaterThan(singleOptions.count, 0)
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+
+        singleOptions.element(boundBy: 0).tap()
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 2", cells.element(boundBy: 1).label)
+
+        goBack()
+        Thread.sleep(forTimeInterval: 0.5)
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a5790cdf7cfd2863234b9f7"]?.multiSelector)
+        XCTAssertEqual(["6a5790cd316f2243bfcbf84e"], selected, "Single-select must keep exactly one value")
+    }
+
+    func testMultiSelectColumnWithMultiTrueIsMultiSelect() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        let cells = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier")
+        XCTAssertTrue(cells.element(boundBy: 0).waitForExistence(timeout: 5), "Table cells should exist")
+        let col3Cell = cells.element(boundBy: 2) // row 0 / column 3 (`multi: true`)
+        for _ in 0..<5 where !col3Cell.isHittable {
+            app.swipeLeft()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        }
+        XCTAssertTrue(col3Cell.isHittable, "Column 3 cell should be reachable")
+        col3Cell.tap()
+
+        let multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        let singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options")
+        XCTAssertGreaterThan(multiOptions.count, 0)
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+
+        // Checkbox behavior: multiple selections coexist.
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+        XCTAssertEqual("Option 1, +1", col3Cell.label)
+
+        goBack()
+        Thread.sleep(forTimeInterval: 0.5)
+        let selected = try XCTUnwrap(onChangeResultValue().valueElements?.first?.cells?["6a5790d077dfd7c217781f1f"]?.multiSelector)
+        XCTAssertEqual(2, selected.count, "Multi-select should keep both selected values")
+        XCTAssertTrue(selected.contains("6a5790d07101d73ce15483b7"))
+        XCTAssertTrue(selected.contains("6a5790d0152220240f5f6b59"))
+    }
+
+    func testRowFormSimpleEditMultiSelectColumnsRespectMultiFlag() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        app.images["SingleClickEditButton0"].tap()
+
+        let formFields = app.buttons.matching(identifier: "EditRowsMultiSelecionFieldIdentifier")
+        XCTAssertTrue(formFields.element(boundBy: 0).waitForExistence(timeout: 5), "Row form multiSelect fields should exist")
+
+        formFields.element(boundBy: 0).tap()
+        var singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        var multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options in row form")
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+        singleOptions.element(boundBy: 0).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        formFields.element(boundBy: 1).tap()
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options in row form")
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        formFields.element(boundBy: 2).tap()
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options in row form")
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        app.buttons["DismissEditSingleRowSheetButtonIdentifier"].tap()
+        goBack()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let row0 = try XCTUnwrap(onChangeResultValue().valueElements?.first)
+        let col1 = try XCTUnwrap(row0.cells?["6a5784d1d621c682be90f314"]?.multiSelector)
+        XCTAssertEqual(["6a5784d15b872c819bcaf1f0"], col1, "No-`multi` column must store a single value")
+        let col2 = try XCTUnwrap(row0.cells?["6a5790cdf7cfd2863234b9f7"]?.multiSelector)
+        XCTAssertEqual(["6a5790cd316f2243bfcbf84e"], col2, "`multi: false` column must store a single value")
+        let col3 = try XCTUnwrap(row0.cells?["6a5790d077dfd7c217781f1f"]?.multiSelector)
+        XCTAssertEqual(2, col3.count, "`multi: true` column must store multiple values")
+    }
+
+    func testRowFormBulkEditMultiSelectColumnsRespectMultiFlag() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        tapOnMoreButton() // select all rows + open More menu
+        app.buttons["TableEditRowsIdentifier"].tap()
+
+        let formFields = app.buttons.matching(identifier: "EditRowsMultiSelecionFieldIdentifier")
+        XCTAssertTrue(formFields.element(boundBy: 0).waitForExistence(timeout: 5), "Bulk-edit multiSelect fields should exist")
+
+        formFields.element(boundBy: 0).tap()
+        var singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        var multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "Column without `multi` should render single-select options in bulk edit")
+        XCTAssertEqual(multiOptions.count, 0, "Column without `multi` must not render multi-select options")
+        singleOptions.element(boundBy: 0).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        formFields.element(boundBy: 1).tap()
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        XCTAssertTrue(singleOptions.element.waitForExistence(timeout: 3), "`multi: false` should render single-select options in bulk edit")
+        XCTAssertEqual(multiOptions.count, 0, "`multi: false` must not render multi-select options")
+        singleOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        formFields.element(boundBy: 2).tap()
+        multiOptions = app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier")
+        singleOptions = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(multiOptions.element.waitForExistence(timeout: 3), "`multi: true` should render multi-select options in bulk edit")
+        XCTAssertEqual(singleOptions.count, 0, "`multi: true` must not render single-select options")
+        multiOptions.element(boundBy: 0).tap()
+        multiOptions.element(boundBy: 1).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+
+        app.buttons["ApplyAllButtonIdentifier"].tap()
+        goBack()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let rows = try XCTUnwrap(onChangeResultValue().valueElements)
+        XCTAssertEqual(3, rows.count, "All three rows should be present")
+        for (i, row) in rows.enumerated() {
+            let col1 = try XCTUnwrap(row.cells?["6a5784d1d621c682be90f314"]?.multiSelector, "Row \(i) col1 missing")
+            XCTAssertEqual(["6a5784d15b872c819bcaf1f0"], col1, "Row \(i): no-`multi` column must store a single value")
+            let col2 = try XCTUnwrap(row.cells?["6a5790cdf7cfd2863234b9f7"]?.multiSelector, "Row \(i) col2 missing")
+            XCTAssertEqual(["6a5790cd316f2243bfcbf84e"], col2, "Row \(i): `multi: false` column must store a single value")
+            let col3 = try XCTUnwrap(row.cells?["6a5790d077dfd7c217781f1f"]?.multiSelector, "Row \(i) col3 missing")
+            XCTAssertEqual(2, col3.count, "Row \(i): `multi: true` column must store multiple values")
+        }
+    }
+
+
+    private func setMultiSelectCell(cellIndex: Int, optionIndex: Int, multi: Bool) {
+        let cell = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier").element(boundBy: cellIndex)
+        XCTAssertTrue(cell.waitForExistence(timeout: 5), "Cell \(cellIndex) should exist")
+        for _ in 0..<5 where !cell.isHittable {
+            app.swipeLeft()
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.4))
+        }
+        cell.tap()
+        let optionsId = multi ? "TableMultiSelectOptionsSheetIdentifier" : "TableSingleSelectOptionsSheetIdentifier"
+        let options = app.buttons.matching(identifier: optionsId)
+        XCTAssertTrue(options.element.waitForExistence(timeout: 3), "Options sheet should appear for cell \(cellIndex)")
+        options.element(boundBy: optionIndex).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+    }
+
+    private func filterMultiSelectColumn(titled title: String, optionIndex: Int) {
+        app.images.matching(identifier: "\(title)/ColumnButtonIdentifier").element(boundBy: 0).tap()
+        let searchField = app.buttons.matching(identifier: "SearchBarMultiSelectionFieldIdentifier").firstMatch
+        XCTAssertTrue(searchField.waitForExistence(timeout: 3), "Filter search bar for \(title) should appear")
+        searchField.tap()
+        let options = app.buttons.matching(identifier: "TableSingleSelectOptionsSheetIdentifier")
+        XCTAssertTrue(options.element.waitForExistence(timeout: 3), "Filter option sheet should render single-select options")
+        XCTAssertEqual(app.buttons.matching(identifier: "TableMultiSelectOptionsSheetIdentifier").count, 0, "Filter must not render multi-select options")
+        options.element(boundBy: optionIndex).tap()
+        app.buttons["TableMultiSelectionFieldApplyIdentifier"].tap()
+    }
+
+    private func assertSingleFilteredRow(columnCellIndex: Int, expectedLabel: String) {
+        XCTAssertTrue(app.images["SingleClickEditButton0"].waitForExistence(timeout: 3), "Exactly one filtered row expected")
+        XCTAssertFalse(app.images["SingleClickEditButton1"].exists, "Filter should leave exactly one row")
+        let cell = app.buttons.matching(identifier: "TableMultiSelectionFieldIdentifier").element(boundBy: columnCellIndex)
+        XCTAssertEqual(expectedLabel, cell.label)
+    }
+
+    func testMultiSelectColumnsFilterAcrossAllThreeColumns() throws {
+        goToMultiSelectPage()
+        goToTableDetailPage()
+
+        setMultiSelectCell(cellIndex: 0, optionIndex: 0, multi: false) // row0 / col1 = Option 1
+        setMultiSelectCell(cellIndex: 4, optionIndex: 1, multi: false) // row1 / col2 = Option 2
+        setMultiSelectCell(cellIndex: 8, optionIndex: 2, multi: true)  // row2 / col3 = Option 3
+
+        filterMultiSelectColumn(titled: "MultiSelect Column 1", optionIndex: 0)
+        assertSingleFilteredRow(columnCellIndex: 0, expectedLabel: "Option 1")
+        app.buttons["HideFilterSearchBar"].tap()
+
+        filterMultiSelectColumn(titled: "MultiSelect Column 2", optionIndex: 1)
+        assertSingleFilteredRow(columnCellIndex: 1, expectedLabel: "Option 2")
+        app.buttons["HideFilterSearchBar"].tap()
+
+        filterMultiSelectColumn(titled: "MultiSelect Column 3", optionIndex: 2)
+        assertSingleFilteredRow(columnCellIndex: 2, expectedLabel: "Option 3")
+        app.buttons["HideFilterSearchBar"].tap()
     }
 
     func testTableImageOnFocusOnBlur() throws {

--- a/Sources/JoyfillUI/View/Fields/TableView/TableMultiSelectView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableMultiSelectView.swift
@@ -19,7 +19,7 @@ struct TableMultiSelectView: View {
     private var isSearching: Bool
 
     private var isMulti: Bool {
-        cellModel.data.multi ?? true
+        cellModel.data.multi ?? false
     }
 
     private var selectedValues: [String] {
@@ -41,7 +41,7 @@ struct TableMultiSelectView: View {
         
         if !isUsedForBulkEdit {
             let values = cellModel.wrappedValue.data.multiSelectValues ?? []
-            if cellModel.wrappedValue.data.multi ?? true {
+            if cellModel.wrappedValue.data.multi ?? false {
                 _multiSelectedOptionArray = State(initialValue: values)
             } else {
                 _singleSelectedOptionArray = State(initialValue: values)
@@ -108,7 +108,7 @@ struct TableMultiSelectView: View {
         .onAppear {
             guard !isUsedForBulkEdit else { return }
             let values = cellModel.data.multiSelectValues ?? []
-            if cellModel.data.multi ?? true {
+            if cellModel.data.multi ?? false {
                 multiSelectedOptionArray = values
             } else {
                 singleSelectedOptionArray = values


### PR DESCRIPTION
## Context
MultiSelect columns in table/collection fields were defaulting to multi-select when a column's `multi` flag was absent. Spec is that a column should only allow multiple selections when it explicitly opts in via `multi: true`; otherwise it behaves as single-select.

## What changed
- `Sources/JoyfillUI/View/Fields/TableView/TableMultiSelectView.swift` — flipped the default from `multi ?? true` to `multi ?? false` at all three sites (`isMulti` computed prop, `init`, `onAppear`). `TableMultiSelectView` is shared by table cells, collection cells, row edit forms, and the filter search bar, so this one change covers every context.
- Test fixtures: added a "MultiSelect" page to `TableFieldTestData.json` and a "Multiselect" page to `CollectionFilter.json`, each with three columns — no `multi` key, `multi: false`, and `multi: true`.
- Tests: 6 table + 6 collection UI tests covering cell-level, row-form (simple + bulk edit), and filter behavior.

## Decisions
- Fixed the single shared view rather than each call site — all four contexts read the same flag, so one change keeps them consistent.
- The filter search bar stays single-select regardless of the column's `multi` flag (unchanged, `isSearching: true`); tests assert this explicitly.
- Collection page-navigation helper scrolls the target page off the sheet's bottom edge before tapping — on iPad the last row sits against the sheet edge and a direct tap lands one row early.

## Screenshot / video
N/A — behavior is exercised by the UI tests below (single-select renders radio options, multi renders checkboxes).

## Public API
No public API change. No docs update required.

## Tests
Covered now. 12 UI tests total (6 table, 6 collection), all passing on iPad Pro 13-inch (M5):
- no-`multi` column → single-select
- `multi: false` → single-select
- `multi: true` → multi-select
- row form simple + bulk edit honor each column's flag
- filtering each of the three columns narrows to the matching row

## Reviewer notes
The behavioral change is the 3-line default flip in `TableMultiSelectView.swift`; the rest of the diff is JSON test fixtures and UI tests. Worth confirming `multi ?? false` is the intended default for existing documents in the wild that omit the `multi` key — those columns will now render as single-select rather than multi.