### PR TITLE
NO-2256: Conditional required-ness via requiredLogic & cellRequiredLogic

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		E24089F52F7C28ED005C4885 /* SampleFormFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24089F42F7C28ED005C4885 /* SampleFormFooter.swift */; };
 		E2408A022F7CF023005C4885 /* NavigationGotoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2408A012F7CF023005C4885 /* NavigationGotoUITests.swift */; };
 		E2459A7D2F442B4B000504A3 /* ColumnConditionalLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */; };
+		DEC0F40000000000000040F0 /* RequiredLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F40000000000000040F1 /* RequiredLogicTests.swift */; };
 		E254BF802D410F990083C3E4 /* ConditionLogicUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */; };
 		E26315E42F76AEA70008B89B /* ValidatePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26315E32F76AEA70008B89B /* ValidatePathTests.swift */; };
 		E26A54642DFADD04006E05E9 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = E26A54632DFADD04006E05E9 /* JoyfillModel */; };
@@ -907,6 +908,7 @@
 		E24089F42F7C28ED005C4885 /* SampleFormFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleFormFooter.swift; sourceTree = "<group>"; };
 		E2408A012F7CF023005C4885 /* NavigationGotoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGotoUITests.swift; sourceTree = "<group>"; };
 		E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnConditionalLogicTests.swift; sourceTree = "<group>"; };
+		DEC0F40000000000000040F1 /* RequiredLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredLogicTests.swift; sourceTree = "<group>"; };
 		E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionLogicUnitTests.swift; sourceTree = "<group>"; };
 		E26315E32F76AEA70008B89B /* ValidatePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePathTests.swift; sourceTree = "<group>"; };
 		E27061C72E797E56006BAD18 /* TableViewModelDocumentEditorDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewModelDocumentEditorDelegateTests.swift; sourceTree = "<group>"; };
@@ -1262,6 +1264,7 @@
 				E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */,
 				E2C8BD262E4628A900B93B9E /* MobileTitleDisplayTests.swift */,
 				E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */,
+				DEC0F40000000000000040F1 /* RequiredLogicTests.swift */,
 				E27061C62E797E12006BAD18 /* OnChangeHandler */,
 				134FC0792BDA82E9008B7030 /* JoyfillTests.swift */,
 				DEC0F22000000000000000F2 /* DocumentEditorFieldLookupTests.swift */,
@@ -2881,6 +2884,7 @@
 				95288F4F2FECEB73000A2CC1 /* FormulaTemplate_NowFunctionTests.swift in Sources */,
 				DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */,
 				E2459A7D2F442B4B000504A3 /* ColumnConditionalLogicTests.swift in Sources */,
+				DEC0F40000000000000040F0 /* RequiredLogicTests.swift in Sources */,
 				3682A4CC2E158D21005B73C3 /* FormulaTemplate_Write_ChartField.swift in Sources */,
 				362746762E26E266005B0FA7 /* FormulaTemplate_DateFieldTests.swift in Sources */,
 				E2B8E3E92E43803300AC6018 /* FormulaTemplate_TextFieldTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -209,8 +209,8 @@
 		95C0BE9D3006200400D207B9 /* LandScapeMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C0BE9A3006200400D207B9 /* LandScapeMode.swift */; };
 		95C0BEA03006200400D207B9 /* LandscapeMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BE993006200400D207B9 /* LandscapeMode.json */; };
 		95C0BEE9300A443500D207B9 /* RequiredLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BEE8300A442500D207B9 /* RequiredLogic.json */; };
-		95C0BEEC300A443500D207B9 /* RequiredLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BEE8300A442500D207B9 /* RequiredLogic.json */; };
 		95C0BEEB300A445300D207B9 /* RequiredLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C0BEEA300A444900D207B9 /* RequiredLogic.swift */; };
+		95C0BEEC300A443500D207B9 /* RequiredLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BEE8300A442500D207B9 /* RequiredLogic.json */; };
 		9EAAC7C02E979A20000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
 		9EAAC7C12E979A20000B6F3C /* TimeZoneUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */; };
 		9EAAC7C22E979BC8000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
@@ -1277,11 +1277,11 @@
 				DEC000A000000000000000A0 /* DecoratorAPI */,
 				E2B8E3BC2E4361DF00AC6018 /* Formula */,
 				0448AE082D0C45AD00754EA0 /* ValidationTestCase.swift */,
-				E26315E32F76AEA70008B89B /* ValidatePathTests.swift */,
 				36F4DB772E6F394500C9AD4A /* LicenseValidatorTests.swift */,
 				1307CF132BE1292900B19FBA /* JoyDoc+Assert.swift */,
 				E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */,
 				E225D1C42F3AE626000674CF /* HiddenViewsTests.swift */,
+				E26315E32F76AEA70008B89B /* ValidatePathTests.swift */,
 			);
 			path = JoyfillTests;
 			sourceTree = "<group>";

--- a/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
+++ b/JoyfillSwiftUIExample/JoyfillExample.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		1324937A2BA570F9002C6ADC /* Joyfill in Frameworks */ = {isa = PBXBuildFile; productRef = 132493792BA570F9002C6ADC /* Joyfill */; };
 		1324937D2BAD5A42002C6ADC /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = 1324937C2BAD5A42002C6ADC /* JoyfillModel */; };
 		134FC07A2BDA82E9008B7030 /* JoyfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134FC0792BDA82E9008B7030 /* JoyfillTests.swift */; };
-		DEC0F22000000000000000F3 /* DocumentEditorFieldLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F22000000000000000F2 /* DocumentEditorFieldLookupTests.swift */; };
-		DEC0F11000000000000000F2 /* DocumentEditorConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */; };
 		136D3DBF2C103BD8008B1CA3 /* PageNavigationFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136D3DBE2C103BD8008B1CA3 /* PageNavigationFieldTest.swift */; };
 		13A3F8EA2C34171A00B0A255 /* ConditionalLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3F8E92C34171A00B0A255 /* ConditionalLogicTests.swift */; };
 		13A3F8EC2C356DB800B0A255 /* ConditinalPageLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A3F8EB2C356DB800B0A255 /* ConditinalPageLogicTests.swift */; };
@@ -208,8 +206,11 @@
 		95288F4E2FECEB73000A2CC1 /* FormulaTemplate_RoundFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95288F252FECEB73000A2CC1 /* FormulaTemplate_RoundFunctionTests.swift */; };
 		95288F4F2FECEB73000A2CC1 /* FormulaTemplate_NowFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95288F212FECEB73000A2CC1 /* FormulaTemplate_NowFunctionTests.swift */; };
 		95C0BE9C3006200400D207B9 /* LandscapeMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BE993006200400D207B9 /* LandscapeMode.json */; };
-		95C0BEA03006200400D207B9 /* LandscapeMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BE993006200400D207B9 /* LandscapeMode.json */; };
 		95C0BE9D3006200400D207B9 /* LandScapeMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C0BE9A3006200400D207B9 /* LandScapeMode.swift */; };
+		95C0BEA03006200400D207B9 /* LandscapeMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BE993006200400D207B9 /* LandscapeMode.json */; };
+		95C0BEE9300A443500D207B9 /* RequiredLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BEE8300A442500D207B9 /* RequiredLogic.json */; };
+		95C0BEEC300A443500D207B9 /* RequiredLogic.json in Resources */ = {isa = PBXBuildFile; fileRef = 95C0BEE8300A442500D207B9 /* RequiredLogic.json */; };
+		95C0BEEB300A445300D207B9 /* RequiredLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C0BEEA300A444900D207B9 /* RequiredLogic.swift */; };
 		9EAAC7C02E979A20000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
 		9EAAC7C12E979A20000B6F3C /* TimeZoneUITestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */; };
 		9EAAC7C22E979BC8000B6F3C /* TimeZoneTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */; };
@@ -232,6 +233,8 @@
 		DEC000B400000000000000A4 /* DecoratorErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */; };
 		DEC000B500000000000000A5 /* DecoratorLiveUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */; };
 		DEC0F11000000000000000F2 /* DocumentEditorConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */; };
+		DEC0F22000000000000000F3 /* DocumentEditorFieldLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F22000000000000000F2 /* DocumentEditorFieldLookupTests.swift */; };
+		DEC0F40000000000000040F0 /* RequiredLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F40000000000000040F1 /* RequiredLogicTests.swift */; };
 		E20E53022F876E500088A4E4 /* DecoratorAPIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */; };
 		E2173C2F2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */; };
 		E22516882E8BA4C60089E2D2 /* UserJsonTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */; };
@@ -240,7 +243,6 @@
 		E24089F52F7C28ED005C4885 /* SampleFormFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24089F42F7C28ED005C4885 /* SampleFormFooter.swift */; };
 		E2408A022F7CF023005C4885 /* NavigationGotoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2408A012F7CF023005C4885 /* NavigationGotoUITests.swift */; };
 		E2459A7D2F442B4B000504A3 /* ColumnConditionalLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */; };
-		DEC0F40000000000000040F0 /* RequiredLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0F40000000000000040F1 /* RequiredLogicTests.swift */; };
 		E254BF802D410F990083C3E4 /* ConditionLogicUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */; };
 		E26315E42F76AEA70008B89B /* ValidatePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26315E32F76AEA70008B89B /* ValidatePathTests.swift */; };
 		E26A54642DFADD04006E05E9 /* JoyfillModel in Frameworks */ = {isa = PBXBuildFile; productRef = E26A54632DFADD04006E05E9 /* JoyfillModel */; };
@@ -785,8 +787,6 @@
 		1307CF1D2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		134FC0772BDA82E9008B7030 /* JoyfillTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JoyfillTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		134FC0792BDA82E9008B7030 /* JoyfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoyfillTests.swift; sourceTree = "<group>"; };
-		DEC0F22000000000000000F2 /* DocumentEditorFieldLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorFieldLookupTests.swift; sourceTree = "<group>"; };
-		DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorConfigTests.swift; sourceTree = "<group>"; };
 		136D3DBE2C103BD8008B1CA3 /* PageNavigationFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigationFieldTest.swift; sourceTree = "<group>"; };
 		13A3F8E92C34171A00B0A255 /* ConditionalLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalLogicTests.swift; sourceTree = "<group>"; };
 		13A3F8EB2C356DB800B0A255 /* ConditinalPageLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditinalPageLogicTests.swift; sourceTree = "<group>"; };
@@ -884,6 +884,8 @@
 		95288F2B2FECEB73000A2CC1 /* FormulaTemplate_YearFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTemplate_YearFunctionTests.swift; sourceTree = "<group>"; };
 		95C0BE993006200400D207B9 /* LandscapeMode.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LandscapeMode.json; sourceTree = "<group>"; };
 		95C0BE9A3006200400D207B9 /* LandScapeMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandScapeMode.swift; sourceTree = "<group>"; };
+		95C0BEE8300A442500D207B9 /* RequiredLogic.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = RequiredLogic.json; sourceTree = "<group>"; };
+		95C0BEEA300A444900D207B9 /* RequiredLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredLogic.swift; sourceTree = "<group>"; };
 		9EAAC7BD2E979A20000B6F3C /* TimeZoneTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TimeZoneTestData.json; sourceTree = "<group>"; };
 		9EAAC7BE2E979A20000B6F3C /* TimeZoneUITestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneUITestCases.swift; sourceTree = "<group>"; };
 		9EAAC7DD2EAB3EF4000B6F3C /* PageNavigationTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PageNavigationTest.json; sourceTree = "<group>"; };
@@ -900,6 +902,8 @@
 		DEC000F400000000000000A4 /* DecoratorErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorErrorHandlingTests.swift; sourceTree = "<group>"; };
 		DEC000F500000000000000A5 /* DecoratorLiveUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorLiveUpdateTests.swift; sourceTree = "<group>"; };
 		DEC0F11000000000000000F1 /* DocumentEditorConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorConfigTests.swift; sourceTree = "<group>"; };
+		DEC0F22000000000000000F2 /* DocumentEditorFieldLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentEditorFieldLookupTests.swift; sourceTree = "<group>"; };
+		DEC0F40000000000000040F1 /* RequiredLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredLogicTests.swift; sourceTree = "<group>"; };
 		E20E53002F876E500088A4E4 /* DecoratorAPIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratorAPIDemoView.swift; sourceTree = "<group>"; };
 		E2173C2E2F6937AF000A2A63 /* PageDeletableCopyableValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDeletableCopyableValidationTests.swift; sourceTree = "<group>"; };
 		E22516872E8BA4C60089E2D2 /* UserJsonTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJsonTextFieldView.swift; sourceTree = "<group>"; };
@@ -908,7 +912,6 @@
 		E24089F42F7C28ED005C4885 /* SampleFormFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleFormFooter.swift; sourceTree = "<group>"; };
 		E2408A012F7CF023005C4885 /* NavigationGotoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGotoUITests.swift; sourceTree = "<group>"; };
 		E2459A7C2F442B4B000504A3 /* ColumnConditionalLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnConditionalLogicTests.swift; sourceTree = "<group>"; };
-		DEC0F40000000000000040F1 /* RequiredLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredLogicTests.swift; sourceTree = "<group>"; };
 		E254BF7F2D410F990083C3E4 /* ConditionLogicUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionLogicUnitTests.swift; sourceTree = "<group>"; };
 		E26315E32F76AEA70008B89B /* ValidatePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatePathTests.swift; sourceTree = "<group>"; };
 		E27061C72E797E56006BAD18 /* TableViewModelDocumentEditorDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewModelDocumentEditorDelegateTests.swift; sourceTree = "<group>"; };
@@ -1223,6 +1226,7 @@
 		1307CF1A2BE36ECE00B19FBA /* JoyfillUITests */ = {
 			isa = PBXGroup;
 			children = (
+				95C0BEE7300A441300D207B9 /* RequiredLogicTest */,
 				95C0BE9B3006200400D207B9 /* LandscapeModeTest */,
 				BA2353382FA1DFEF002D9345 /* PageDeletableCopyable */,
 				BA2352F02F99E9DB002D9345 /* DecoratorUITests */,
@@ -1433,6 +1437,15 @@
 				95C0BE9A3006200400D207B9 /* LandScapeMode.swift */,
 			);
 			path = LandscapeModeTest;
+			sourceTree = "<group>";
+		};
+		95C0BEE7300A441300D207B9 /* RequiredLogicTest */ = {
+			isa = PBXGroup;
+			children = (
+				95C0BEEA300A444900D207B9 /* RequiredLogic.swift */,
+				95C0BEE8300A442500D207B9 /* RequiredLogic.json */,
+			);
+			path = RequiredLogicTest;
 			sourceTree = "<group>";
 		};
 		9EAAC7BF2E979A20000B6F3C /* TimeZone */ = {
@@ -2352,6 +2365,7 @@
 				369D454C2E0E51AC00677280 /* FormulaTemplate_TextareaField.json in Resources */,
 				362746512E24F0D0005B0FA7 /* FormulaTemplate_EqualityOperator.json in Resources */,
 				E2F568852E2A45BC005216A6 /* ChartFieldTestData.json in Resources */,
+				95C0BEE9300A443500D207B9 /* RequiredLogic.json in Resources */,
 				362746522E24F0D0005B0FA7 /* FormulaTemplate_LessThanOperator.json in Resources */,
 				362746532E24F0D0005B0FA7 /* FormulaTemplate_LessThanOrEqualOperator.json in Resources */,
 				362746542E24F0D0005B0FA7 /* FormulaTemplate_GreaterThanOrEqualOperator.json in Resources */,
@@ -2560,6 +2574,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95C0BEEC300A443500D207B9 /* RequiredLogic.json in Resources */,
 				95C0BEA03006200400D207B9 /* LandscapeMode.json in Resources */,
 				BA2352F32F99E9FE002D9346 /* Decorator.json in Resources */,
 				BA23533B2FA1DFEF002D9345 /* PageDeletableCopyable.json in Resources */,
@@ -2760,6 +2775,7 @@
 				E2B4CFD92F9A060700F2128D /* DecoratorUITestSupport.swift in Sources */,
 				95288E7E2FE2A46A000A2CC1 /* DecoratorRowUpdateUITests.swift in Sources */,
 				E2408A022F7CF023005C4885 /* NavigationGotoUITests.swift in Sources */,
+				95C0BEEB300A445300D207B9 /* RequiredLogic.swift in Sources */,
 				E29FF8822F2527790079A614 /* TestMobileViewDuplicateLogic.swift in Sources */,
 				1307CF1E2BE36ECE00B19FBA /* JoyfillUITestsLaunchTests.swift in Sources */,
 				E2F5687C2E2A45A8005216A6 /* SignatureFieldTests.swift in Sources */,

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -1,0 +1,482 @@
+import XCTest
+import Foundation
+import JoyfillModel
+@testable import Joyfill
+
+/// Tests for `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell).
+///
+/// Semantics under test (action fully overrides the static `required` flag):
+///   - action == "enforce" -> required only when conditions match
+///   - action == "unforce" -> optional only when conditions match (required otherwise)
+final class RequiredLogicTests: XCTestCase {
+    let fileID = "file-1"
+    let pageID = "page-1"
+    let dropdownFieldID = "dropdown1"
+    let textFieldID = "text1"
+    let tableFieldID = "table1"
+    let optYes = "opt-yes"
+    let optNo = "opt-no"
+
+    // Column ids for the table fixtures
+    let textColumnID = "col-text"
+    let ddColumnID = "col-dd"
+
+    func documentEditor(document: JoyDoc) -> DocumentEditor {
+        DocumentEditor(document: document, validateSchema: false)
+    }
+
+    // MARK: - Builders
+
+    private func requiredLogic(action: String, condField: String, value: Any, condition: String = "=") -> [String: Any] {
+        [
+            "action": action,
+            "eval": "and",
+            "conditions": [[
+                "file": fileID, "page": pageID, "field": condField,
+                "condition": condition, "value": value, "_id": UUID().uuidString
+            ]],
+            "_id": UUID().uuidString
+        ]
+    }
+
+    /// Builds requiredLogic with multiple conditions and an explicit eval ("and" / "or").
+    private func requiredLogicMulti(action: String, eval: String, conditions: [(field: String, value: Any, condition: String)]) -> [String: Any] {
+        [
+            "action": action,
+            "eval": eval,
+            "conditions": conditions.map { c in
+                ["file": fileID, "page": pageID, "field": c.field,
+                 "condition": c.condition, "value": c.value, "_id": UUID().uuidString] as [String: Any]
+            },
+            "_id": UUID().uuidString
+        ]
+    }
+
+    /// A page with a text field (carrying requiredLogic) and a dropdown field it depends on.
+    private func makeFieldLevelDoc(action: String, staticRequired: Bool, textValue: String?, dropdownValue: String) -> JoyDoc {
+        var textField: [String: Any] = [
+            "_id": textFieldID, "file": fileID, "type": "text", "required": staticRequired,
+            "requiredLogic": requiredLogic(action: action, condField: dropdownFieldID, value: optYes)
+        ]
+        if let textValue = textValue { textField["value"] = textValue }
+
+        return JoyDoc(dictionary: [
+            "_id": "doc-1",
+            "files": [[
+                "_id": fileID, "pageOrder": [pageID],
+                "pages": [[
+                    "_id": pageID,
+                    "fieldPositions": [
+                        ["_id": "fp-text", "field": textFieldID, "type": "text"],
+                        ["_id": "fp-dd", "field": dropdownFieldID, "type": "dropdown"],
+                    ],
+                ]],
+            ]],
+            "fields": [
+                textField,
+                ["_id": dropdownFieldID, "file": fileID, "type": "dropdown", "value": dropdownValue,
+                 "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]],
+            ],
+        ])
+    }
+
+    private func textStatus(_ editor: DocumentEditor) -> ValidationStatus? {
+        editor.validate().fieldValidities.first(where: { $0.fieldId == textFieldID })?.status
+    }
+
+    // MARK: - Field-level enforce / unforce
+
+    func testFieldEnforce_conditionsMatch_makesRequired() {
+        // dropdown = Yes -> enforce matches -> required -> empty text is invalid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "enforce", staticRequired: false, textValue: nil, dropdownValue: optYes))
+        XCTAssertEqual(textStatus(editor), .invalid)
+    }
+
+    func testFieldEnforce_conditionsDoNotMatch_makesOptional() {
+        // dropdown = No -> enforce does not match -> optional -> empty text is valid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "enforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
+        XCTAssertEqual(textStatus(editor), .valid)
+    }
+
+    func testFieldUnforce_conditionsMatch_makesOptional() {
+        // dropdown = Yes -> unforce matches -> optional -> empty text is valid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "unforce", staticRequired: true, textValue: nil, dropdownValue: optYes))
+        XCTAssertEqual(textStatus(editor), .valid)
+    }
+
+    func testFieldUnforce_conditionsDoNotMatch_makesRequired() {
+        // dropdown = No -> unforce does not match -> required -> empty text is invalid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "unforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
+        XCTAssertEqual(textStatus(editor), .invalid)
+    }
+
+    func testFieldEnforce_overridesStaticRequiredTrue() {
+        // static required = true but enforce does not match -> optional -> empty text is valid.
+        // Proves the logic fully overrides the static flag.
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "enforce", staticRequired: true, textValue: nil, dropdownValue: optNo))
+        XCTAssertEqual(textStatus(editor), .valid)
+    }
+
+    // MARK: - Dynamic re-evaluation
+
+    func testFieldEnforce_flipsWhenDependencyChanges() {
+        // Start with dropdown = No -> optional -> valid.
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "enforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
+        XCTAssertEqual(textStatus(editor), .valid)
+        XCTAssertFalse(editor.isFieldRequired(fieldID: textFieldID))
+
+        // Change dropdown to Yes -> enforce now matches -> required -> invalid.
+        let fi = FieldIdentifier(fieldID: dropdownFieldID)
+        editor.updateField(event: FieldChangeData(fieldIdentifier: fi, updateValue: .string(optYes)), fieldIdentifier: fi)
+
+        XCTAssertTrue(editor.isFieldRequired(fieldID: textFieldID))
+        XCTAssertEqual(textStatus(editor), .invalid)
+    }
+
+    // MARK: - Column-level requiredLogic (page-field conditions, column-wide)
+
+    private func makeTableDoc(
+        textColumn: [String: Any],
+        rows: [[String: Any]],
+        includePageDropdown: Bool,
+        dropdownValue: String,
+        fieldRequiredLogic: [String: Any]? = nil
+    ) -> JoyDoc {
+        var fieldPositions: [[String: Any]] = [["_id": "fp-table", "field": tableFieldID, "type": "table"]]
+        var tableField: [String: Any] = [
+            "_id": tableFieldID, "file": fileID, "type": "table", "required": false,
+            "tableColumns": [
+                textColumn,
+                ["_id": ddColumnID, "type": "dropdown", "title": "DD",
+                 "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]],
+            ],
+            "tableColumnOrder": [textColumnID, ddColumnID],
+            "rowOrder": rows.compactMap { $0["_id"] as? String },
+            "value": rows,
+        ]
+        if let fieldRequiredLogic = fieldRequiredLogic { tableField["requiredLogic"] = fieldRequiredLogic }
+        var fields: [[String: Any]] = [tableField]
+
+        if includePageDropdown {
+            fieldPositions.append(["_id": "fp-dd", "field": dropdownFieldID, "type": "dropdown"])
+            fields.append(["_id": dropdownFieldID, "file": fileID, "type": "dropdown", "value": dropdownValue,
+                           "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]])
+        }
+
+        return JoyDoc(dictionary: [
+            "_id": "doc-1",
+            "files": [[
+                "_id": fileID, "pageOrder": [pageID],
+                "pages": [["_id": pageID, "fieldPositions": fieldPositions]],
+            ]],
+            "fields": fields,
+        ])
+    }
+
+    private func cellStatus(_ editor: DocumentEditor, rowId: String, columnId: String) -> ValidationStatus? {
+        editor.validate().fieldValidities
+            .first(where: { $0.fieldId == tableFieldID })?
+            .rowValidities?.first(where: { $0.rowId == rowId })?
+            .cellValidities.first(where: { $0.columnId == columnId })?.status
+    }
+
+    func testColumnEnforce_appliesToAllCells() {
+        // Column text requiredLogic enforce on page dropdown = Yes. Two rows, both empty text cells.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [
+            ["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optNo]],
+            ["_id": "row-2", "cells": [textColumnID: "", ddColumnID: optYes]],
+        ]
+
+        // Page dropdown = Yes -> column required -> both empty cells invalid
+        let matchEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
+        XCTAssertEqual(cellStatus(matchEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+        XCTAssertEqual(cellStatus(matchEditor, rowId: "row-2", columnId: textColumnID), .invalid)
+
+        // Page dropdown = No -> column optional -> both empty cells valid
+        let noMatchEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
+        XCTAssertEqual(cellStatus(noMatchEditor, rowId: "row-1", columnId: textColumnID), .valid)
+        XCTAssertEqual(cellStatus(noMatchEditor, rowId: "row-2", columnId: textColumnID), .valid)
+    }
+
+    // MARK: - Cell-level cellRequiredLogic (sibling-cell conditions, per-row)
+
+    func testCellRequiredLogic_resolvesAgainstSiblingCellPerRow() {
+        // text column cellRequiredLogic enforce referencing sibling dropdown column = Yes.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "cellRequiredLogic": requiredLogic(action: "enforce", condField: ddColumnID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [
+            ["_id": "row-match", "cells": [textColumnID: "", ddColumnID: optYes]],   // sibling matches -> required -> invalid
+            ["_id": "row-nomatch", "cells": [textColumnID: "", ddColumnID: optNo]],  // sibling no match -> optional -> valid
+        ]
+        let editor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: false, dropdownValue: optNo))
+
+        XCTAssertEqual(cellStatus(editor, rowId: "row-match", columnId: textColumnID), .invalid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-nomatch", columnId: textColumnID), .valid)
+    }
+
+    // MARK: - Table: additional column / cell coverage
+
+    func testColumnUnforce_conditionsMatch_makesOptional() {
+        // Column is statically required; unforce turns it optional only when the page dropdown = Yes.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text", "required": true,
+            "requiredLogic": requiredLogic(action: "unforce", condField: dropdownFieldID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optNo]]]
+
+        // dropdown = Yes -> unforce matches -> optional -> empty cell valid
+        let optionalEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
+        XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
+
+        // dropdown = No -> unforce no match -> static required stays -> empty cell invalid
+        let requiredEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    func testColumnEnforce_cellFilled_isValid() {
+        // Column required (enforce matches) but the cell is filled -> valid.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "filled", ddColumnID: optYes]]]
+        let editor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
+    }
+
+    func testColumnEnforce_flipsWhenPageDependencyChanges() {
+        // Column enforce on page dropdown = Yes. Start with No -> optional; flip to Yes -> required.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optNo]]]
+        let editor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
+
+        XCTAssertFalse(editor.isColumnRequired(columnID: textColumnID, fieldID: tableFieldID))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
+
+        let fi = FieldIdentifier(fieldID: dropdownFieldID)
+        editor.updateField(event: FieldChangeData(fieldIdentifier: fi, updateValue: .string(optYes)), fieldIdentifier: fi)
+
+        XCTAssertTrue(editor.isColumnRequired(columnID: textColumnID, fieldID: tableFieldID))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    func testCellLogicTakesPrecedenceOverColumnLogic_table() {
+        // Column requiredLogic says optional (page dropdown = No), but cellRequiredLogic says required
+        // (sibling dd cell = Yes). Cell logic wins -> empty cell invalid.
+        let textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes),
+            "cellRequiredLogic": requiredLogic(action: "enforce", condField: ddColumnID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optYes]]]
+        let editor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
+
+        XCTAssertFalse(editor.isColumnRequired(columnID: textColumnID, fieldID: tableFieldID))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    func testTableFieldLevelRequired_refreshesWhenTriggerChanges() {
+        // Regression: field-level requiredLogic on a table must be refreshed when its trigger changes.
+        let textColumn: [String: Any] = ["_id": textColumnID, "type": "text", "title": "Text"]
+        let editor = documentEditor(document: makeTableDoc(
+            textColumn: textColumn, rows: [], includePageDropdown: true, dropdownValue: optNo,
+            fieldRequiredLogic: requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes)
+        ))
+        XCTAssertFalse(editor.isFieldRequired(fieldID: tableFieldID))
+
+        // Mutate the trigger without triggering refresh, then ask which fields need refreshing.
+        var dropdown = editor.field(fieldID: dropdownFieldID)
+        dropdown?.value = .string(optYes)
+        editor.updateField(field: dropdown)
+
+        let refreshed = editor.requiredLogicHandler.fieldsNeedsToBeRefreshed(fieldID: dropdownFieldID)
+        XCTAssertTrue(refreshed.contains(tableFieldID))
+        XCTAssertTrue(editor.isFieldRequired(fieldID: tableFieldID))
+    }
+
+    // MARK: - eval "or"
+
+    func testFieldEnforce_evalOr_anyConditionMatches() {
+        let dropdown2ID = "dropdown2"
+        func doc(dd1: String, dd2: String) -> JoyDoc {
+            JoyDoc(dictionary: [
+                "_id": "doc-1",
+                "files": [[
+                    "_id": fileID, "pageOrder": [pageID],
+                    "pages": [["_id": pageID, "fieldPositions": [
+                        ["_id": "fp-text", "field": textFieldID, "type": "text"],
+                        ["_id": "fp-dd", "field": dropdownFieldID, "type": "dropdown"],
+                        ["_id": "fp-dd2", "field": dropdown2ID, "type": "dropdown"],
+                    ]]],
+                ]],
+                "fields": [
+                    ["_id": textFieldID, "file": fileID, "type": "text", "required": false,
+                     "requiredLogic": requiredLogicMulti(action: "enforce", eval: "or", conditions: [
+                        (field: dropdownFieldID, value: optYes, condition: "="),
+                        (field: dropdown2ID, value: optYes, condition: "="),
+                     ])],
+                    ["_id": dropdownFieldID, "file": fileID, "type": "dropdown", "value": dd1,
+                     "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]],
+                    ["_id": dropdown2ID, "file": fileID, "type": "dropdown", "value": dd2,
+                     "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]],
+                ],
+            ])
+        }
+        // One condition matches (dd2 = Yes) -> or -> required -> empty text invalid
+        XCTAssertEqual(textStatus(documentEditor(document: doc(dd1: optNo, dd2: optYes))), .invalid)
+        // Neither matches -> optional -> empty text valid
+        XCTAssertEqual(textStatus(documentEditor(document: doc(dd1: optNo, dd2: optNo))), .valid)
+    }
+
+    // MARK: - Collection: requiredLogic / cellRequiredLogic
+
+    let collectionFieldID = "collection1"
+    let rootSchemaID = "rootSchema"
+    let nestedSchemaID = "childSchema"
+    let rootTextCol = "root-text"
+    let rootDdCol = "root-dd"
+    let childTextCol = "child-text"
+    let childNotesCol = "child-notes"
+
+    private func makeCollectionDoc(
+        rootColumns: [[String: Any]],
+        nestedColumns: [[String: Any]],
+        rootRows: [[String: Any]],
+        fieldRequiredLogic: [String: Any]? = nil,
+        includePageDropdown: Bool = false,
+        dropdownValue: String = ""
+    ) -> JoyDoc {
+        var fieldPositions: [[String: Any]] = [["_id": "fp-collection", "field": collectionFieldID, "type": "collection"]]
+        var collectionField: [String: Any] = [
+            "_id": collectionFieldID, "file": fileID, "type": "collection", "required": false,
+            "schema": [
+                rootSchemaID: ["title": "Root", "root": true, "children": [nestedSchemaID], "tableColumns": rootColumns] as [String: Any],
+                nestedSchemaID: ["title": "Child", "children": [], "tableColumns": nestedColumns] as [String: Any],
+            ],
+            "value": rootRows,
+        ]
+        if let fieldRequiredLogic = fieldRequiredLogic { collectionField["requiredLogic"] = fieldRequiredLogic }
+        var fields: [[String: Any]] = [collectionField]
+
+        if includePageDropdown {
+            fieldPositions.append(["_id": "fp-dd", "field": dropdownFieldID, "type": "dropdown"])
+            fields.append(["_id": dropdownFieldID, "file": fileID, "type": "dropdown", "value": dropdownValue,
+                           "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]])
+        }
+
+        return JoyDoc(dictionary: [
+            "_id": "doc-1",
+            "files": [[
+                "_id": fileID, "pageOrder": [pageID],
+                "pages": [["_id": pageID, "fieldPositions": fieldPositions]],
+            ]],
+            "fields": fields,
+        ])
+    }
+
+    private func rootRow(_ editor: DocumentEditor, id: String) -> ValueElement? {
+        editor.field(fieldID: collectionFieldID)?.valueToValueElements?.first(where: { $0.id == id })
+    }
+
+    private func nestedRow(_ editor: DocumentEditor, parentID: String, childID: String) -> ValueElement? {
+        rootRow(editor, id: parentID)?.childrens?[nestedSchemaID]?.valueToValueElements?.first(where: { $0.id == childID })
+    }
+
+    private var minimalNestedColumns: [[String: Any]] {
+        [["_id": childTextCol, "type": "text", "title": "Child Text"]]
+    }
+
+    func testCollection_columnEnforce_pageDependency() {
+        let rootText: [String: Any] = [
+            "_id": rootTextCol, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes)
+        ]
+        let rows: [[String: Any]] = [["_id": "root-1", "cells": [rootTextCol: ""]]]
+
+        let matchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optYes))
+        XCTAssertTrue(matchEditor.isColumnRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID))
+
+        let noMatchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optNo))
+        XCTAssertFalse(noMatchEditor.isColumnRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID))
+    }
+
+    func testCollection_cellRequiredLogic_siblingPerRow() {
+        let rootText: [String: Any] = [
+            "_id": rootTextCol, "type": "text", "title": "Text",
+            "cellRequiredLogic": requiredLogic(action: "enforce", condField: rootDdCol, value: optYes)
+        ]
+        let rootDd: [String: Any] = ["_id": rootDdCol, "type": "dropdown", "title": "DD",
+                                     "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]]
+        let rows: [[String: Any]] = [
+            ["_id": "root-match", "cells": [rootTextCol: "", rootDdCol: optYes]],
+            ["_id": "root-nomatch", "cells": [rootTextCol: "", rootDdCol: optNo]],
+        ]
+        let editor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows))
+
+        XCTAssertTrue(editor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(editor, id: "root-match")!))
+        XCTAssertFalse(editor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(editor, id: "root-nomatch")!))
+    }
+
+    func testCollection_nestedCellRequiredLogic() {
+        let childText: [String: Any] = ["_id": childTextCol, "type": "text", "title": "Child Text"]
+        let childNotes: [String: Any] = [
+            "_id": childNotesCol, "type": "text", "title": "Notes",
+            "cellRequiredLogic": requiredLogic(action: "enforce", condField: childTextCol, value: "", condition: "*=")
+        ]
+        let rootRows: [[String: Any]] = [[
+            "_id": "root-1", "cells": [:],
+            "children": [nestedSchemaID: ["value": [
+                ["_id": "child-filled", "cells": [childTextCol: "hi", childNotesCol: ""]],
+                ["_id": "child-empty", "cells": [childTextCol: "", childNotesCol: ""]],
+            ]]],
+        ]]
+        let editor = documentEditor(document: makeCollectionDoc(rootColumns: [["_id": rootTextCol, "type": "text", "title": "Text"]], nestedColumns: [childText, childNotes], rootRows: rootRows))
+
+        XCTAssertTrue(editor.isCellRequired(columnID: childNotesCol, fieldID: collectionFieldID, schemaKey: nestedSchemaID, row: nestedRow(editor, parentID: "root-1", childID: "child-filled")!))
+        XCTAssertFalse(editor.isCellRequired(columnID: childNotesCol, fieldID: collectionFieldID, schemaKey: nestedSchemaID, row: nestedRow(editor, parentID: "root-1", childID: "child-empty")!))
+    }
+
+    func testCollection_cellLogicTakesPrecedenceOverColumnLogic() {
+        let rootText: [String: Any] = [
+            "_id": rootTextCol, "type": "text", "title": "Text",
+            "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes),
+            "cellRequiredLogic": requiredLogic(action: "enforce", condField: rootDdCol, value: optYes)
+        ]
+        let rootDd: [String: Any] = ["_id": rootDdCol, "type": "dropdown", "title": "DD",
+                                     "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]]
+        let rows: [[String: Any]] = [["_id": "root-1", "cells": [rootTextCol: "", rootDdCol: optYes]]]
+        let editor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optNo))
+
+        // Column-wide is optional (page dropdown = No) but the cell logic makes this row's cell required.
+        XCTAssertFalse(editor.isColumnRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID))
+        XCTAssertTrue(editor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(editor, id: "root-1")!))
+    }
+
+    func testCollection_fieldLevelRequired_refreshesWhenTriggerChanges() {
+        // Regression: field-level requiredLogic on a collection must be refreshed when its trigger changes.
+        let editor = documentEditor(document: makeCollectionDoc(
+            rootColumns: [["_id": rootTextCol, "type": "text", "title": "Text"]],
+            nestedColumns: minimalNestedColumns, rootRows: [],
+            fieldRequiredLogic: requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes),
+            includePageDropdown: true, dropdownValue: optNo
+        ))
+        XCTAssertFalse(editor.isFieldRequired(fieldID: collectionFieldID))
+
+        var dropdown = editor.field(fieldID: dropdownFieldID)
+        dropdown?.value = .string(optYes)
+        editor.updateField(field: dropdown)
+
+        let refreshed = editor.requiredLogicHandler.fieldsNeedsToBeRefreshed(fieldID: dropdownFieldID)
+        XCTAssertTrue(refreshed.contains(collectionFieldID))
+        XCTAssertTrue(editor.isFieldRequired(fieldID: collectionFieldID))
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -5,9 +5,10 @@ import JoyfillModel
 
 /// Tests for `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell).
 ///
-/// Semantics under test (action fully overrides the static `required` flag):
-///   - action == "enforce" -> required only when conditions match
-///   - action == "unforce" -> optional only when conditions match (required otherwise)
+/// Semantics under test (the action only changes required-ness when its conditions match,
+/// otherwise it falls back to the static `required` flag — matches the Kotlin/JS reference):
+///   - action == "enforce" -> required when conditions match, else static `required`
+///   - action == "unforce" -> optional when conditions match, else static `required`
 final class RequiredLogicTests: XCTestCase {
     let fileID = "file-1"
     let pageID = "page-1"
@@ -104,17 +105,16 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(textStatus(editor), .valid)
     }
 
-    func testFieldUnforce_conditionsDoNotMatch_makesRequired() {
-        // dropdown = No -> unforce does not match -> required -> empty text is invalid
+    func testFieldUnforce_conditionsDoNotMatch_fallsBackToStatic() {
+        // dropdown = No -> unforce does not match -> falls back to static required:false -> optional -> empty text is valid
         let editor = documentEditor(document: makeFieldLevelDoc(action: "unforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
-        XCTAssertEqual(textStatus(editor), .invalid)
+        XCTAssertEqual(textStatus(editor), .valid)
     }
 
-    func testFieldEnforce_overridesStaticRequiredTrue() {
-        // static required = true but enforce does not match -> optional -> empty text is valid.
-        // Proves the logic fully overrides the static flag.
+    func testFieldEnforce_conditionsDoNotMatch_fallsBackToStaticRequiredTrue() {
+        // static required = true, enforce does not match -> falls back to static required:true -> required -> empty text is invalid.
         let editor = documentEditor(document: makeFieldLevelDoc(action: "enforce", staticRequired: true, textValue: nil, dropdownValue: optNo))
-        XCTAssertEqual(textStatus(editor), .valid)
+        XCTAssertEqual(textStatus(editor), .invalid)
     }
 
     // MARK: - Dynamic re-evaluation

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -8,7 +8,7 @@ import JoyfillModel
 /// Semantics under test (the action only changes required-ness when its conditions match,
 /// otherwise it falls back to the static `required` flag — matches the Kotlin/JS reference):
 ///   - action == "enforce" -> required when conditions match, else static `required`
-///   - action == "unforce" -> optional when conditions match, else static `required`
+///   - action == "unenforce" -> optional when conditions match, else static `required`
 final class RequiredLogicTests: XCTestCase {
     let fileID = "file-1"
     let pageID = "page-1"
@@ -85,7 +85,7 @@ final class RequiredLogicTests: XCTestCase {
         editor.validate().fieldValidities.first(where: { $0.fieldId == textFieldID })?.status
     }
 
-    // MARK: - Field-level enforce / unforce
+    // MARK: - Field-level enforce / unenforce
 
     func testFieldEnforce_conditionsMatch_makesRequired() {
         // dropdown = Yes -> enforce matches -> required -> empty text is invalid
@@ -99,15 +99,15 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(textStatus(editor), .valid)
     }
 
-    func testFieldUnforce_conditionsMatch_makesOptional() {
-        // dropdown = Yes -> unforce matches -> optional -> empty text is valid
-        let editor = documentEditor(document: makeFieldLevelDoc(action: "unforce", staticRequired: true, textValue: nil, dropdownValue: optYes))
+    func testFieldUnenforce_conditionsMatch_makesOptional() {
+        // dropdown = Yes -> unenforce matches -> optional -> empty text is valid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "unenforce", staticRequired: true, textValue: nil, dropdownValue: optYes))
         XCTAssertEqual(textStatus(editor), .valid)
     }
 
-    func testFieldUnforce_conditionsDoNotMatch_fallsBackToStatic() {
-        // dropdown = No -> unforce does not match -> falls back to static required:false -> optional -> empty text is valid
-        let editor = documentEditor(document: makeFieldLevelDoc(action: "unforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
+    func testFieldUnenforce_conditionsDoNotMatch_fallsBackToStatic() {
+        // dropdown = No -> unenforce does not match -> falls back to static required:false -> optional -> empty text is valid
+        let editor = documentEditor(document: makeFieldLevelDoc(action: "unenforce", staticRequired: false, textValue: nil, dropdownValue: optNo))
         XCTAssertEqual(textStatus(editor), .valid)
     }
 
@@ -222,19 +222,19 @@ final class RequiredLogicTests: XCTestCase {
 
     // MARK: - Table: additional column / cell coverage
 
-    func testColumnUnforce_conditionsMatch_makesOptional() {
-        // Column is statically required; unforce turns it optional only when the page dropdown = Yes.
+    func testColumnUnenforce_conditionsMatch_makesOptional() {
+        // Column is statically required; unenforce turns it optional only when the page dropdown = Yes.
         let textColumn: [String: Any] = [
             "_id": textColumnID, "type": "text", "title": "Text", "required": true,
-            "requiredLogic": requiredLogic(action: "unforce", condField: dropdownFieldID, value: optYes)
+            "requiredLogic": requiredLogic(action: "unenforce", condField: dropdownFieldID, value: optYes)
         ]
         let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optNo]]]
 
-        // dropdown = Yes -> unforce matches -> optional -> empty cell valid
+        // dropdown = Yes -> unenforce matches -> optional -> empty cell valid
         let optionalEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
         XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
 
-        // dropdown = No -> unforce no match -> static required stays -> empty cell invalid
+        // dropdown = No -> unenforce no match -> static required stays -> empty cell invalid
         let requiredEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
         XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
     }

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -22,6 +22,14 @@ final class RequiredLogicTests: XCTestCase {
     let textColumnID = "col-text"
     let ddColumnID = "col-dd"
 
+    // Option ids for the sample-JSON scenario (page dropdown vs table dropdown are distinct).
+    let pageYes = "page-yes"
+    let pageNo = "page-no"
+    let tblYes = "tbl-yes"
+    let tblNo = "tbl-no"
+    let pageDropdownID = "dropdownPage"
+    let numberFieldID = "number1"
+
     func documentEditor(document: JoyDoc) -> DocumentEditor {
         DocumentEditor(document: document, validateSchema: false)
     }
@@ -344,6 +352,185 @@ final class RequiredLogicTests: XCTestCase {
         ))
         let refreshed = editor.requiredLogicHandler.fieldsNeedsToBeRefreshed(fieldID: "number1")
         XCTAssertTrue(refreshed.contains(tableFieldID))
+    }
+
+    func testCellRequiredLogic_mixedConditions_evalOr_anyMatches() {
+        // enforce OR: sibling flag == "yes" (false, is "no") OR page number1 == 100 (true) -> matched -> required.
+        let matchEditor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "or",
+            siblingValue: "no", conditionSiblingValue: "yes",
+            pageNumberValue: 100, conditionPageNumberValue: 100
+        ))
+        XCTAssertEqual(cellStatus(matchEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+
+        // enforce OR: neither matches -> falls back to column base (static false) -> optional.
+        let noMatchEditor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "or",
+            siblingValue: "no", conditionSiblingValue: "yes",
+            pageNumberValue: 10, conditionPageNumberValue: 100
+        ))
+        XCTAssertEqual(cellStatus(noMatchEditor, rowId: "row-1", columnId: textColumnID), .valid)
+    }
+
+    func testCellRequiredLogic_unenforce_matchedMakesOptional_elseFallsBackToColumnStatic() {
+        // Column is statically required. Cell unenforce AND [ sibling "yes", page number1 == 100 ].
+        // Both match -> unenforce -> optional -> valid.
+        let optionalEditor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "unenforce", cellEval: "and",
+            siblingValue: "yes", conditionSiblingValue: "yes",
+            pageNumberValue: 100, conditionPageNumberValue: 100,
+            columnStaticRequired: true
+        ))
+        XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
+
+        // One condition fails -> unenforce doesn't match -> falls back to column static required:true -> invalid.
+        let requiredEditor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "unenforce", cellEval: "and",
+            siblingValue: "yes", conditionSiblingValue: "yes",
+            pageNumberValue: 10, conditionPageNumberValue: 100,
+            columnStaticRequired: true
+        ))
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    // MARK: - Sample JSON use case (mixed cell logic + column unenforce + static required)
+
+    /// Reproduces the provided template: `text1` has static `required:true`, column `requiredLogic`
+    /// `unenforce` (page dropdown == Yes), and `cellRequiredLogic` `enforce` AND
+    /// [ sibling `dropdown1` == "No", page `number1` == 100 ]. Three rows (row-1 has dropdown = No).
+    private func makeSampleDoc(pageDropdownValue: String, number1Value: Double) -> JoyDoc {
+        let textCol: [String: Any] = [
+            "_id": "text1", "type": "text", "title": "Text Column", "required": true,
+            "requiredLogic": [
+                "action": "unenforce", "eval": "and", "_id": UUID().uuidString,
+                "conditions": [["field": pageDropdownID, "condition": "=", "value": pageYes, "_id": UUID().uuidString]] as [[String: Any]],
+            ] as [String: Any],
+            "cellRequiredLogic": [
+                "action": "enforce", "eval": "and", "_id": UUID().uuidString,
+                "conditions": [
+                    ["column": "dropdown1", "condition": "=", "value": tblNo, "_id": UUID().uuidString],
+                    ["field": numberFieldID, "condition": "=", "value": number1Value, "_id": UUID().uuidString],
+                ] as [[String: Any]],
+            ] as [String: Any],
+        ]
+        let ddCol: [String: Any] = [
+            "_id": "dropdown1", "type": "dropdown", "title": "Dropdown Column",
+            "options": [["_id": tblYes, "value": "Yes"], ["_id": tblNo, "value": "No"]],
+        ]
+        let rows: [[String: Any]] = [
+            ["_id": "row-1", "cells": ["dropdown1": tblNo]],
+            ["_id": "row-2", "cells": [:]],
+            ["_id": "row-3", "cells": [:]],
+        ]
+        return JoyDoc(dictionary: [
+            "_id": "doc-1",
+            "files": [[
+                "_id": fileID, "pageOrder": [pageID],
+                "pages": [["_id": pageID, "fieldPositions": [
+                    ["_id": "fp-table", "field": tableFieldID, "type": "table"],
+                    ["_id": "fp-dd", "field": pageDropdownID, "type": "dropdown"],
+                    ["_id": "fp-num", "field": numberFieldID, "type": "number"],
+                ]]],
+            ]],
+            "fields": [
+                ["_id": tableFieldID, "file": fileID, "type": "table", "required": false,
+                 "tableColumns": [textCol, ddCol],
+                 "tableColumnOrder": ["text1", "dropdown1"],
+                 "rowOrder": ["row-1", "row-2", "row-3"],
+                 "value": rows],
+                ["_id": pageDropdownID, "file": fileID, "type": "dropdown", "value": pageDropdownValue,
+                 "options": [["_id": pageYes, "value": "Yes"], ["_id": pageNo, "value": "No"]]],
+                ["_id": numberFieldID, "file": fileID, "type": "number", "value": number1Value],
+            ],
+        ])
+    }
+
+    func testSampleJSON_text1RequiredInAllThreeRows() {
+        // page dropdown = No, number1 = 100. Column unenforce doesn't match (dropdown != Yes) ->
+        // column-effective falls back to static required:true.
+        let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
+        XCTAssertTrue(editor.isColumnRequired(columnID: "text1", fieldID: tableFieldID))
+
+        // row-1: cell enforce matches (sibling No + number 100) -> required.
+        // row-2 / row-3: cell not matched (dropdown empty) -> fall back to column-effective (required).
+        for rowId in ["row-1", "row-2", "row-3"] {
+            XCTAssertEqual(cellStatus(editor, rowId: rowId, columnId: "text1"), .invalid,
+                           "text1 should be required (empty -> invalid) in \(rowId)")
+        }
+    }
+
+    func testSampleJSON_dynamicFlipAcrossResolutionOrder() {
+        let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
+        // Baseline: every row required.
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .invalid)
+
+        // Flip page dropdown -> Yes: column unenforce now matches -> column-effective becomes optional.
+        let ddFI = FieldIdentifier(fieldID: pageDropdownID)
+        editor.updateField(event: FieldChangeData(fieldIdentifier: ddFI, updateValue: .string(pageYes)), fieldIdentifier: ddFI)
+        // row-1: cell still matches (sibling No + number 100) -> required.
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
+        // row-2: cell not matched -> falls back to the now-optional column-effective -> valid.
+        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .valid)
+
+        // Change number1 -> 10: row-1 cell AND now fails -> falls back to optional column -> valid.
+        let numFI = FieldIdentifier(fieldID: numberFieldID)
+        editor.updateField(event: FieldChangeData(fieldIdentifier: numFI, updateValue: .double(10)), fieldIdentifier: numFI)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .valid)
+    }
+
+    // MARK: - Collection: mixed sibling + page-field cell logic, nested own-columns
+
+    func testCollection_cellRequiredLogic_mixedSiblingAndPageField() {
+        // Root text cellRequiredLogic enforce AND [ sibling rootDd == Yes, page dropdown == Yes ].
+        let rootText: [String: Any] = [
+            "_id": rootTextCol, "type": "text", "title": "Text",
+            "cellRequiredLogic": [
+                "action": "enforce", "eval": "and", "_id": UUID().uuidString,
+                "conditions": [
+                    ["column": rootDdCol, "condition": "=", "value": optYes, "_id": UUID().uuidString],
+                    ["field": dropdownFieldID, "condition": "=", "value": optYes, "_id": UUID().uuidString],
+                ] as [[String: Any]],
+            ] as [String: Any],
+        ]
+        let rootDd: [String: Any] = ["_id": rootDdCol, "type": "dropdown", "title": "DD",
+                                     "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]]
+        let rows: [[String: Any]] = [["_id": "root-1", "cells": [rootTextCol: "", rootDdCol: optYes]]]
+
+        // page dropdown = Yes -> both conditions match -> required.
+        let matchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optYes))
+        XCTAssertTrue(matchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(matchEditor, id: "root-1")!))
+
+        // page dropdown = No -> page half of the AND fails -> falls back to column base (static false) -> optional.
+        let noMatchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optNo))
+        XCTAssertFalse(noMatchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(noMatchEditor, id: "root-1")!))
+    }
+
+    func testCollection_nestedCellLogic_referencesOwnColumnsNotParent() {
+        // Both root and nested schemas carry a column with id `shared`. The nested notes column's
+        // cellRequiredLogic references `shared` and must resolve against the NESTED row's own cell,
+        // never the parent/root cell. Root's `shared` is empty in both cases, so a required result
+        // can only come from the nested row's own value.
+        let sharedID = "shared"
+        let rootShared: [String: Any] = ["_id": sharedID, "type": "text", "title": "Root Shared"]
+        let nestedShared: [String: Any] = ["_id": sharedID, "type": "text", "title": "Child Shared"]
+        let nestedNotes: [String: Any] = [
+            "_id": childNotesCol, "type": "text", "title": "Notes",
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: sharedID, value: "", condition: "*=")
+        ]
+        let rootRows: [[String: Any]] = [[
+            "_id": "root-1", "cells": [sharedID: ""],
+            "children": [nestedSchemaID: ["value": [
+                ["_id": "child-filled", "cells": [sharedID: "hi", childNotesCol: ""]],
+                ["_id": "child-empty", "cells": [sharedID: "", childNotesCol: ""]],
+            ]]],
+        ]]
+        let editor = documentEditor(document: makeCollectionDoc(rootColumns: [rootShared], nestedColumns: [nestedShared, nestedNotes], rootRows: rootRows))
+
+        // Nested row whose OWN `shared` is filled -> notes required (proves it read the nested cell).
+        XCTAssertTrue(editor.isCellRequired(columnID: childNotesCol, fieldID: collectionFieldID, schemaKey: nestedSchemaID, row: nestedRow(editor, parentID: "root-1", childID: "child-filled")!))
+        // Nested row whose own `shared` is empty -> notes not required.
+        XCTAssertFalse(editor.isCellRequired(columnID: childNotesCol, fieldID: collectionFieldID, schemaKey: nestedSchemaID, row: nestedRow(editor, parentID: "root-1", childID: "child-empty")!))
     }
 
     // MARK: - Table: additional column / cell coverage

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -5,10 +5,10 @@ import JoyfillModel
 
 /// Tests for `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell).
 ///
-/// Semantics under test (the action only changes required-ness when its conditions match,
-/// otherwise it falls back to the static `required` flag — matches the Kotlin/JS reference):
-///   - action == "enforce" -> required when conditions match, else static `required`
-///   - action == "unenforce" -> optional when conditions match, else static `required`
+/// Table/collection cell semantics under test:
+///   - cellRequiredLogic, when present, resolves the cell without falling through
+///   - otherwise column requiredLogic, when present, resolves the cell without falling through
+///   - static `required` is used only when no cell or column logic is present
 final class RequiredLogicTests: XCTestCase {
     let fileID = "file-1"
     let pageID = "page-1"
@@ -317,9 +317,9 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
     }
 
-    func testCellRequiredLogic_mixedSiblingAndPageField_pageFieldMissesUnderAnd_fallsBack() {
+    func testCellRequiredLogic_mixedSiblingAndPageField_pageFieldMissesUnderAnd_makesOptional() {
         // enforce AND: sibling flag == "yes" (true) AND page number1 == 100 (false, is 10).
-        // AND fails -> falls back to column base (no column logic, static false) -> optional -> valid.
+        // AND fails -> cell logic resolves optional without falling through.
         let editor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "and",
             siblingValue: "yes", conditionSiblingValue: "yes",
@@ -328,10 +328,9 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
-    func testCellRequiredLogic_mixedConditions_fallBackToColumnStaticRequired() {
-        // Mirrors the sample JSON: cell enforce-AND fails (number1 != 100), so we fall back to the
-        // column base. Column requiredLogic is unenforce on page dropdown = Yes but dropdown = No, so
-        // it also fails and falls back to the column's static required:true -> required -> invalid.
+    func testCellRequiredLogic_mixedConditions_doesNotFallBackToColumnStaticRequired() {
+        // Mirrors the sample JSON: cell enforce-AND fails (number1 != 100), so the cell is optional.
+        // Column logic and static required are not consulted when cell logic exists.
         let editor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "and",
             siblingValue: "No", conditionSiblingValue: "No",
@@ -340,7 +339,7 @@ final class RequiredLogicTests: XCTestCase {
             columnStaticRequired: true,
             includePageDropdown: true, dropdownValue: optNo
         ))
-        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
     func testCellRequiredLogic_pageFieldDependency_refreshesOwningTable() {
@@ -363,7 +362,7 @@ final class RequiredLogicTests: XCTestCase {
         ))
         XCTAssertEqual(cellStatus(matchEditor, rowId: "row-1", columnId: textColumnID), .invalid)
 
-        // enforce OR: neither matches -> falls back to column base (static false) -> optional.
+        // enforce OR: neither matches -> cell logic resolves optional.
         let noMatchEditor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "or",
             siblingValue: "no", conditionSiblingValue: "yes",
@@ -372,7 +371,7 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(noMatchEditor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
-    func testCellRequiredLogic_unenforce_matchedMakesOptional_elseFallsBackToColumnStatic() {
+    func testCellRequiredLogic_unenforce_matchedMakesOptional_elseStillOptional() {
         // Column is statically required. Cell unenforce AND [ sibling "yes", page number1 == 100 ].
         // Both match -> unenforce -> optional -> valid.
         let optionalEditor = documentEditor(document: makeMixedCellDoc(
@@ -383,14 +382,14 @@ final class RequiredLogicTests: XCTestCase {
         ))
         XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
 
-        // One condition fails -> unenforce doesn't match -> falls back to column static required:true -> invalid.
+        // One condition fails -> cell logic still resolves optional without falling through.
         let requiredEditor = documentEditor(document: makeMixedCellDoc(
             cellAction: "unenforce", cellEval: "and",
             siblingValue: "yes", conditionSiblingValue: "yes",
             pageNumberValue: 10, conditionPageNumberValue: 100,
             columnStaticRequired: true
         ))
-        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
     // MARK: - Sample JSON use case (mixed cell logic + column unenforce + static required)
@@ -445,35 +444,36 @@ final class RequiredLogicTests: XCTestCase {
         ])
     }
 
-    func testSampleJSON_text1RequiredInAllThreeRows() {
-        // page dropdown = No, number1 = 100. Column unenforce doesn't match (dropdown != Yes) ->
-        // column-effective falls back to static required:true.
+    func testSampleJSON_text1CellLogicControlsRows() {
+        // page dropdown = No, number1 = 100. Column unenforce resolves optional, and static required
+        // is ignored because column logic exists.
         let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
-        XCTAssertTrue(editor.isColumnRequired(columnID: "text1", fieldID: tableFieldID))
+        XCTAssertFalse(editor.isColumnRequired(columnID: "text1", fieldID: tableFieldID))
 
         // row-1: cell enforce matches (sibling No + number 100) -> required.
-        // row-2 / row-3: cell not matched (dropdown empty) -> fall back to column-effective (required).
-        for rowId in ["row-1", "row-2", "row-3"] {
-            XCTAssertEqual(cellStatus(editor, rowId: rowId, columnId: "text1"), .invalid,
-                           "text1 should be required (empty -> invalid) in \(rowId)")
+        // row-2 / row-3: cell logic exists but does not match -> optional.
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
+        for rowId in ["row-2", "row-3"] {
+            XCTAssertEqual(cellStatus(editor, rowId: rowId, columnId: "text1"), .valid,
+                           "text1 should be optional when cell logic does not match in \(rowId)")
         }
     }
 
     func testSampleJSON_dynamicFlipAcrossResolutionOrder() {
         let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
-        // Baseline: every row required.
+        // Baseline: only the matching row is required.
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
-        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .invalid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .valid)
 
         // Flip page dropdown -> Yes: column unenforce now matches -> column-effective becomes optional.
         let ddFI = FieldIdentifier(fieldID: pageDropdownID)
         editor.updateField(event: FieldChangeData(fieldIdentifier: ddFI, updateValue: .string(pageYes)), fieldIdentifier: ddFI)
         // row-1: cell still matches (sibling No + number 100) -> required.
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
-        // row-2: cell not matched -> falls back to the now-optional column-effective -> valid.
+        // row-2: cell not matched -> optional.
         XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .valid)
 
-        // Change number1 -> 10: row-1 cell AND now fails -> falls back to optional column -> valid.
+        // Change number1 -> 10: row-1 cell AND now fails -> optional.
         let numFI = FieldIdentifier(fieldID: numberFieldID)
         editor.updateField(event: FieldChangeData(fieldIdentifier: numFI, updateValue: .double(10)), fieldIdentifier: numFI)
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .valid)
@@ -501,7 +501,7 @@ final class RequiredLogicTests: XCTestCase {
         let matchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optYes))
         XCTAssertTrue(matchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(matchEditor, id: "root-1")!))
 
-        // page dropdown = No -> page half of the AND fails -> falls back to column base (static false) -> optional.
+        // page dropdown = No -> page half of the AND fails -> cell logic resolves optional.
         let noMatchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optNo))
         XCTAssertFalse(noMatchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(noMatchEditor, id: "root-1")!))
     }
@@ -547,9 +547,9 @@ final class RequiredLogicTests: XCTestCase {
         let optionalEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
         XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
 
-        // dropdown = No -> unenforce no match -> static required stays -> empty cell invalid
+        // dropdown = No -> column logic exists but does not require, so static required is ignored.
         let requiredEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
-        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
     func testColumnEnforce_cellFilled_isValid() {

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -53,6 +53,20 @@ final class RequiredLogicTests: XCTestCase {
         ]
     }
 
+    /// Builds cellRequiredLogic whose single condition references a SIBLING column (via the `column`
+    /// key), resolved against the same row's cells — mirrors show/hide logic and the sample JSON.
+    private func cellRequiredLogic(action: String, condColumn: String, value: Any, condition: String = "=") -> [String: Any] {
+        [
+            "action": action,
+            "eval": "and",
+            "conditions": [[
+                "column": condColumn,
+                "condition": condition, "value": value, "_id": UUID().uuidString
+            ]],
+            "_id": UUID().uuidString
+        ]
+    }
+
     /// A page with a text field (carrying requiredLogic) and a dropdown field it depends on.
     private func makeFieldLevelDoc(action: String, staticRequired: Bool, textValue: String?, dropdownValue: String) -> JoyDoc {
         var textField: [String: Any] = [
@@ -208,7 +222,7 @@ final class RequiredLogicTests: XCTestCase {
         // text column cellRequiredLogic enforce referencing sibling dropdown column = Yes.
         let textColumn: [String: Any] = [
             "_id": textColumnID, "type": "text", "title": "Text",
-            "cellRequiredLogic": requiredLogic(action: "enforce", condField: ddColumnID, value: optYes)
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: ddColumnID, value: optYes)
         ]
         let rows: [[String: Any]] = [
             ["_id": "row-match", "cells": [textColumnID: "", ddColumnID: optYes]],   // sibling matches -> required -> invalid
@@ -218,6 +232,118 @@ final class RequiredLogicTests: XCTestCase {
 
         XCTAssertEqual(cellStatus(editor, rowId: "row-match", columnId: textColumnID), .invalid)
         XCTAssertEqual(cellStatus(editor, rowId: "row-nomatch", columnId: textColumnID), .valid)
+    }
+
+    // MARK: - Cell logic with mixed sibling-column + page-field conditions
+
+    /// A table whose text column carries a `cellRequiredLogic` mixing a sibling-column condition
+    /// (`column`) and a page-level field condition (`field`), plus a page number field it depends on.
+    private func makeMixedCellDoc(
+        cellAction: String,
+        cellEval: String,
+        siblingValue: String,
+        conditionSiblingValue: String,
+        pageNumberValue: Double,
+        conditionPageNumberValue: Double,
+        columnRequiredLogic: [String: Any]? = nil,
+        columnStaticRequired: Bool = false,
+        includePageDropdown: Bool = false,
+        dropdownValue: String = ""
+    ) -> JoyDoc {
+        let numberFieldID = "number1"
+        var textColumn: [String: Any] = [
+            "_id": textColumnID, "type": "text", "title": "Text",
+            "required": columnStaticRequired,
+            "cellRequiredLogic": [
+                "action": cellAction, "eval": cellEval, "_id": UUID().uuidString,
+                "conditions": [
+                    // sibling-column condition (resolved against the row's own cells)
+                    ["column": ddColumnID, "condition": "=", "value": conditionSiblingValue, "_id": UUID().uuidString],
+                    // page-field condition (resolved against the document)
+                    ["field": numberFieldID, "condition": "=", "value": conditionPageNumberValue, "_id": UUID().uuidString],
+                ] as [[String: Any]],
+            ] as [String: Any],
+        ]
+        if let columnRequiredLogic = columnRequiredLogic { textColumn["requiredLogic"] = columnRequiredLogic }
+
+        var fieldPositions: [[String: Any]] = [
+            ["_id": "fp-table", "field": tableFieldID, "type": "table"],
+            ["_id": "fp-num", "field": numberFieldID, "type": "number"],
+        ]
+        var fields: [[String: Any]] = [
+            [
+                "_id": tableFieldID, "file": fileID, "type": "table", "required": false,
+                "tableColumns": [
+                    textColumn,
+                    ["_id": ddColumnID, "type": "text", "title": "Flag"],
+                ] as [[String: Any]],
+                "tableColumnOrder": [textColumnID, ddColumnID],
+                "rowOrder": ["row-1"],
+                "value": [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: siblingValue]]] as [[String: Any]],
+            ],
+            ["_id": numberFieldID, "file": fileID, "type": "number", "value": pageNumberValue],
+        ]
+        if includePageDropdown {
+            fieldPositions.append(["_id": "fp-dd", "field": dropdownFieldID, "type": "dropdown"])
+            fields.append(["_id": dropdownFieldID, "file": fileID, "type": "dropdown", "value": dropdownValue,
+                           "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]])
+        }
+
+        return JoyDoc(dictionary: [
+            "_id": "doc-1",
+            "files": [[
+                "_id": fileID, "pageOrder": [pageID],
+                "pages": [["_id": pageID, "fieldPositions": fieldPositions]],
+            ]],
+            "fields": fields,
+        ])
+    }
+
+    func testCellRequiredLogic_mixedSiblingAndPageField_bothMatch_makesRequired() {
+        // enforce AND: sibling flag == "yes" AND page number1 == 100. Both true -> required -> empty cell invalid.
+        let editor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "and",
+            siblingValue: "yes", conditionSiblingValue: "yes",
+            pageNumberValue: 100, conditionPageNumberValue: 100
+        ))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    func testCellRequiredLogic_mixedSiblingAndPageField_pageFieldMissesUnderAnd_fallsBack() {
+        // enforce AND: sibling flag == "yes" (true) AND page number1 == 100 (false, is 10).
+        // AND fails -> falls back to column base (no column logic, static false) -> optional -> valid.
+        let editor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "and",
+            siblingValue: "yes", conditionSiblingValue: "yes",
+            pageNumberValue: 10, conditionPageNumberValue: 100
+        ))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
+    }
+
+    func testCellRequiredLogic_mixedConditions_fallBackToColumnStaticRequired() {
+        // Mirrors the sample JSON: cell enforce-AND fails (number1 != 100), so we fall back to the
+        // column base. Column requiredLogic is unenforce on page dropdown = Yes but dropdown = No, so
+        // it also fails and falls back to the column's static required:true -> required -> invalid.
+        let editor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "and",
+            siblingValue: "No", conditionSiblingValue: "No",
+            pageNumberValue: 10, conditionPageNumberValue: 100,
+            columnRequiredLogic: requiredLogic(action: "unenforce", condField: dropdownFieldID, value: optYes),
+            columnStaticRequired: true,
+            includePageDropdown: true, dropdownValue: optNo
+        ))
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
+    }
+
+    func testCellRequiredLogic_pageFieldDependency_refreshesOwningTable() {
+        // A change to the page field referenced by cellRequiredLogic must mark the table for refresh.
+        let editor = documentEditor(document: makeMixedCellDoc(
+            cellAction: "enforce", cellEval: "and",
+            siblingValue: "yes", conditionSiblingValue: "yes",
+            pageNumberValue: 10, conditionPageNumberValue: 100
+        ))
+        let refreshed = editor.requiredLogicHandler.fieldsNeedsToBeRefreshed(fieldID: "number1")
+        XCTAssertTrue(refreshed.contains(tableFieldID))
     }
 
     // MARK: - Table: additional column / cell coverage
@@ -275,7 +401,7 @@ final class RequiredLogicTests: XCTestCase {
         let textColumn: [String: Any] = [
             "_id": textColumnID, "type": "text", "title": "Text",
             "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes),
-            "cellRequiredLogic": requiredLogic(action: "enforce", condField: ddColumnID, value: optYes)
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: ddColumnID, value: optYes)
         ]
         let rows: [[String: Any]] = [["_id": "row-1", "cells": [textColumnID: "", ddColumnID: optYes]]]
         let editor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
@@ -412,7 +538,7 @@ final class RequiredLogicTests: XCTestCase {
     func testCollection_cellRequiredLogic_siblingPerRow() {
         let rootText: [String: Any] = [
             "_id": rootTextCol, "type": "text", "title": "Text",
-            "cellRequiredLogic": requiredLogic(action: "enforce", condField: rootDdCol, value: optYes)
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: rootDdCol, value: optYes)
         ]
         let rootDd: [String: Any] = ["_id": rootDdCol, "type": "dropdown", "title": "DD",
                                      "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]]
@@ -430,7 +556,7 @@ final class RequiredLogicTests: XCTestCase {
         let childText: [String: Any] = ["_id": childTextCol, "type": "text", "title": "Child Text"]
         let childNotes: [String: Any] = [
             "_id": childNotesCol, "type": "text", "title": "Notes",
-            "cellRequiredLogic": requiredLogic(action: "enforce", condField: childTextCol, value: "", condition: "*=")
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: childTextCol, value: "", condition: "*=")
         ]
         let rootRows: [[String: Any]] = [[
             "_id": "root-1", "cells": [:],
@@ -449,7 +575,7 @@ final class RequiredLogicTests: XCTestCase {
         let rootText: [String: Any] = [
             "_id": rootTextCol, "type": "text", "title": "Text",
             "requiredLogic": requiredLogic(action: "enforce", condField: dropdownFieldID, value: optYes),
-            "cellRequiredLogic": requiredLogic(action: "enforce", condField: rootDdCol, value: optYes)
+            "cellRequiredLogic": cellRequiredLogic(action: "enforce", condColumn: rootDdCol, value: optYes)
         ]
         let rootDd: [String: Any] = ["_id": rootDdCol, "type": "dropdown", "title": "DD",
                                      "options": [["_id": optYes, "value": "Yes"], ["_id": optNo, "value": "No"]]]

--- a/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/RequiredLogicTests.swift
@@ -5,10 +5,10 @@ import JoyfillModel
 
 /// Tests for `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell).
 ///
-/// Table/collection cell semantics under test:
-///   - cellRequiredLogic, when present, resolves the cell without falling through
-///   - otherwise column requiredLogic, when present, resolves the cell without falling through
-///   - static `required` is used only when no cell or column logic is present
+/// Semantics under test (the action only changes required-ness when its conditions match,
+/// otherwise it falls back to the static `required` flag — matches the Kotlin/JS reference):
+///   - action == "enforce" -> required when conditions match, else static `required`
+///   - action == "unenforce" -> optional when conditions match, else static `required`
 final class RequiredLogicTests: XCTestCase {
     let fileID = "file-1"
     let pageID = "page-1"
@@ -317,9 +317,9 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
     }
 
-    func testCellRequiredLogic_mixedSiblingAndPageField_pageFieldMissesUnderAnd_makesOptional() {
+    func testCellRequiredLogic_mixedSiblingAndPageField_pageFieldMissesUnderAnd_fallsBack() {
         // enforce AND: sibling flag == "yes" (true) AND page number1 == 100 (false, is 10).
-        // AND fails -> cell logic resolves optional without falling through.
+        // AND fails -> falls back to column base (no column logic, static false) -> optional -> valid.
         let editor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "and",
             siblingValue: "yes", conditionSiblingValue: "yes",
@@ -328,9 +328,10 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
-    func testCellRequiredLogic_mixedConditions_doesNotFallBackToColumnStaticRequired() {
-        // Mirrors the sample JSON: cell enforce-AND fails (number1 != 100), so the cell is optional.
-        // Column logic and static required are not consulted when cell logic exists.
+    func testCellRequiredLogic_mixedConditions_fallBackToColumnStaticRequired() {
+        // Mirrors the sample JSON: cell enforce-AND fails (number1 != 100), so we fall back to the
+        // column base. Column requiredLogic is unenforce on page dropdown = Yes but dropdown = No, so
+        // it also fails and falls back to the column's static required:true -> required -> invalid.
         let editor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "and",
             siblingValue: "No", conditionSiblingValue: "No",
@@ -339,7 +340,7 @@ final class RequiredLogicTests: XCTestCase {
             columnStaticRequired: true,
             includePageDropdown: true, dropdownValue: optNo
         ))
-        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .valid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: textColumnID), .invalid)
     }
 
     func testCellRequiredLogic_pageFieldDependency_refreshesOwningTable() {
@@ -362,7 +363,7 @@ final class RequiredLogicTests: XCTestCase {
         ))
         XCTAssertEqual(cellStatus(matchEditor, rowId: "row-1", columnId: textColumnID), .invalid)
 
-        // enforce OR: neither matches -> cell logic resolves optional.
+        // enforce OR: neither matches -> falls back to column base (static false) -> optional.
         let noMatchEditor = documentEditor(document: makeMixedCellDoc(
             cellAction: "enforce", cellEval: "or",
             siblingValue: "no", conditionSiblingValue: "yes",
@@ -371,7 +372,7 @@ final class RequiredLogicTests: XCTestCase {
         XCTAssertEqual(cellStatus(noMatchEditor, rowId: "row-1", columnId: textColumnID), .valid)
     }
 
-    func testCellRequiredLogic_unenforce_matchedMakesOptional_elseStillOptional() {
+    func testCellRequiredLogic_unenforce_matchedMakesOptional_elseFallsBackToColumnStatic() {
         // Column is statically required. Cell unenforce AND [ sibling "yes", page number1 == 100 ].
         // Both match -> unenforce -> optional -> valid.
         let optionalEditor = documentEditor(document: makeMixedCellDoc(
@@ -382,14 +383,14 @@ final class RequiredLogicTests: XCTestCase {
         ))
         XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
 
-        // One condition fails -> cell logic still resolves optional without falling through.
+        // One condition fails -> unenforce doesn't match -> falls back to column static required:true -> invalid.
         let requiredEditor = documentEditor(document: makeMixedCellDoc(
             cellAction: "unenforce", cellEval: "and",
             siblingValue: "yes", conditionSiblingValue: "yes",
             pageNumberValue: 10, conditionPageNumberValue: 100,
             columnStaticRequired: true
         ))
-        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .valid)
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
     }
 
     // MARK: - Sample JSON use case (mixed cell logic + column unenforce + static required)
@@ -444,36 +445,35 @@ final class RequiredLogicTests: XCTestCase {
         ])
     }
 
-    func testSampleJSON_text1CellLogicControlsRows() {
-        // page dropdown = No, number1 = 100. Column unenforce resolves optional, and static required
-        // is ignored because column logic exists.
+    func testSampleJSON_text1RequiredInAllThreeRows() {
+        // page dropdown = No, number1 = 100. Column unenforce doesn't match (dropdown != Yes) ->
+        // column-effective falls back to static required:true.
         let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
-        XCTAssertFalse(editor.isColumnRequired(columnID: "text1", fieldID: tableFieldID))
+        XCTAssertTrue(editor.isColumnRequired(columnID: "text1", fieldID: tableFieldID))
 
         // row-1: cell enforce matches (sibling No + number 100) -> required.
-        // row-2 / row-3: cell logic exists but does not match -> optional.
-        XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
-        for rowId in ["row-2", "row-3"] {
-            XCTAssertEqual(cellStatus(editor, rowId: rowId, columnId: "text1"), .valid,
-                           "text1 should be optional when cell logic does not match in \(rowId)")
+        // row-2 / row-3: cell not matched (dropdown empty) -> fall back to column-effective (required).
+        for rowId in ["row-1", "row-2", "row-3"] {
+            XCTAssertEqual(cellStatus(editor, rowId: rowId, columnId: "text1"), .invalid,
+                           "text1 should be required (empty -> invalid) in \(rowId)")
         }
     }
 
     func testSampleJSON_dynamicFlipAcrossResolutionOrder() {
         let editor = documentEditor(document: makeSampleDoc(pageDropdownValue: pageNo, number1Value: 100))
-        // Baseline: only the matching row is required.
+        // Baseline: every row required.
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
-        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .valid)
+        XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .invalid)
 
         // Flip page dropdown -> Yes: column unenforce now matches -> column-effective becomes optional.
         let ddFI = FieldIdentifier(fieldID: pageDropdownID)
         editor.updateField(event: FieldChangeData(fieldIdentifier: ddFI, updateValue: .string(pageYes)), fieldIdentifier: ddFI)
         // row-1: cell still matches (sibling No + number 100) -> required.
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .invalid)
-        // row-2: cell not matched -> optional.
+        // row-2: cell not matched -> falls back to the now-optional column-effective -> valid.
         XCTAssertEqual(cellStatus(editor, rowId: "row-2", columnId: "text1"), .valid)
 
-        // Change number1 -> 10: row-1 cell AND now fails -> optional.
+        // Change number1 -> 10: row-1 cell AND now fails -> falls back to optional column -> valid.
         let numFI = FieldIdentifier(fieldID: numberFieldID)
         editor.updateField(event: FieldChangeData(fieldIdentifier: numFI, updateValue: .double(10)), fieldIdentifier: numFI)
         XCTAssertEqual(cellStatus(editor, rowId: "row-1", columnId: "text1"), .valid)
@@ -501,7 +501,7 @@ final class RequiredLogicTests: XCTestCase {
         let matchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optYes))
         XCTAssertTrue(matchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(matchEditor, id: "root-1")!))
 
-        // page dropdown = No -> page half of the AND fails -> cell logic resolves optional.
+        // page dropdown = No -> page half of the AND fails -> falls back to column base (static false) -> optional.
         let noMatchEditor = documentEditor(document: makeCollectionDoc(rootColumns: [rootText, rootDd], nestedColumns: minimalNestedColumns, rootRows: rows, includePageDropdown: true, dropdownValue: optNo))
         XCTAssertFalse(noMatchEditor.isCellRequired(columnID: rootTextCol, fieldID: collectionFieldID, schemaKey: rootSchemaID, row: rootRow(noMatchEditor, id: "root-1")!))
     }
@@ -547,9 +547,9 @@ final class RequiredLogicTests: XCTestCase {
         let optionalEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optYes))
         XCTAssertEqual(cellStatus(optionalEditor, rowId: "row-1", columnId: textColumnID), .valid)
 
-        // dropdown = No -> column logic exists but does not require, so static required is ignored.
+        // dropdown = No -> unenforce no match -> static required stays -> empty cell invalid
         let requiredEditor = documentEditor(document: makeTableDoc(textColumn: textColumn, rows: rows, includePageDropdown: true, dropdownValue: optNo))
-        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .valid)
+        XCTAssertEqual(cellStatus(requiredEditor, rowId: "row-1", columnId: textColumnID), .invalid)
     }
 
     func testColumnEnforce_cellFilled_isValid() {

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
@@ -1,0 +1,216 @@
+{
+  "_id": "req_feature_test_0001",
+  "type": "template",
+  "stage": "draft",
+  "identifier": "template_req_feature_test_0001",
+  "name": "Required-Logic Feature Test",
+  "files": [
+    {
+      "_id": "file1",
+      "name": "New File",
+      "version": 1,
+      "styles": { "margin": 4 },
+      "pages": [
+        {
+          "name": "Page 1",
+          "fieldPositions": [
+            { "_id": "fp_num",   "type": "number",     "displayType": "original", "x": 0, "y": 0,  "width": 4, "height": 8,  "field": "number1" },
+            { "_id": "fp_trig",  "type": "text",        "displayType": "original", "x": 0, "y": 8,  "width": 4, "height": 8,  "field": "trigger1" },
+            { "_id": "fp_table", "type": "table",       "displayType": "original", "x": 0, "y": 16, "width": 8, "height": 30, "field": "table1" },
+            { "_id": "fp_coll",  "type": "collection",  "displayType": "original", "x": 0, "y": 46, "width": 8, "height": 82, "field": "collection1" }
+          ],
+          "hidden": false,
+          "width": 816, "height": 1056, "cols": 8, "rowHeight": 8,
+          "layout": "grid", "presentation": "normal", "margin": 0, "padding": 24, "borderWidth": 0,
+          "_id": "page1"
+        }
+      ],
+      "pageOrder": ["page1"],
+      "views": [],
+      "orientation": "portrait"
+    }
+  ],
+  "fields": [
+    {
+      "file": "file1", "_id": "number1", "type": "number",
+      "title": "Number (driver)", "identifier": "field_number1"
+    },
+    {
+      "file": "file1", "_id": "trigger1", "type": "text",
+      "title": "Trigger (driver)", "identifier": "field_trigger1"
+    },
+
+    {
+      "file": "file1", "_id": "table1", "type": "table", "title": "Table",
+      "identifier": "field_table1",
+      "requiredLogic": {
+        "action": "enforce", "eval": "and",
+        "conditions": [ { "field": "trigger1", "condition": "*=" } ]
+      },
+      "tableColumns": [
+        {
+          "_id": "text1", "type": "text", "title": "Col A (column-required when Number filled)",
+          "identifier": "table1_column_text1", "width": 0,
+          "requiredLogic": {
+            "action": "enforce", "eval": "and",
+            "conditions": [ { "field": "number1", "condition": "*=" } ]
+          }
+        },
+        {
+          "_id": "dropdown1", "type": "dropdown", "title": "Col B (static required)",
+          "identifier": "table1_column_dropdown1", "width": 0, "required": true,
+          "options": [
+            { "_id": "optYes", "value": "Yes" },
+            { "_id": "optNo",  "value": "No" }
+          ]
+        },
+        {
+          "_id": "text2", "type": "text", "title": "Col C (cell-required when Col A filled)",
+          "identifier": "table1_column_text2", "width": 0,
+          "cellRequiredLogic": {
+            "action": "enforce", "eval": "and",
+            "conditions": [ { "field": "text1", "condition": "*=" } ]
+          }
+        },
+        {
+          "_id": "text3", "type": "text", "title": "Col D (static required, UNforced when Number empty)",
+          "identifier": "table1_column_text3", "width": 0, "required": true,
+          "requiredLogic": {
+            "action": "unforce", "eval": "and",
+            "conditions": [ { "field": "number1", "condition": "null=" } ]
+          }
+        },
+        {
+          "_id": "text4", "type": "text", "title": "Col E (dual: column enforce Number, cell unforce sibling Col A)",
+          "identifier": "table1_column_text4", "width": 0,
+          "requiredLogic": {
+            "action": "enforce", "eval": "and",
+            "conditions": [ { "field": "number1", "condition": "*=" } ]
+          },
+          "cellRequiredLogic": {
+            "action": "unforce", "eval": "and",
+            "conditions": [ { "field": "text1", "condition": "*=" } ]
+          }
+        }
+      ],
+      "tableColumnOrder": ["text1", "dropdown1", "text2", "text3", "text4"],
+      "value": [
+        { "_id": "rowA", "deleted": false, "cells": { "text1": "filled" } },
+        { "_id": "rowB", "deleted": false, "cells": {} }
+      ],
+      "rowOrder": ["rowA", "rowB"]
+    },
+
+    {
+      "file": "file1", "_id": "collection1", "type": "collection", "title": "Collection",
+      "identifier": "field_collection1",
+      "requiredLogic": {
+        "action": "enforce", "eval": "and",
+        "conditions": [ { "field": "trigger1", "condition": "*=" } ]
+      },
+      "schema": {
+        "rootSchema": {
+          "title": "Main Collection", "root": true, "children": ["childSchema"],
+          "tableColumns": [
+            {
+              "_id": "text1", "type": "text", "title": "Root A (column-required when Number filled)",
+              "identifier": "collection1_column_text1", "width": 0,
+              "requiredLogic": {
+                "action": "enforce", "eval": "and",
+                "conditions": [ { "field": "number1", "condition": "*=" } ]
+              }
+            },
+            {
+              "_id": "dropdown1", "type": "dropdown", "title": "Root B (static required)",
+              "identifier": "collection1_column_dropdown1", "width": 0, "required": true,
+              "options": [
+                { "_id": "optHigh", "value": "High" },
+                { "_id": "optLow",  "value": "Low" }
+              ]
+            },
+            {
+              "_id": "image1", "type": "image", "title": "Root C (cell-required when Root A filled)",
+              "identifier": "collection1_column_image1", "width": 0,
+              "maxImageWidth": 200, "maxImageHeight": 200,
+              "cellRequiredLogic": {
+                "action": "enforce", "eval": "and",
+                "conditions": [ { "field": "text1", "condition": "*=" } ]
+              }
+            },
+            {
+              "_id": "dual1", "type": "text", "title": "Root E (dual: column enforce Number, cell unforce sibling Root A)",
+              "identifier": "collection1_column_dual1", "width": 0,
+              "requiredLogic": {
+                "action": "enforce", "eval": "and",
+                "conditions": [ { "field": "number1", "condition": "*=" } ]
+              },
+              "cellRequiredLogic": {
+                "action": "unforce", "eval": "and",
+                "conditions": [ { "field": "text1", "condition": "*=" } ]
+              }
+            },
+            {
+              "_id": "text3", "type": "text", "title": "Root D (static required, UNforced when Number empty)",
+              "identifier": "collection1_column_text3", "width": 0, "required": true,
+              "requiredLogic": {
+                "action": "unforce", "eval": "and",
+                "conditions": [ { "field": "number1", "condition": "null=" } ]
+              }
+            }
+          ]
+        },
+        "childSchema": {
+          "title": "Child Table", "children": [], "required": true,
+          "tableColumns": [
+            {
+              "_id": "text1", "type": "text", "title": "Child A (static required)",
+              "identifier": "childSchema_column_text1", "width": 0, "required": true
+            },
+            {
+              "_id": "notes1", "type": "text", "title": "Child B (cell-required when Child A filled)",
+              "identifier": "childSchema_column_notes1", "width": 0,
+              "cellRequiredLogic": {
+                "action": "enforce", "eval": "and",
+                "conditions": [ { "field": "text1", "condition": "*=" } ]
+              }
+            },
+            {
+              "_id": "flag1", "type": "text", "title": "Child C (column-required when Number filled)",
+              "identifier": "childSchema_column_flag1", "width": 0,
+              "requiredLogic": {
+                "action": "enforce", "eval": "and",
+                "conditions": [ { "field": "number1", "condition": "*=" } ]
+              }
+            }
+          ]
+        }
+      },
+      "value": [
+        {
+          "_id": "collRoot1",
+          "cells": { "text1": "filled" },
+          "children": {
+            "childSchema": {
+              "value": [
+                { "_id": "collChild1", "cells": { "text1": "childFilled" } },
+                { "_id": "collChild2", "cells": {} }
+              ]
+            }
+          }
+        },
+        {
+          "_id": "collRoot2",
+          "cells": {},
+          "children": {
+            "childSchema": {
+              "value": []
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "formulas": [],
+  "deleted": false,
+  "categories": []
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
@@ -73,22 +73,22 @@
           }
         },
         {
-          "_id": "text3", "type": "text", "title": "Col D (static required, UNforced when Number empty)",
+          "_id": "text3", "type": "text", "title": "Col D (static required, UNenforced when Number empty)",
           "identifier": "table1_column_text3", "width": 0, "required": true,
           "requiredLogic": {
-            "action": "unforce", "eval": "and",
+            "action": "unenforce", "eval": "and",
             "conditions": [ { "field": "number1", "condition": "null=" } ]
           }
         },
         {
-          "_id": "text4", "type": "text", "title": "Col E (dual: column enforce Number, cell unforce sibling Col A)",
+          "_id": "text4", "type": "text", "title": "Col E (dual: column enforce Number, cell unenforce sibling Col A)",
           "identifier": "table1_column_text4", "width": 0,
           "requiredLogic": {
             "action": "enforce", "eval": "and",
             "conditions": [ { "field": "number1", "condition": "*=" } ]
           },
           "cellRequiredLogic": {
-            "action": "unforce", "eval": "and",
+            "action": "unenforce", "eval": "and",
             "conditions": [ { "field": "text1", "condition": "*=" } ]
           }
         }
@@ -138,22 +138,22 @@
               }
             },
             {
-              "_id": "dual1", "type": "text", "title": "Root E (dual: column enforce Number, cell unforce sibling Root A)",
+              "_id": "dual1", "type": "text", "title": "Root E (dual: column enforce Number, cell unenforce sibling Root A)",
               "identifier": "collection1_column_dual1", "width": 0,
               "requiredLogic": {
                 "action": "enforce", "eval": "and",
                 "conditions": [ { "field": "number1", "condition": "*=" } ]
               },
               "cellRequiredLogic": {
-                "action": "unforce", "eval": "and",
+                "action": "unenforce", "eval": "and",
                 "conditions": [ { "field": "text1", "condition": "*=" } ]
               }
             },
             {
-              "_id": "text3", "type": "text", "title": "Root D (static required, UNforced when Number empty)",
+              "_id": "text3", "type": "text", "title": "Root D (static required, UNenforced when Number empty)",
               "identifier": "collection1_column_text3", "width": 0, "required": true,
               "requiredLogic": {
-                "action": "unforce", "eval": "and",
+                "action": "unenforce", "eval": "and",
                 "conditions": [ { "field": "number1", "condition": "null=" } ]
               }
             }

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
@@ -69,7 +69,7 @@
           "identifier": "table1_column_text2", "width": 0,
           "cellRequiredLogic": {
             "action": "enforce", "eval": "and",
-            "conditions": [ { "field": "text1", "condition": "*=" } ]
+            "conditions": [ { "column": "text1", "condition": "*=" } ]
           }
         },
         {
@@ -89,7 +89,7 @@
           },
           "cellRequiredLogic": {
             "action": "unenforce", "eval": "and",
-            "conditions": [ { "field": "text1", "condition": "*=" } ]
+            "conditions": [ { "column": "text1", "condition": "*=" } ]
           }
         }
       ],
@@ -134,7 +134,7 @@
               "maxImageWidth": 200, "maxImageHeight": 200,
               "cellRequiredLogic": {
                 "action": "enforce", "eval": "and",
-                "conditions": [ { "field": "text1", "condition": "*=" } ]
+                "conditions": [ { "column": "text1", "condition": "*=" } ]
               }
             },
             {
@@ -146,7 +146,7 @@
               },
               "cellRequiredLogic": {
                 "action": "unenforce", "eval": "and",
-                "conditions": [ { "field": "text1", "condition": "*=" } ]
+                "conditions": [ { "column": "text1", "condition": "*=" } ]
               }
             },
             {
@@ -171,7 +171,7 @@
               "identifier": "childSchema_column_notes1", "width": 0,
               "cellRequiredLogic": {
                 "action": "enforce", "eval": "and",
-                "conditions": [ { "field": "text1", "condition": "*=" } ]
+                "conditions": [ { "column": "text1", "condition": "*=" } ]
               }
             },
             {

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.json
@@ -91,14 +91,26 @@
             "action": "unenforce", "eval": "and",
             "conditions": [ { "column": "text1", "condition": "*=" } ]
           }
+        },
+        {
+          "_id": "text5", "type": "text", "title": "Col F (cell-required when sibling Dropdown = No AND Number = 100)",
+          "identifier": "table1_column_text5", "width": 0,
+          "cellRequiredLogic": {
+            "action": "enforce", "eval": "and",
+            "conditions": [
+              { "column": "dropdown1", "condition": "=", "value": "optNo" },
+              { "field": "number1", "condition": "=", "value": 100 }
+            ]
+          }
         }
       ],
-      "tableColumnOrder": ["text1", "dropdown1", "text2", "text3", "text4"],
+      "tableColumnOrder": ["text1", "dropdown1", "text2", "text3", "text4", "text5"],
       "value": [
         { "_id": "rowA", "deleted": false, "cells": { "text1": "filled" } },
-        { "_id": "rowB", "deleted": false, "cells": {} }
+        { "_id": "rowB", "deleted": false, "cells": {} },
+        { "_id": "rowC", "deleted": false, "cells": { "dropdown1": "optNo" } }
       ],
-      "rowOrder": ["rowA", "rowB"]
+      "rowOrder": ["rowA", "rowB", "rowC"]
     },
 
     {

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
@@ -1,0 +1,462 @@
+//
+//  RequiredLogic.swift
+//  JoyfillExample
+//
+//  Created by Vivek Mac on 17/07/26.
+//
+
+import XCTest
+import JoyfillModel
+
+final class RequiredLogic: JoyfillUITestsBaseClass {
+
+    private typealias S = DecoratorUITestSupport
+
+    override func getJSONFileNameForTest() -> String {
+        return "RequiredLogic"
+    }
+
+    // MARK: - Page field helpers (number1 / trigger1 are plain TextFields)
+
+    private func setPageText(_ text: String) {
+        scrollToTop()
+        let field = app.textFields["Text"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "trigger1 text field should exist")
+        field.tap()
+        field.typeText(text)
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.3)
+    }
+
+    private func clearPageText() {
+        scrollToTop()
+        let field = app.textFields["Text"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "trigger1 text field should exist")
+        field.tap()
+        field.clearText()
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.3)
+    }
+
+    private func setPageNumber(_ text: String) {
+        scrollToTop()
+        let field = app.textFields["Number"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "number1 field should exist")
+        field.tap()
+        field.typeText(text)
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.3)
+    }
+
+    private func clearPageNumber() {
+        scrollToTop()
+        let field = app.textFields["Number"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "number1 field should exist")
+        field.tap()
+        field.clearText()
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.3)
+    }
+
+    private func rowFormTextCell(_ boundBy: Int) -> XCUIElement {
+        app.textFields.matching(identifier: "EditRowsTextFieldIdentifier").element(boundBy: boundBy)
+    }
+
+    // MARK: - Scrolling
+
+    private func scrollToTop(maxSwipes: Int = 8) {
+        var n = 0
+        let anchor = app.textFields["Number"]
+        while n < maxSwipes && !(anchor.exists && anchor.isHittable) {
+            app.swipeDown()
+            spinRunloop(0.15)
+            n += 1
+        }
+    }
+
+    @discardableResult
+    private func scrollToStaticText(_ label: String, maxSwipes: Int = 8) -> Bool {
+        let el = app.staticTexts[label]
+        var n = 0
+        while n < maxSwipes {
+            if el.exists && el.isHittable { return true }
+            app.swipeUp()
+            spinRunloop(0.15)
+            n += 1
+        }
+        return el.exists
+    }
+
+    // MARK: - Modal navigation
+
+    private func openTable() { S.openTableDetailView(in: app) }
+    private func openCollection() { S.openCollectionDetailView(in: app) }
+
+    private func closeRowForm() {
+        let dismiss = app.buttons["DismissEditSingleRowSheetButtonIdentifier"]
+        if dismiss.waitForExistence(timeout: 2) {
+            dismiss.tap()
+            spinRunloop(0.2)
+        }
+    }
+
+    private func exitModal() {
+        closeRowForm()
+        goBack()
+        spinRunloop(0.3)
+    }
+
+    // MARK: - Asterisk lookup
+
+    private func fieldAsterisk(_ title: String) -> XCUIElement {
+        app.images["RequiredAsterisk_field_\(title)"]
+    }
+
+    private func tableColAsterisk(_ columnID: String) -> XCUIElement {
+        app.images["RequiredAsterisk_col_\(columnID)"]
+    }
+
+    private func collColAsterisk(_ columnID: String) -> XCUIElement {
+        app.images.matching(NSPredicate(format: "identifier BEGINSWITH %@ AND identifier ENDSWITH %@",
+                                        "RequiredAsterisk_col_", "_\(columnID)")).firstMatch
+    }
+
+    private func existsInForm(_ element: XCUIElement, timeout: TimeInterval = 3) -> Bool {
+        if element.waitForExistence(timeout: timeout) { return true }
+        for _ in 0..<4 {
+            app.swipeUp()
+            spinRunloop(0.2)
+            if element.exists { return true }
+        }
+        return element.exists
+    }
+
+    // MARK: - A. Field-level required logic (enforce on trigger1 "is filled")
+
+    func testTableFieldAsterisk_appearsWhenTriggerFilled_disappearsWhenCleared() {
+        // trigger1 empty at launch -> table field is optional -> no asterisk.
+        XCTAssertTrue(app.staticTexts["Table"].waitForExistence(timeout: 5))
+        XCTAssertFalse(fieldAsterisk("Table").exists,
+                       "Table field should have no asterisk while trigger1 is empty")
+
+        // Fill trigger1 -> enforce condition matches -> table becomes required.
+        setPageText("go")
+        XCTAssertTrue(fieldAsterisk("Table").waitForExistence(timeout: 3),
+                      "Table field asterisk should appear after trigger1 is filled")
+
+        // Clear trigger1 -> back to optional -> asterisk removed.
+        clearPageText()
+        XCTAssertTrue(fieldAsterisk("Table").waitForNonExistence(timeout: 3),
+                      "Table field asterisk should disappear after trigger1 is cleared")
+    }
+
+    func testCollectionFieldAsterisk_appearsWhenTriggerFilled_disappearsWhenCleared() {
+        scrollToStaticText("Collection")
+        XCTAssertFalse(fieldAsterisk("Collection").exists,
+                       "Collection field should have no asterisk while trigger1 is empty")
+
+        setPageText("go")
+        scrollToStaticText("Collection")
+        XCTAssertTrue(fieldAsterisk("Collection").waitForExistence(timeout: 3),
+                      "Collection field asterisk should appear after trigger1 is filled")
+
+        clearPageText()
+        scrollToStaticText("Collection")
+        XCTAssertTrue(fieldAsterisk("Collection").waitForNonExistence(timeout: 3),
+                      "Collection field asterisk should disappear after trigger1 is cleared")
+    }
+
+    // MARK: - B. Column-level required logic (table)
+
+    func testTableColumnEnforce_asteriskAppearsWhenNumberFilled() {
+        // Col A (text1): enforce when number1 is filled. Row B has text1 empty.
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (empty)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3),
+                      "Static-required Col B anchor should render in the row-form")
+        XCTAssertFalse(tableColAsterisk("text1").exists,
+                       "Col A should not be required while number1 is empty")
+        exitModal()
+
+        setPageNumber("5")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text1")),
+                      "Col A should become required once number1 is filled")
+    }
+
+    func testTableColumnStaticRequired_asteriskAlwaysPresent() {
+        // Col B (dropdown1): static required:true -> always required.
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (empty dropdown)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3),
+                      "Static-required Col B should always show an asterisk when empty")
+    }
+
+    func testTableColumnUnforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
+        // Col D (text3): static required, but UNforced when number1 is empty.
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (empty)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text3").exists,
+                       "Col D should be optional (unforced) while number1 is empty")
+        exitModal()
+
+        setPageNumber("5")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text3")),
+                      "Col D static-required should apply once number1 is filled (unforce no longer matches)")
+    }
+
+    // MARK: - B. Column-level required logic (collection root)
+
+    func testCollectionRootColumnEnforce_asteriskWhenNumberFilled() {
+        // Root A (text1): enforce when number1 filled. collRoot2 has text1 empty.
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (empty)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3),
+                      "Static-required Root B anchor should render")
+        XCTAssertFalse(collColAsterisk("text1").exists,
+                       "Root A should not be required while number1 is empty")
+        exitModal()
+
+        setPageNumber("5")
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(collColAsterisk("text1")),
+                      "Root A should become required once number1 is filled")
+    }
+
+    func testCollectionRootColumnStaticRequired_asteriskAlwaysPresent() {
+        // Root B (dropdown1): static required.
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (empty)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3),
+                      "Static-required Root B should always show an asterisk when empty")
+    }
+
+    // MARK: - C. Cell-level required logic (per-row, sibling)
+
+    func testTableCellRequired_perRowSibling() {
+        // Col C (text2): cell-required when sibling Col A (text1) is filled in that row.
+        // rowA has text1 filled -> Col C required; rowB has text1 empty -> not required.
+        openTable()
+        S.openTableRowEditForm(rowIndex: 1, in: app) // rowA (text1 filled)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text2")),
+                      "Col C should be required in rowA (sibling Col A filled)")
+        closeRowForm()
+
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (text1 empty)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text2").exists,
+                       "Col C should not be required in rowB (sibling Col A empty)")
+    }
+
+    func testCollectionRootCellRequired_imageSibling() {
+        // Root C (image1): cell-required when sibling Root A (text1) filled.
+        // collRoot1 text1 filled -> required; collRoot2 text1 empty -> not required.
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app) // collRoot1 (text1 filled)
+        XCTAssertTrue(existsInForm(collColAsterisk("image1")),
+                      "Root C should be required in collRoot1 (sibling Root A filled)")
+        closeRowForm()
+
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (text1 empty)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(collColAsterisk("image1").exists,
+                       "Root C should not be required in collRoot2 (sibling Root A empty)")
+    }
+
+    func testCollectionChildCellRequired_notesSibling() {
+        // Child B (notes1): cell-required when sibling Child A (text1) filled.
+        // collChild1 text1 filled -> required; collChild2 text1 empty -> not required.
+        openCollection()
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 1, boundBy: 0, in: app) // collChild1 (text1 filled)
+        XCTAssertTrue(existsInForm(collColAsterisk("notes1")),
+                      "Child B should be required in collChild1 (sibling Child A filled)")
+        closeRowForm()
+
+        S.openCollectionNestedRowEditForm(rowIndex: 2, boundBy: 0, in: app) // collChild2 (text1 empty)
+        XCTAssertTrue(collColAsterisk("text1").waitForExistence(timeout: 3),
+                      "Static-required Child A anchor should render for the empty child row")
+        XCTAssertFalse(collColAsterisk("notes1").exists,
+                       "Child B should not be required in collChild2 (sibling Child A empty)")
+    }
+
+    // MARK: - D. Static required in nested child schema
+
+    func testCollectionChildStaticRequired() {
+        // Child A (text1): static required:true -> asterisk on the empty child row.
+        openCollection()
+        S.expandCollectionRootRow(at: 1, in: app)
+        S.openCollectionNestedRowEditForm(rowIndex: 2, boundBy: 0, in: app) // collChild2 (empty)
+        XCTAssertTrue(existsInForm(collColAsterisk("text1")),
+                      "Static-required Child A should show an asterisk in the empty child row")
+    }
+
+    // MARK: - E. Precedence: cellRequiredLogic overrides column requiredLogic per row
+
+    func testTableCellLogicOverridesColumnLogic_perRow() {
+        // Col E (text4): column enforce when number1 filled; cell UNforce when sibling Col A filled.
+        // With number1 filled: rowA (text1 filled) -> cell unforce wins -> optional (no asterisk);
+        //                      rowB (text1 empty)  -> column rule applies -> required (asterisk).
+        setPageNumber("5")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 1, in: app) // rowA (text1 filled)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text4").exists,
+                       "Col E cell-unforce should override column rule in rowA (sibling filled)")
+        closeRowForm()
+
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (text1 empty)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text4")),
+                      "Col E column rule should apply in rowB (sibling empty, number filled)")
+    }
+
+    func testCollectionCellLogicOverridesColumnLogic_perRow() {
+        // Root E (dual1): column enforce when number1 filled; cell UNforce when sibling Root A filled.
+        setPageNumber("5")
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 1, in: app) // collRoot1 (text1 filled)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(collColAsterisk("dual1").exists,
+                       "Root E cell-unforce should override column rule in collRoot1 (sibling filled)")
+        closeRowForm()
+
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (text1 empty)
+        XCTAssertTrue(existsInForm(collColAsterisk("dual1")),
+                      "Root E column rule should apply in collRoot2 (sibling empty, number filled)")
+    }
+
+    // MARK: - F. Sibling-edit write path: editing a sibling cell drives cell-required-ness
+
+    func testTableCellRequired_updatesAfterSiblingEditedInRowForm() {
+        // Col C (text2): cell-required when sibling Col A (text1) is filled in the same row.
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (text1 empty)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text2").exists,
+                       "Col C should not be required before sibling Col A is filled")
+
+        // Col A (text1) is the first text cell in the row-form; typing commits per keystroke.
+        let colA = rowFormTextCell(0)
+        XCTAssertTrue(colA.waitForExistence(timeout: 3), "Col A text cell should exist in the row-form")
+        colA.tap()
+        colA.typeText("x")
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.4)
+
+        // Reopen the same row so the column titles recompute from the committed value.
+        closeRowForm()
+        S.openTableRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text2")),
+                      "Col C should be required after Col A was filled in the row-form")
+    }
+
+    func testCollectionRootCellRequired_updatesAfterSiblingEditedInRowForm() {
+        // Root C (image1): cell-required when sibling Root A (text1) is filled.
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (text1 empty)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(collColAsterisk("image1").exists,
+                       "Root C should not be required before sibling Root A is filled")
+
+        // Root A (text1) is the first text cell in the collection row-form.
+        let rootA = rowFormTextCell(0)
+        XCTAssertTrue(rootA.waitForExistence(timeout: 3), "Root A text cell should exist in the row-form")
+        rootA.tap()
+        rootA.typeText("x")
+        app.dismissKeyboardIfVisible()
+        spinRunloop(0.4)
+
+        closeRowForm()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(collColAsterisk("image1")),
+                      "Root C should be required after Root A was filled in the row-form")
+    }
+
+    // MARK: - G. Column enforce toggle-off: driver page field cleared removes the asterisk
+
+    func testTableColumnEnforce_toggleOffWhenNumberCleared() {
+        // Col A (text1): enforce when number1 filled. Fill -> asterisk; clear -> asterisk gone.
+        setPageNumber("5")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (empty)
+        XCTAssertTrue(existsInForm(tableColAsterisk("text1")),
+                      "Col A should be required while number1 is filled")
+        exitModal()
+
+        clearPageNumber()
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text1").exists,
+                       "Col A should be optional again after number1 is cleared")
+    }
+
+    func testCollectionRootColumnEnforce_toggleOffWhenNumberCleared() {
+        // Root A (text1): enforce when number1 filled. Fill -> asterisk; clear -> asterisk gone.
+        setPageNumber("5")
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (empty)
+        XCTAssertTrue(existsInForm(collColAsterisk("text1")),
+                      "Root A should be required while number1 is filled")
+        exitModal()
+
+        clearPageNumber()
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(collColAsterisk("text1").exists,
+                       "Root A should be optional again after number1 is cleared")
+    }
+
+    // MARK: - H. Collection parity: root-column unforce & child-column requiredLogic
+
+    func testCollectionRootColumnUnforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
+        // Root D (text3): static required, but UNforced when number1 is empty (parity with table Col D).
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (empty)
+        XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(collColAsterisk("text3").exists,
+                       "Root D should be optional (unforced) while number1 is empty")
+        exitModal()
+
+        setPageNumber("5")
+        openCollection()
+        S.openCollectionRootRowEditForm(rowIndex: 2, in: app)
+        XCTAssertTrue(existsInForm(collColAsterisk("text3")),
+                      "Root D static-required should apply once number1 is filled (unforce no longer matches)")
+    }
+
+    func testCollectionChildColumnEnforce_asteriskWhenNumberFilled() {
+        // Child C (flag1): column-level enforce when number1 filled (child-schema requiredLogic).
+        // expandCollectionRootRow is a toggle, so `openChildRowForm` only expands the root when
+        // the nested edit button isn't already visible — robust whether or not the collection
+        // retains its expanded state across a close/reopen.
+        openCollection()
+        openChildRowForm() // collChild2 (empty)
+        XCTAssertTrue(collColAsterisk("text1").waitForExistence(timeout: 3),
+                      "Static-required Child A anchor should render for the empty child row")
+        XCTAssertFalse(collColAsterisk("flag1").exists,
+                       "Child C should not be required while number1 is empty")
+
+        // Fill number1 in a fresh open, then re-open the child row-form for the positive check.
+        exitModal()
+        setPageNumber("5")
+        openCollection()
+        openChildRowForm()
+        XCTAssertTrue(existsInForm(collColAsterisk("flag1")),
+                      "Child C column enforce should apply once number1 is filled")
+    }
+
+    private func openChildRowForm() {
+        let childEdit = app.images.matching(identifier: "SingleClickEditNestedButton2").firstMatch
+        if !childEdit.waitForExistence(timeout: 1) {
+            S.expandCollectionRootRow(at: 1, in: app)
+        }
+        S.openCollectionNestedRowEditForm(rowIndex: 2, boundBy: 0, in: app)
+    }
+}

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
@@ -193,20 +193,20 @@ final class RequiredLogic: JoyfillUITestsBaseClass {
                       "Static-required Col B should always show an asterisk when empty")
     }
 
-    func testTableColumnUnforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
-        // Col D (text3): static required, but UNforced when number1 is empty.
+    func testTableColumnUnenforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
+        // Col D (text3): static required, but UNenforced when number1 is empty.
         openTable()
         S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (empty)
         XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
         XCTAssertFalse(tableColAsterisk("text3").exists,
-                       "Col D should be optional (unforced) while number1 is empty")
+                       "Col D should be optional (unenforced) while number1 is empty")
         exitModal()
 
         setPageNumber("5")
         openTable()
         S.openTableRowEditForm(rowIndex: 2, in: app)
         XCTAssertTrue(existsInForm(tableColAsterisk("text3")),
-                      "Col D static-required should apply once number1 is filled (unforce no longer matches)")
+                      "Col D static-required should apply once number1 is filled (unenforce no longer matches)")
     }
 
     // MARK: - B. Column-level required logic (collection root)
@@ -299,15 +299,15 @@ final class RequiredLogic: JoyfillUITestsBaseClass {
     // MARK: - E. Precedence: cellRequiredLogic overrides column requiredLogic per row
 
     func testTableCellLogicOverridesColumnLogic_perRow() {
-        // Col E (text4): column enforce when number1 filled; cell UNforce when sibling Col A filled.
-        // With number1 filled: rowA (text1 filled) -> cell unforce wins -> optional (no asterisk);
+        // Col E (text4): column enforce when number1 filled; cell UNenforce when sibling Col A filled.
+        // With number1 filled: rowA (text1 filled) -> cell unenforce wins -> optional (no asterisk);
         //                      rowB (text1 empty)  -> column rule applies -> required (asterisk).
         setPageNumber("5")
         openTable()
         S.openTableRowEditForm(rowIndex: 1, in: app) // rowA (text1 filled)
         XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
         XCTAssertFalse(tableColAsterisk("text4").exists,
-                       "Col E cell-unforce should override column rule in rowA (sibling filled)")
+                       "Col E cell-unenforce should override column rule in rowA (sibling filled)")
         closeRowForm()
 
         S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (text1 empty)
@@ -316,13 +316,13 @@ final class RequiredLogic: JoyfillUITestsBaseClass {
     }
 
     func testCollectionCellLogicOverridesColumnLogic_perRow() {
-        // Root E (dual1): column enforce when number1 filled; cell UNforce when sibling Root A filled.
+        // Root E (dual1): column enforce when number1 filled; cell UNenforce when sibling Root A filled.
         setPageNumber("5")
         openCollection()
         S.openCollectionRootRowEditForm(rowIndex: 1, in: app) // collRoot1 (text1 filled)
         XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
         XCTAssertFalse(collColAsterisk("dual1").exists,
-                       "Root E cell-unforce should override column rule in collRoot1 (sibling filled)")
+                       "Root E cell-unenforce should override column rule in collRoot1 (sibling filled)")
         closeRowForm()
 
         S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (text1 empty)
@@ -413,22 +413,22 @@ final class RequiredLogic: JoyfillUITestsBaseClass {
                        "Root A should be optional again after number1 is cleared")
     }
 
-    // MARK: - H. Collection parity: root-column unforce & child-column requiredLogic
+    // MARK: - H. Collection parity: root-column unenforce & child-column requiredLogic
 
-    func testCollectionRootColumnUnforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
-        // Root D (text3): static required, but UNforced when number1 is empty (parity with table Col D).
+    func testCollectionRootColumnUnenforce_noAsteriskWhenNumberEmpty_appearsWhenFilled() {
+        // Root D (text3): static required, but UNenforced when number1 is empty (parity with table Col D).
         openCollection()
         S.openCollectionRootRowEditForm(rowIndex: 2, in: app) // collRoot2 (empty)
         XCTAssertTrue(collColAsterisk("dropdown1").waitForExistence(timeout: 3))
         XCTAssertFalse(collColAsterisk("text3").exists,
-                       "Root D should be optional (unforced) while number1 is empty")
+                       "Root D should be optional (unenforced) while number1 is empty")
         exitModal()
 
         setPageNumber("5")
         openCollection()
         S.openCollectionRootRowEditForm(rowIndex: 2, in: app)
         XCTAssertTrue(existsInForm(collColAsterisk("text3")),
-                      "Root D static-required should apply once number1 is filled (unforce no longer matches)")
+                      "Root D static-required should apply once number1 is filled (unenforce no longer matches)")
     }
 
     func testCollectionChildColumnEnforce_asteriskWhenNumberFilled() {

--- a/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/RequiredLogicTest/RequiredLogic.swift
@@ -459,4 +459,49 @@ final class RequiredLogic: JoyfillUITestsBaseClass {
         }
         S.openCollectionNestedRowEditForm(rowIndex: 2, boundBy: 0, in: app)
     }
+
+    // MARK: - I. Mixed cell logic: sibling column AND page field (JSON use case)
+
+    func testTableCellMixed_requiredWhenSiblingNoAndNumber100() {
+        openTable()
+        S.openTableRowEditForm(rowIndex: 3, in: app) // rowC (dropdown1 = No)
+        XCTAssertTrue(app.buttons["DismissEditSingleRowSheetButtonIdentifier"].waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text5").exists,
+                       "Col F should be optional while number1 != 100")
+        exitModal()
+
+        // number1 = 100 -> BOTH conditions match in rowC (sibling No + number 100) -> required.
+        setPageNumber("100")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 3, in: app) // rowC
+        XCTAssertTrue(existsInForm(tableColAsterisk("text5")),
+                      "Col F should be required when sibling dropdown == No AND number1 == 100")
+    }
+
+    func testTableCellMixed_optionalWhenSiblingNotNo() {
+        // With number1 = 100 satisfied but sibling dropdown != "No" (rowB has an empty dropdown),
+        // the AND fails -> Col F falls back to its optional base -> no asterisk.
+        setPageNumber("100")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 2, in: app) // rowB (dropdown empty)
+        XCTAssertTrue(tableColAsterisk("dropdown1").waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text5").exists,
+                       "Col F should be optional when sibling dropdown is not 'No', even if number1 == 100")
+    }
+
+    func testTableCellMixed_toggleOffWhenNumberCleared() {
+        setPageNumber("100")
+        openTable()
+        S.openTableRowEditForm(rowIndex: 3, in: app) // rowC
+        XCTAssertTrue(existsInForm(tableColAsterisk("text5")),
+                      "Col F should be required while sibling == No AND number1 == 100")
+        exitModal()
+
+        clearPageNumber()
+        openTable()
+        S.openTableRowEditForm(rowIndex: 3, in: app)
+        XCTAssertTrue(app.buttons["DismissEditSingleRowSheetButtonIdentifier"].waitForExistence(timeout: 3))
+        XCTAssertFalse(tableColAsterisk("text5").exists,
+                       "Col F should be optional again after number1 is cleared")
+    }
 }

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -464,6 +464,13 @@ public struct JoyDocField: Equatable {
         }
     }
     
+    /// Conditional logic that overrides this field's static `required` flag.
+    /// `action` is "enforce" (required when conditions match) or "unforce" (optional when conditions match).
+    public var requiredLogic: Logic? {
+        get { Logic.init(field: dictionary["requiredLogic"] as? [String: Any]) }
+        set { dictionary["requiredLogic"] = newValue?.dictionary }
+    }
+
     public var hidden: Bool? {
         get { dictionary["hidden"] as? Bool }
         set { dictionary["hidden"] = newValue }
@@ -1198,6 +1205,20 @@ public struct FieldTableColumn {
     public var logic: Logic? {
         get { Logic.init(field: dictionary["logic"] as? [String: Any]) }
         set { dictionary["logic"] = newValue?.dictionary }
+    }
+
+    /// Column-wide required logic. Conditions reference page-level fields. `action` is "enforce"/"unforce"
+    /// and overrides the static `required` flag for every cell in the column.
+    public var requiredLogic: Logic? {
+        get { Logic.init(field: dictionary["requiredLogic"] as? [String: Any]) }
+        set { dictionary["requiredLogic"] = newValue?.dictionary }
+    }
+
+    /// Per-cell required logic. Conditions reference sibling column ids and resolve against the
+    /// same row's cell values. Takes precedence over `requiredLogic`/static `required` for that cell.
+    public var cellRequiredLogic: Logic? {
+        get { Logic.init(field: dictionary["cellRequiredLogic"] as? [String: Any]) }
+        set { dictionary["cellRequiredLogic"] = newValue?.dictionary }
     }
 
     /// View types in which this column is force-hidden. Takes precedence over conditional logic.

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -465,7 +465,7 @@ public struct JoyDocField: Equatable {
     }
     
     /// Conditional logic that overrides this field's static `required` flag.
-    /// `action` is "enforce" (required when conditions match) or "unforce" (optional when conditions match).
+    /// `action` is "enforce" (required when conditions match) or "unenforce" (optional when conditions match).
     public var requiredLogic: Logic? {
         get { Logic.init(field: dictionary["requiredLogic"] as? [String: Any]) }
         set { dictionary["requiredLogic"] = newValue?.dictionary }
@@ -1207,7 +1207,7 @@ public struct FieldTableColumn {
         set { dictionary["logic"] = newValue?.dictionary }
     }
 
-    /// Column-wide required logic. Conditions reference page-level fields. `action` is "enforce"/"unforce"
+    /// Column-wide required logic. Conditions reference page-level fields. `action` is "enforce"/"unenforce"
     /// and overrides the static `required` flag for every cell in the column.
     public var requiredLogic: Logic? {
         get { Logic.init(field: dictionary["requiredLogic"] as? [String: Any]) }

--- a/Sources/JoyfillModel/JoyDoc.swift
+++ b/Sources/JoyfillModel/JoyDoc.swift
@@ -926,6 +926,11 @@ public struct Condition: Equatable{
         set { dictionary["field"] = newValue }
     }
     
+    public var column: String? {
+        get { dictionary["column"] as? String }
+        set { dictionary["column"] = newValue }
+    }
+
     public var condition: String? {
         get { dictionary["condition"] as? String }
         set { dictionary["condition"] = newValue }

--- a/Sources/JoyfillUI/View/FieldHeaderView.swift
+++ b/Sources/JoyfillUI/View/FieldHeaderView.swift
@@ -34,6 +34,7 @@ struct FieldHeaderView: View {
                 Image(systemName: "asterisk")
                     .foregroundColor(isFilled ? .gray : .red)
                     .imageScale(.small)
+                    .accessibilityIdentifier("RequiredAsterisk_field_\(fieldHeaderModel?.title ?? "")")
             }
             
             Spacer()

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -305,6 +305,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                 Image(systemName: "asterisk")
                     .foregroundColor(.red)
                     .imageScale(.small)
+                    .accessibilityIdentifier("RequiredAsterisk_col_\(schemaKey)_\(col.id ?? "")")
             }
             
             Text(col.title)

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -290,10 +290,18 @@ struct CollectionEditMultipleRowsSheetView: View {
         viewID = UUID()
     }
     
+    private func isColumnEffectivelyRequired(_ col: FieldTableColumn, schemaKey: String) -> Bool {
+        guard let columnID = col.id else { return col.required ?? false }
+        if viewModel.tableDataModel.selectedRows.count == 1, let rowID = viewModel.tableDataModel.selectedRows.first {
+            return viewModel.isCellRequired(columnID: columnID, rowID: rowID, schemaKey: schemaKey)
+        }
+        return viewModel.tableDataModel.documentEditor?.isColumnRequired(columnID: columnID, fieldID: viewModel.tableDataModel.fieldIdentifier.fieldID, schemaKey: schemaKey) ?? (col.required ?? false)
+    }
+
     @ViewBuilder
     private func fieldTitle(_ col: FieldTableColumn, isCellFilled: Bool, schemaKey: String) -> some View {
         HStack(alignment: .center, spacing: 4) {
-            if let required = col.required, required, !isCellFilled {
+            if isColumnEffectivelyRequired(col, schemaKey: schemaKey), !isCellFilled {
                 Image(systemName: "asterisk")
                     .foregroundColor(.red)
                     .imageScale(.small)

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModelView.swift
@@ -19,8 +19,7 @@ struct CollectionRowView: View {
         LazyHStack(alignment: .top, spacing: 0) {
             ForEach($rowDataModel.cells, id: \.id) { $cellModel in
                 let schemaKey = rowDataModel.rowType.parentSchemaKey.isEmpty ? viewModel.rootSchemaKey : rowDataModel.rowType.parentSchemaKey
-                let column = viewModel.columnsMap["\(schemaKey)_\(cellModel.data.id)"]
-                let showRequired = (column?.required ?? false) && !cellModel.data.isCellFilled
+                let showRequired = viewModel.isCellRequired(columnID: cellModel.data.id, rowID: rowDataModel.rowID, schemaKey: schemaKey) && !cellModel.data.isCellFilled
 
                 CollectionViewCellBuilder(viewModel: viewModel, cellModel: $cellModel)
                     .frame(width: 200, height: 60)

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -48,6 +48,19 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
         return tableDataModel.rowDecorators(forSchemaKey: schemaKey)
     }
 
+    func isCellRequired(columnID: String, rowID: String, schemaKey: String) -> Bool {
+        guard let documentEditor = tableDataModel.documentEditor,
+              let row = rowToValueElementMap[rowID] else {
+            return columnsMap["\(schemaKey)_\(columnID)"]?.required ?? false
+        }
+        return documentEditor.isCellRequired(
+            columnID: columnID,
+            fieldID: tableDataModel.fieldIdentifier.fieldID,
+            schemaKey: schemaKey,
+            row: row
+        )
+    }
+
     func getCollectionCellDecorators(rowIds: [String], columnId: String, schemaKey: String) -> [DecoratorLocal] {
         let columnDecorators = columnsMap["\(schemaKey)_\(columnId)"]?
             .decorators?

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -235,10 +235,18 @@ struct EditMultipleRowsSheetView: View {
         viewID = UUID()
     }
 
+    private func isColumnEffectivelyRequired(_ col: FieldTableColumn) -> Bool {
+        guard let columnID = col.id else { return col.required ?? false }
+        if viewModel.tableDataModel.selectedRows.count == 1, let rowID = viewModel.tableDataModel.selectedRows.first {
+            return viewModel.isCellRequired(columnID: columnID, rowID: rowID)
+        }
+        return viewModel.tableDataModel.documentEditor?.isColumnRequired(columnID: columnID, fieldID: viewModel.tableDataModel.fieldIdentifier.fieldID) ?? (col.required ?? false)
+    }
+
     @ViewBuilder
     private func columnTitle(_ col: FieldTableColumn, isCellFilled: Bool) -> some View {
         HStack(alignment: .center, spacing: 4) {
-            if let required = col.required, required, !isCellFilled {
+            if isColumnEffectivelyRequired(col), !isCellFilled {
                 Image(systemName: "asterisk")
                     .foregroundColor(.red)
                     .imageScale(.small)

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -250,6 +250,7 @@ struct EditMultipleRowsSheetView: View {
                 Image(systemName: "asterisk")
                     .foregroundColor(.red)
                     .imageScale(.small)
+                    .accessibilityIdentifier("RequiredAsterisk_col_\(col.id ?? "")")
             }
 
             Text(viewModel.tableDataModel.getColumnTitle(columnId: col.id ?? ""))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -26,8 +26,9 @@ struct TableRowView : View {
                 .background(Color.rowSelectionBackground(isSelected: isSelected, colorScheme: colorScheme))
                 .border(Color.tableCellBorderColor)
             }
+            let rowElement = viewModel.rowElement(forRowID: rowDataModel.rowID)
             ForEach($rowDataModel.cells, id: \.id) { $cellModel in
-                let showRequired = viewModel.isCellRequired(columnID: cellModel.data.id, rowID: rowDataModel.rowID) && !cellModel.data.isCellFilled
+                let showRequired = viewModel.isCellRequired(columnID: cellModel.data.id, row: rowElement) && !cellModel.data.isCellFilled
                 TableViewCellBuilder(viewModel: viewModel, cellModel: $cellModel)
                     .frame(width: Utility.singleColumnWidth, height: 60)
                     .background(Color.rowSelectionBackground(isSelected: isSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalView.swift
@@ -27,7 +27,7 @@ struct TableRowView : View {
                 .border(Color.tableCellBorderColor)
             }
             ForEach($rowDataModel.cells, id: \.id) { $cellModel in
-                let showRequired = viewModel.tableDataModel.requiredColumnIDs.contains(cellModel.data.id) && !cellModel.data.isCellFilled
+                let showRequired = viewModel.isCellRequired(columnID: cellModel.data.id, rowID: rowDataModel.rowID) && !cellModel.data.isCellFilled
                 TableViewCellBuilder(viewModel: viewModel, cellModel: $cellModel)
                     .frame(width: Utility.singleColumnWidth, height: 60)
                     .background(Color.rowSelectionBackground(isSelected: isSelected, colorScheme: colorScheme))

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -32,6 +32,22 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
         return decoratorsWidth + CGFloat(tableDataModel.tableColumns.count) * Utility.singleColumnWidth
     }
 
+    /// Per-cell required-ness for the live grid border. Honours `cellRequiredLogic`
+    /// (resolved against this row's sibling cells), then the column's `requiredLogic`,
+    /// then the static `required` flag. Falls back to the column-wide set if the row
+    /// value can't be resolved.
+    func isCellRequired(columnID: String, rowID: String) -> Bool {
+        guard let documentEditor = tableDataModel.documentEditor,
+              let row = tableDataModel.valueToValueElements?.first(where: { $0.id == rowID }) else {
+            return tableDataModel.requiredColumnIDs.contains(columnID)
+        }
+        return documentEditor.isCellRequired(
+            columnID: columnID,
+            fieldID: tableDataModel.fieldIdentifier.fieldID,
+            row: row
+        )
+    }
+
     private func refreshRowDecoratorMap() {
         guard let field = tableDataModel.documentEditor?.field(fieldID: tableDataModel.fieldIdentifier.fieldID) else { return }
         tableDataModel.setTableRowDecorators(rowDecorators: field.rowDecorators, rows: tableDataModel.valueToValueElements ?? [])

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -37,8 +37,15 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
     /// then the static `required` flag. Falls back to the column-wide set if the row
     /// value can't be resolved.
     func isCellRequired(columnID: String, rowID: String) -> Bool {
-        guard let documentEditor = tableDataModel.documentEditor,
-              let row = tableDataModel.valueToValueElements?.first(where: { $0.id == rowID }) else {
+        return isCellRequired(columnID: columnID, row: rowElement(forRowID: rowID))
+    }
+
+    func rowElement(forRowID rowID: String) -> ValueElement? {
+        tableDataModel.valueToValueElements?.first(where: { $0.id == rowID })
+    }
+
+    func isCellRequired(columnID: String, row: ValueElement?) -> Bool {
+        guard let documentEditor = tableDataModel.documentEditor, let row = row else {
             return tableDataModel.requiredColumnIDs.contains(columnID)
         }
         return documentEditor.isCellRequired(

--- a/Sources/JoyfillUI/ViewModels/ConditionalLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ConditionalLogicHandler.swift
@@ -527,7 +527,7 @@ class ConditionalLogicHandler {
         }
     }
 
-    private func shoulTakeActionOnThisField(logic: LogicModel) -> Bool {
+    func shoulTakeActionOnThisField(logic: LogicModel) -> Bool {
         guard let conditions = logic.conditions else {
             return false
         }

--- a/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
+++ b/Sources/JoyfillUI/ViewModels/DocumentEditor.swift
@@ -130,6 +130,7 @@ public class DocumentEditor: ObservableObject {
     
     private var validationHandler: ValidationHandler!
     var conditionalLogicHandler: ConditionalLogicHandler!
+    var requiredLogicHandler: RequiredLogicHandler!
     internal var joyDocContext: JoyfillDocContext!
 
     public init(document: JoyDoc,
@@ -173,6 +174,7 @@ public class DocumentEditor: ObservableObject {
         updateFieldMap()
         updateFieldPositionMap()
         self.conditionalLogicHandler = ConditionalLogicHandler(documentEditor: self)
+        self.requiredLogicHandler = RequiredLogicHandler(documentEditor: self)
         guard let firstFile = files.first, let fileID = firstFile.id else {
             return
         }
@@ -274,7 +276,22 @@ public class DocumentEditor: ObservableObject {
     public func shouldShowSchema(for collectionFieldID: String, rowSchemaID: RowSchemaID) -> Bool {
         return conditionalLogicHandler.shouldShowSchema(for: collectionFieldID, rowSchemaID: rowSchemaID)
     }
-    
+
+    /// Effective required-ness of a field, honouring `requiredLogic` (falls back to the static `required` flag).
+    public func isFieldRequired(fieldID: String) -> Bool {
+        return requiredLogicHandler.isFieldRequired(fieldID: fieldID)
+    }
+
+    /// Effective column-wide required-ness, honouring the column's `requiredLogic`.
+    public func isColumnRequired(columnID: String, fieldID: String, schemaKey: String? = nil) -> Bool {
+        return requiredLogicHandler.isColumnRequired(columnID: columnID, fieldID: fieldID, schemaKey: schemaKey)
+    }
+
+    /// Effective required-ness of a single cell, honouring `cellRequiredLogic` (per-row) then `requiredLogic`.
+    public func isCellRequired(columnID: String, fieldID: String, schemaKey: String? = nil, row: ValueElement) -> Bool {
+        return requiredLogicHandler.isCellRequired(columnID: columnID, fieldID: fieldID, schemaKey: schemaKey, row: row)
+    }
+
     public func change(changes: [Change]) {
         for change in changes {
             guard let targetValue = change.target,
@@ -738,7 +755,8 @@ extension DocumentEditor {
     }
     
     func refreshDependent(for fieldID: String) {
-        let refreshFields = conditionalLogicHandler.fieldsNeedsToBeRefreshed(fieldID: fieldID)
+        var refreshFields = Set(conditionalLogicHandler.fieldsNeedsToBeRefreshed(fieldID: fieldID))
+        refreshFields.formUnion(requiredLogicHandler.fieldsNeedsToBeRefreshed(fieldID: fieldID))
         for fieldId in refreshFields {
             refreshField(fieldId: fieldId)
         }
@@ -756,7 +774,7 @@ extension DocumentEditor {
         
         let showTitle = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none")
         
-        var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
+        var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: requiredLogicHandler.isFieldRequired(fieldID: fieldPositionFieldID), tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
         
         switch fieldPosition.type {
         case .text:
@@ -938,7 +956,7 @@ extension DocumentEditor {
             
             let showTitle = (fieldPosition.titleDisplay == nil || fieldPosition.titleDisplay != "none")
             
-            var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: fieldData?.required, tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
+            var fieldHeaderModel = FieldHeaderModel(title: showTitle ? fieldData?.title : nil, required: requiredLogicHandler.isFieldRequired(fieldID: fieldPositionFieldID), tipDescription: fieldData?.tipDescription, tipTitle: fieldData?.tipTitle, tipVisible: fieldData?.tipVisible, decorators: decorators, mode: fieldEditMode, visibleLimitInFields: decoratorConfig.visibleLimitInFields)
             
             dataModelType = getFieldModel(fieldPosition: fieldPosition, fieldIdentifier: fieldIdentifier)
             fieldListModels.append(FieldListModel(fieldIdentifier: fieldIdentifier, fieldEditMode: fieldEditMode, model: dataModelType))
@@ -1266,6 +1284,7 @@ extension DocumentEditor {
         updateFieldMap()
         updateFieldPositionMap()
         self.conditionalLogicHandler = ConditionalLogicHandler(documentEditor: self)
+        self.requiredLogicHandler = RequiredLogicHandler(documentEditor: self)
         if !isMobileViewActive {
             updatePageFieldModels(duplicatedPage, newPageID, firstFile.id ?? "")
         }
@@ -1479,6 +1498,7 @@ extension DocumentEditor {
         
         // 11. Reinitialize conditional logic handler
         self.conditionalLogicHandler = ConditionalLogicHandler(documentEditor: self)
+        self.requiredLogicHandler = RequiredLogicHandler(documentEditor: self)
         
         // 12. Handle navigation
         if shouldNavigate && !nextPageID.isEmpty {

--- a/Sources/JoyfillUI/ViewModels/Models.swift
+++ b/Sources/JoyfillUI/ViewModels/Models.swift
@@ -232,7 +232,7 @@ struct TableDataModel {
                     self.filterModels.append(filterModel)
                 }
             }
-            self.fieldRequired = fieldData.required ?? false
+            self.fieldRequired = documentEditor.isFieldRequired(fieldID: fieldIdentifier.fieldID)
         } else {
             fieldData.tableColumnOrder?.enumerated().forEach() { colIndex, colID in
                 let column = fieldData.tableColumns?.first { $0.id == colID }
@@ -243,7 +243,7 @@ struct TableDataModel {
                 if let columnType = column.type {
                     if supportedColumnTypes.contains(columnType) {
                         tableColumns.append(column)
-                        if column.required == true {
+                        if documentEditor.isColumnRequired(columnID: colID, fieldID: fieldIdentifier.fieldID) {
                             requiredColumnIDs.insert(colID)
                         }
                     }

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -2,12 +2,12 @@
 //  RequiredLogicHandler.swift
 //
 //  Evaluates `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell) to produce
-//  an *effective* required-ness that overrides the static `required` flag.
+//  an *effective* required-ness on top of the static `required` flag.
 //
-//  Semantics (action fully overrides the base `required`):
+//  Semantics (the action only changes required-ness when its conditions match; otherwise it falls back to the static base):
 //    - no logic present            -> static `required`
-//    - action == "enforce"         -> required only when conditions match
-//    - action == "unforce"         -> optional only when conditions match (required otherwise)
+//    - action == "enforce"         -> required when conditions match, else static `required`
+//    - action == "unforce"         -> optional when conditions match, else static `required`
 //
 //  Field / column logic conditions reference page-level fields (by `field` id).
 //  Cell logic conditions reference sibling column ids and resolve against the same row's cells.
@@ -193,8 +193,8 @@ class RequiredLogicHandler {
 
     private func applyAction(_ action: String, matched: Bool, staticRequired: Bool) -> Bool {
         switch action {
-        case "enforce": return matched
-        case "unforce": return !matched
+        case "enforce": return matched ? true : staticRequired
+        case "unforce": return matched ? false : staticRequired
         default: return staticRequired
         }
     }

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -7,7 +7,7 @@
 //  Semantics (the action only changes required-ness when its conditions match; otherwise it falls back to the static base):
 //    - no logic present            -> static `required`
 //    - action == "enforce"         -> required when conditions match, else static `required`
-//    - action == "unforce"         -> optional when conditions match, else static `required`
+//    - action == "unenforce"         -> optional when conditions match, else static `required`
 //
 //  Field / column logic conditions reference page-level fields (by `field` id).
 //  Cell logic conditions reference sibling column ids and resolve against the same row's cells.
@@ -194,7 +194,7 @@ class RequiredLogicHandler {
     private func applyAction(_ action: String, matched: Bool, staticRequired: Bool) -> Bool {
         switch action {
         case "enforce": return matched ? true : staticRequired
-        case "unforce": return matched ? false : staticRequired
+        case "unenforce": return matched ? false : staticRequired
         default: return staticRequired
         }
     }

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -1,0 +1,238 @@
+//
+//  RequiredLogicHandler.swift
+//
+//  Evaluates `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell) to produce
+//  an *effective* required-ness that overrides the static `required` flag.
+//
+//  Semantics (action fully overrides the base `required`):
+//    - no logic present            -> static `required`
+//    - action == "enforce"         -> required only when conditions match
+//    - action == "unforce"         -> optional only when conditions match (required otherwise)
+//
+//  Field / column logic conditions reference page-level fields (by `field` id).
+//  Cell logic conditions reference sibling column ids and resolve against the same row's cells.
+//
+
+import Foundation
+import JoyfillModel
+
+class RequiredLogicHandler {
+    weak var documentEditor: DocumentEditor!
+
+    // Cached effective required state, used to detect changes for dependent-field refresh.
+    private var requiredFieldMap = [String: Bool]()
+    private var requiredColumnMap = [String: [ColumnSchemaID: Bool]]() // fieldID -> column -> required
+
+    // dependentFieldID (a field referenced by some requiredLogic condition) -> owning field/table/collection ids
+    private var requiredDependencyMap = [String: Set<String>]()
+
+    init(documentEditor: DocumentEditor) {
+        self.documentEditor = documentEditor
+        documentEditor.allFields.forEach { field in
+            guard let fieldID = field.id else {
+                Log("Field ID not found", type: .error)
+                return
+            }
+            requiredFieldMap[fieldID] = computeFieldRequired(field: field)
+            registerFieldDependencies(field: field, ownerFieldID: fieldID)
+
+            if field.fieldType == .table {
+                buildColumnRequiredForTable(field: field, fieldID: fieldID)
+            } else if field.fieldType == .collection {
+                buildColumnRequiredForCollection(field: field, fieldID: fieldID)
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Effective required-ness of a field, honouring `requiredLogic`.
+    func isFieldRequired(fieldID: String) -> Bool {
+        guard let field = documentEditor.field(fieldID: fieldID) else { return false }
+        return computeFieldRequired(field: field)
+    }
+
+    /// Effective column-wide required-ness, honouring the column's `requiredLogic`.
+    func isColumnRequired(columnID: String, fieldID: String, schemaKey: String? = nil) -> Bool {
+        guard let column = column(columnID: columnID, fieldID: fieldID, schemaKey: schemaKey) else { return false }
+        return computeColumnRequired(column: column)
+    }
+
+    /// Effective required-ness of a single cell. Precedence: `cellRequiredLogic` (per-row) >
+    /// `requiredLogic` (column-wide) > static `required`.
+    func isCellRequired(columnID: String, fieldID: String, schemaKey: String? = nil, row: ValueElement) -> Bool {
+        guard let column = column(columnID: columnID, fieldID: fieldID, schemaKey: schemaKey) else { return false }
+
+        if let cellLogic = column.cellRequiredLogic, let action = cellLogic.action {
+            let model = cellLogicModel(logic: cellLogic, columns: columns(fieldID: fieldID, schemaKey: schemaKey), row: row)
+            return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: column.required ?? false)
+        }
+        return computeColumnRequired(column: column)
+    }
+
+    /// Fields that must be re-rendered because `fieldID` changed and some requiredLogic depends on it.
+    func fieldsNeedsToBeRefreshed(fieldID: String) -> [String] {
+        guard let owners = requiredDependencyMap[fieldID] else { return [] }
+        var refreshIDs = [String]()
+        for ownerID in owners {
+            guard let field = documentEditor.field(fieldID: ownerID) else { continue }
+            switch field.fieldType {
+            case .table, .collection:
+                var changed = columnRequiredChanged(field: field, fieldID: ownerID)
+                let newFieldRequired = computeFieldRequired(field: field)
+                if requiredFieldMap[ownerID] != newFieldRequired {
+                    requiredFieldMap[ownerID] = newFieldRequired
+                    changed = true
+                }
+                if changed {
+                    refreshIDs.append(ownerID)
+                }
+            default:
+                let newValue = computeFieldRequired(field: field)
+                if requiredFieldMap[ownerID] != newValue {
+                    requiredFieldMap[ownerID] = newValue
+                    refreshIDs.append(ownerID)
+                }
+            }
+        }
+        return refreshIDs
+    }
+
+    // MARK: - Cache building
+
+    private func buildColumnRequiredForTable(field: JoyDocField, fieldID: String) {
+        guard let columns = field.tableColumns else { return }
+        var map = [ColumnSchemaID: Bool]()
+        for column in columns {
+            guard let columnID = column.id else { continue }
+            map[ColumnSchemaID(columnID: columnID)] = computeColumnRequired(column: column)
+            registerColumnDependencies(column: column, ownerFieldID: fieldID)
+        }
+        requiredColumnMap[fieldID] = map
+    }
+
+    private func buildColumnRequiredForCollection(field: JoyDocField, fieldID: String) {
+        guard let schema = field.schema else { return }
+        var map = [ColumnSchemaID: Bool]()
+        for (schemaKey, schemaValue) in schema {
+            guard let columns = schemaValue.tableColumns else { continue }
+            for column in columns {
+                guard let columnID = column.id else { continue }
+                map[ColumnSchemaID(columnID: columnID, schemaID: schemaKey)] = computeColumnRequired(column: column)
+                registerColumnDependencies(column: column, ownerFieldID: fieldID)
+            }
+        }
+        requiredColumnMap[fieldID] = map
+    }
+
+    private func registerFieldDependencies(field: JoyDocField, ownerFieldID: String) {
+        register(logic: field.requiredLogic, ownerFieldID: ownerFieldID)
+    }
+
+    private func registerColumnDependencies(column: FieldTableColumn, ownerFieldID: String) {
+        // Column requiredLogic references page-level fields; register those as dependencies.
+        register(logic: column.requiredLogic, ownerFieldID: ownerFieldID)
+        // cellRequiredLogic references sibling cells within the same row, so a change to the owning
+        // table/collection field already triggers its own refresh — no external dependency to register.
+    }
+
+    private func register(logic: Logic?, ownerFieldID: String) {
+        guard let conditions = logic?.conditions else { return }
+        for condition in conditions {
+            guard let dependentFieldID = condition.field else { continue }
+            var owners = requiredDependencyMap[dependentFieldID] ?? Set<String>()
+            owners.insert(ownerFieldID)
+            requiredDependencyMap[dependentFieldID] = owners
+        }
+    }
+
+    private func columnRequiredChanged(field: JoyDocField, fieldID: String) -> Bool {
+        var map = requiredColumnMap[fieldID] ?? [:]
+        var hasChange = false
+
+        func check(column: FieldTableColumn, schemaKey: String?) {
+            guard let columnID = column.id else { return }
+            let key = ColumnSchemaID(columnID: columnID, schemaID: schemaKey)
+            let newValue = computeColumnRequired(column: column)
+            if map[key] != newValue {
+                map[key] = newValue
+                hasChange = true
+            }
+        }
+
+        switch field.fieldType {
+        case .table:
+            for column in field.tableColumns ?? [] { check(column: column, schemaKey: nil) }
+        case .collection:
+            for (schemaKey, schemaValue) in field.schema ?? [:] {
+                for column in schemaValue.tableColumns ?? [] { check(column: column, schemaKey: schemaKey) }
+            }
+        default:
+            break
+        }
+
+        if hasChange { requiredColumnMap[fieldID] = map }
+        return hasChange
+    }
+
+    // MARK: - Effective-required computation
+
+    private func computeFieldRequired(field: JoyDocField) -> Bool {
+        let staticRequired = field.required ?? false
+        guard let logic = field.requiredLogic, let action = logic.action else { return staticRequired }
+        let model = fieldLogicModel(logic: logic)
+        return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: staticRequired)
+    }
+
+    private func computeColumnRequired(column: FieldTableColumn) -> Bool {
+        let staticRequired = column.required ?? false
+        guard let logic = column.requiredLogic, let action = logic.action else { return staticRequired }
+        let model = fieldLogicModel(logic: logic)
+        return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: staticRequired)
+    }
+
+    private func applyAction(_ action: String, matched: Bool, staticRequired: Bool) -> Bool {
+        switch action {
+        case "enforce": return matched
+        case "unforce": return !matched
+        default: return staticRequired
+        }
+    }
+
+    // MARK: - Logic-model builders
+
+    /// Builds a model for field/column requiredLogic whose conditions reference page-level fields.
+    private func fieldLogicModel(logic: Logic) -> LogicModel {
+        let conditionModels = (logic.conditions ?? []).compactMap { condition -> ConditionModel? in
+            guard let conditionFieldID = condition.field,
+                  let conditionField = documentEditor.field(fieldID: conditionFieldID) else { return nil }
+            return ConditionModel(fieldValue: conditionField.value, fieldType: FieldTypes(conditionField.type), condition: condition.condition, value: condition.value)
+        }
+        return LogicModel(id: logic.id, action: logic.action, eval: logic.eval, conditions: conditionModels)
+    }
+
+    /// Builds a model for cellRequiredLogic whose conditions reference sibling column ids in the same row.
+    private func cellLogicModel(logic: Logic, columns: [FieldTableColumn], row: ValueElement) -> LogicModel {
+        let conditionModels = (logic.conditions ?? []).compactMap { condition -> ConditionModel? in
+            guard let siblingColumnID = condition.field else { return nil }
+            let columnType = columns.first(where: { $0.id == siblingColumnID })?.type?.toFieldType ?? .unknown
+            let cellValue = row.cells?[siblingColumnID]
+            return ConditionModel(fieldValue: cellValue, fieldType: columnType, condition: condition.condition, value: condition.value)
+        }
+        return LogicModel(id: logic.id, action: logic.action, eval: logic.eval, conditions: conditionModels)
+    }
+
+    // MARK: - Lookups
+
+    private func columns(fieldID: String, schemaKey: String?) -> [FieldTableColumn] {
+        guard let field = documentEditor.field(fieldID: fieldID) else { return [] }
+        if let schemaKey = schemaKey {
+            return field.schema?[schemaKey]?.tableColumns ?? []
+        }
+        return field.tableColumns ?? []
+    }
+
+    private func column(columnID: String, fieldID: String, schemaKey: String?) -> FieldTableColumn? {
+        return columns(fieldID: fieldID, schemaKey: schemaKey).first(where: { $0.id == columnID })
+    }
+}

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -65,7 +65,7 @@ class RequiredLogicHandler {
 
         if let cellLogic = column.cellRequiredLogic, let action = cellLogic.action {
             let model = cellLogicModel(logic: cellLogic, columns: columns(fieldID: fieldID, schemaKey: schemaKey), row: row)
-            return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: column.required ?? false)
+            return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: computeColumnRequired(column: column))
         }
         return computeColumnRequired(column: column)
     }

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -26,6 +26,9 @@ class RequiredLogicHandler {
     // dependentFieldID (a field referenced by some requiredLogic condition) -> owning field/table/collection ids
     private var requiredDependencyMap = [String: Set<String>]()
 
+    // dependentFieldID (a page field referenced by some cellRequiredLogic condition) -> owning table/collection ids
+    private var cellRequiredDependencyMap = [String: Set<String>]()
+
     init(documentEditor: DocumentEditor) {
         self.documentEditor = documentEditor
         documentEditor.allFields.forEach { field in
@@ -72,13 +75,19 @@ class RequiredLogicHandler {
 
     /// Fields that must be re-rendered because `fieldID` changed and some requiredLogic depends on it.
     func fieldsNeedsToBeRefreshed(fieldID: String) -> [String] {
-        guard let owners = requiredDependencyMap[fieldID] else { return [] }
+        let cellOwners = cellRequiredDependencyMap[fieldID] ?? Set<String>()
+        var owners = requiredDependencyMap[fieldID] ?? Set<String>()
+        owners.formUnion(cellOwners)
+        guard !owners.isEmpty else { return [] }
         var refreshIDs = [String]()
         for ownerID in owners {
             guard let field = documentEditor.field(fieldID: ownerID) else { continue }
             switch field.fieldType {
             case .table, .collection:
                 var changed = columnRequiredChanged(field: field, fieldID: ownerID)
+                // Cell-level logic is per-row and evaluated lazily, so column/field recomputation can't
+                // observe it — if this change touches a cell-logic dependency, force a refresh.
+                if cellOwners.contains(ownerID) { changed = true }
                 let newFieldRequired = computeFieldRequired(field: field)
                 if requiredFieldMap[ownerID] != newFieldRequired {
                     requiredFieldMap[ownerID] = newFieldRequired
@@ -132,8 +141,11 @@ class RequiredLogicHandler {
     private func registerColumnDependencies(column: FieldTableColumn, ownerFieldID: String) {
         // Column requiredLogic references page-level fields; register those as dependencies.
         register(logic: column.requiredLogic, ownerFieldID: ownerFieldID)
-        // cellRequiredLogic references sibling cells within the same row, so a change to the owning
-        // table/collection field already triggers its own refresh — no external dependency to register.
+        // cellRequiredLogic resolves sibling-cell (`column`) conditions from the row itself — a change
+        // there already refreshes the owning table/collection. But it can ALSO reference page-level
+        // fields (`field` conditions); track those separately so an external change forces the owning
+        // table/collection to re-validate its per-row cells.
+        registerCellLogicDependencies(logic: column.cellRequiredLogic, ownerFieldID: ownerFieldID)
     }
 
     private func register(logic: Logic?, ownerFieldID: String) {
@@ -143,6 +155,18 @@ class RequiredLogicHandler {
             var owners = requiredDependencyMap[dependentFieldID] ?? Set<String>()
             owners.insert(ownerFieldID)
             requiredDependencyMap[dependentFieldID] = owners
+        }
+    }
+
+    private func registerCellLogicDependencies(logic: Logic?, ownerFieldID: String) {
+        guard let conditions = logic?.conditions else { return }
+        for condition in conditions {
+            // Only `field` (page-level) conditions are external dependencies; `column` (sibling) ones
+            // resolve from the row itself.
+            guard let dependentFieldID = condition.field else { continue }
+            var owners = cellRequiredDependencyMap[dependentFieldID] ?? Set<String>()
+            owners.insert(ownerFieldID)
+            cellRequiredDependencyMap[dependentFieldID] = owners
         }
     }
 
@@ -211,13 +235,20 @@ class RequiredLogicHandler {
         return LogicModel(id: logic.id, action: logic.action, eval: logic.eval, conditions: conditionModels)
     }
 
-    /// Builds a model for cellRequiredLogic whose conditions reference sibling column ids in the same row.
+    /// Builds a model for cellRequiredLogic. Each condition is resolved by kind:
+    ///   - `column` -> a sibling cell in the same row (resolved against `row.cells`)
+    ///   - `field`  -> a page-level field (resolved against the document)
     private func cellLogicModel(logic: Logic, columns: [FieldTableColumn], row: ValueElement) -> LogicModel {
         let conditionModels = (logic.conditions ?? []).compactMap { condition -> ConditionModel? in
-            guard let siblingColumnID = condition.field else { return nil }
-            let columnType = columns.first(where: { $0.id == siblingColumnID })?.type?.toFieldType ?? .unknown
-            let cellValue = row.cells?[siblingColumnID]
-            return ConditionModel(fieldValue: cellValue, fieldType: columnType, condition: condition.condition, value: condition.value)
+            if let siblingColumnID = condition.column {
+                let columnType = columns.first(where: { $0.id == siblingColumnID })?.type?.toFieldType ?? .unknown
+                let cellValue = row.cells?[siblingColumnID]
+                return ConditionModel(fieldValue: cellValue, fieldType: columnType, condition: condition.condition, value: condition.value)
+            } else if let conditionFieldID = condition.field,
+                      let conditionField = documentEditor.field(fieldID: conditionFieldID) {
+                return ConditionModel(fieldValue: conditionField.value, fieldType: FieldTypes(conditionField.type), condition: condition.condition, value: condition.value)
+            }
+            return nil
         }
         return LogicModel(id: logic.id, action: logic.action, eval: logic.eval, conditions: conditionModels)
     }

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -2,12 +2,12 @@
 //  RequiredLogicHandler.swift
 //
 //  Evaluates `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell) to produce
-//  an *effective* required-ness on top of the static `required` flag.
+//  an *effective* required-ness.
 //
-//  Semantics (the action only changes required-ness when its conditions match; otherwise it falls back to the static base):
-//    - no logic present            -> static `required`
-//    - action == "enforce"         -> required when conditions match, else static `required`
-//    - action == "unenforce"         -> optional when conditions match, else static `required`
+//  Table/collection cell resolution order:
+//    - cellRequiredLogic present   -> resolve that logic for this row
+//    - else requiredLogic present  -> resolve column-wide logic
+//    - else                        -> static `required`
 //
 //  Field / column logic conditions reference page-level fields (by `field` id).
 //  Cell logic conditions reference sibling column ids and resolve against the same row's cells.
@@ -68,7 +68,7 @@ class RequiredLogicHandler {
 
         if let cellLogic = column.cellRequiredLogic, let action = cellLogic.action {
             let model = cellLogicModel(logic: cellLogic, columns: columns(fieldID: fieldID, schemaKey: schemaKey), row: row)
-            return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: computeColumnRequired(column: column))
+            return resolveLogicAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model))
         }
         return computeColumnRequired(column: column)
     }
@@ -209,10 +209,9 @@ class RequiredLogicHandler {
     }
 
     private func computeColumnRequired(column: FieldTableColumn) -> Bool {
-        let staticRequired = column.required ?? false
-        guard let logic = column.requiredLogic, let action = logic.action else { return staticRequired }
+        guard let logic = column.requiredLogic, let action = logic.action else { return column.required ?? false }
         let model = fieldLogicModel(logic: logic)
-        return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: staticRequired)
+        return resolveLogicAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model))
     }
 
     private func applyAction(_ action: String, matched: Bool, staticRequired: Bool) -> Bool {
@@ -220,6 +219,14 @@ class RequiredLogicHandler {
         case "enforce": return matched ? true : staticRequired
         case "unenforce": return matched ? false : staticRequired
         default: return staticRequired
+        }
+    }
+
+    private func resolveLogicAction(_ action: String, matched: Bool) -> Bool {
+        switch action {
+        case "enforce": return matched
+        case "unenforce": return false
+        default: return false
         }
     }
 

--- a/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/RequiredLogicHandler.swift
@@ -2,12 +2,12 @@
 //  RequiredLogicHandler.swift
 //
 //  Evaluates `requiredLogic` (fields, columns) and `cellRequiredLogic` (per-cell) to produce
-//  an *effective* required-ness.
+//  an *effective* required-ness on top of the static `required` flag.
 //
-//  Table/collection cell resolution order:
-//    - cellRequiredLogic present   -> resolve that logic for this row
-//    - else requiredLogic present  -> resolve column-wide logic
-//    - else                        -> static `required`
+//  Semantics (the action only changes required-ness when its conditions match; otherwise it falls back to the static base):
+//    - no logic present            -> static `required`
+//    - action == "enforce"         -> required when conditions match, else static `required`
+//    - action == "unenforce"         -> optional when conditions match, else static `required`
 //
 //  Field / column logic conditions reference page-level fields (by `field` id).
 //  Cell logic conditions reference sibling column ids and resolve against the same row's cells.
@@ -68,7 +68,7 @@ class RequiredLogicHandler {
 
         if let cellLogic = column.cellRequiredLogic, let action = cellLogic.action {
             let model = cellLogicModel(logic: cellLogic, columns: columns(fieldID: fieldID, schemaKey: schemaKey), row: row)
-            return resolveLogicAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model))
+            return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: computeColumnRequired(column: column))
         }
         return computeColumnRequired(column: column)
     }
@@ -209,9 +209,10 @@ class RequiredLogicHandler {
     }
 
     private func computeColumnRequired(column: FieldTableColumn) -> Bool {
-        guard let logic = column.requiredLogic, let action = logic.action else { return column.required ?? false }
+        let staticRequired = column.required ?? false
+        guard let logic = column.requiredLogic, let action = logic.action else { return staticRequired }
         let model = fieldLogicModel(logic: logic)
-        return resolveLogicAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model))
+        return applyAction(action, matched: documentEditor.conditionalLogicHandler.shoulTakeActionOnThisField(logic: model), staticRequired: staticRequired)
     }
 
     private func applyAction(_ action: String, matched: Bool, staticRequired: Bool) -> Bool {
@@ -219,14 +220,6 @@ class RequiredLogicHandler {
         case "enforce": return matched ? true : staticRequired
         case "unenforce": return matched ? false : staticRequired
         default: return staticRequired
-        }
-    }
-
-    private func resolveLogicAction(_ action: String, matched: Bool) -> Bool {
-        switch action {
-        case "enforce": return matched
-        case "unenforce": return false
-        default: return false
         }
     }
 

--- a/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
+++ b/Sources/JoyfillUI/ViewModels/ValidationHandler.swift
@@ -174,7 +174,7 @@ class ValidationHandler {
 
     private func validateField(field: JoyDocField, fieldID: String, fieldPosition: FieldPosition, pageId: String?, fieldPositionId: String?) -> FieldValidity? {
         guard let documentEditor = documentEditor else { return nil }
-        let isRequired = field.required ?? false
+        let isRequired = documentEditor.isFieldRequired(fieldID: fieldID)
 
         if field.fieldType == .table {
             return validateTableField(field: field, fieldID: fieldID, fieldPosition: fieldPosition, pageId: pageId, fieldPositionId: fieldPositionId, isFieldRequired: isRequired)
@@ -221,7 +221,7 @@ class ValidationHandler {
             var cellValidities = [CellValidity]()
             for column in visibleColumns {
                 guard let columnID = column.id else { continue }
-                let isRequired = column.required ?? false
+                let isRequired = documentEditor.isCellRequired(columnID: columnID, fieldID: fieldID, row: row)
 
                 if !isRequired {
                     cellValidities.append(CellValidity(status: .valid, columnId: columnID, value: cells[columnID]))
@@ -312,7 +312,7 @@ class ValidationHandler {
                 continue
             }
 
-            let isRequired = column.required ?? false
+            let isRequired = documentEditor.isCellRequired(columnID: columnID, fieldID: fieldID, schemaKey: schemaId, row: row)
             if !isRequired {
                 cellValidities.append(CellValidity(status: .valid, columnId: columnID, value: cells[columnID]))
                 continue


### PR DESCRIPTION
## Context
JoyDoc supports static `required` on fields and table/collection columns, but there was no way to make required-ness *conditional* the way show/hide logic already is. This ticket adds **conditional required-ness**, evaluated on the same condition engine as show/hide logic:

- `requiredLogic` on a **field** and on a **table/collection column**
- `cellRequiredLogic` on a **column**, evaluated **per cell** against sibling cells in the same row

Semantics:
- `action: "enforce"` → required only when conditions match
- `action: "unenforce"` → optional when conditions match (overrides a static `required: true`)
- Cell precedence: `cellRequiredLogic` → column `requiredLogic` → static `required`

## What changed
- **`RequiredLogicHandler.swift` (new)** — evaluates field/column/cell required-ness; `applyAction(action, matched, staticRequired)` maps enforce→`matched`, unenforce→`!matched`. Column logic conditions resolve against page fields; cell logic resolves against sibling column ids in the same row. Collections are evaluated per `schemaKey` (root and child schemas).
- **`DocumentEditor.swift`** — new public entry points: `isFieldRequired`, `isColumnRequired`, `isCellRequired`.
- **`JoyDoc.swift`** — new public model properties: `JoyDocField.requiredLogic`, `FieldTableColumn.requiredLogic`, `FieldTableColumn.cellRequiredLogic`.
- **Table/Collection view models & modal top-nav views** — column titles and the row-edit form now render a required asterisk driven by the computed (not static) required state, with stable `RequiredAsterisk_*` accessibility identifiers.
- **`Models.swift`** — `TableDataModel` now sources `fieldRequired`/`requiredColumnIDs` from the editor's computed logic instead of the static flags.

## Decisions
- **Reused the existing condition/`Logic` model** rather than inventing a parallel schema, so authors use the same condition syntax as show/hide logic and the change is additive/backward-compatible.
- **Cell logic references sibling column ids, not page fields**, so a cell can react to another cell in its own row — required for the per-row use cases.
- **Row-form asterisk recomputes on render/reopen, not live inside an open form.** Values commit per keystroke, but the column-title asterisk re-evaluates on re-render. The reactive UI tests reflect this honestly (edit sibling → dismiss → reopen → assert) rather than asserting a live in-form update that isn't implemented.

## Public API / docs
- **Yes, this is an additive public API change**: 3 new model properties (`requiredLogic` x2, `cellRequiredLogic`) and 3 new `DocumentEditor` methods (`isFieldRequired`/`isColumnRequired`/`isCellRequired`). All additive — no breaking changes.
- Docs should be updated to describe `requiredLogic`/`cellRequiredLogic` and the enforce/unenforce + precedence rules.

## Test coverage
- **Unit:** `RequiredLogicTests.swift` — enforce/unenforce across field, column, and cell levels for both table and collection.
- **UI:** `RequiredLogicTest/RequiredLogic.{swift,json}` — 19 tests covering field/column/cell logic, enforce/unenforce, cell-over-column precedence, sibling-edit reactivity, column-enforce toggle-off, and collection root/child parity. **All 19 pass on iPad Pro 13-inch (M5).**
- No known gaps deferred.

## Media
_To attach: short screen recording of an asterisk appearing/disappearing as a driver field is filled/cleared._

## Reviewer notes
- The UI-test fixture `RequiredLogic.json` must be a member of the **JoyfillExample app target's** Copy Bundle Resources (loaded via `Bundle.main`), not just the UITests target — see the `project.pbxproj` change. The other pbxproj churn is Xcode re-sorting/de-duplicating existing entries; no files were removed.