### PR TITLE
NO-2271: Fix collection/table bulk-edit crash via columnID keying

### DIFF
--- a/JoyfillSwiftUIExample/JoyfillExample/Footer Example/footer-form.json
+++ b/JoyfillSwiftUIExample/JoyfillExample/Footer Example/footer-form.json
@@ -253,6 +253,184 @@
       "title": "Number",
       "identifier": "field_6a35073a49eb2de132410241",
       "required": true
+    },
+    {
+      "file": "695e36f283142b6b2f8bf493",
+      "_id": "6a6304d09b40c4f73c013cd8",
+      "type": "collection",
+      "title": "Collection",
+      "value": [
+        {
+          "_id": "6a6304f6fca52b29024d2dd6",
+          "cells": {},
+          "children": {
+            "level1Table1": {
+              "value": [
+                {
+                  "_id": "6a6304fd9fd1ea0a368a80c1",
+                  "cells": {},
+                  "children": {}
+                }
+              ]
+            }
+          }
+        },
+        {
+          "_id": "6a63050694124c8cacf3d184",
+          "cells": {},
+          "children": {}
+        },
+        {
+          "_id": "6a63050a7398d44bed67125b",
+          "cells": {},
+          "children": {}
+        }
+      ],
+      "schema": {
+        "collectionSchemaId": {
+          "title": "Main Collection",
+          "root": true,
+          "children": [
+            "level1Table1"
+          ],
+          "tableColumns": [
+            {
+              "_id": "6813008e76da519a97819c69",
+              "type": "text",
+              "title": "Text",
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6813008e76da519a97819c69",
+              "width": 0,
+              "required": true
+            },
+            {
+              "_id": "6813008e36be88d98ed5a90a",
+              "type": "dropdown",
+              "title": "Dropdown",
+              "options": [
+                {
+                  "_id": "6813008e634fdf79fe013b42",
+                  "value": "High"
+                },
+                {
+                  "_id": "6813008efb95416fd9326038",
+                  "value": "Medium"
+                },
+                {
+                  "_id": "6813008e095af24f0f0b32f2",
+                  "value": "Low"
+                }
+              ],
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6813008e36be88d98ed5a90a",
+              "width": 0
+            },
+            {
+              "_id": "6813008ea26d706f2a5db2d5",
+              "type": "image",
+              "title": "Image",
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6813008ea26d706f2a5db2d5",
+              "width": 0
+            }
+          ]
+        },
+        "level1Table1": {
+          "title": "New Table",
+          "children": [],
+          "hidden": false,
+          "tableColumns": [
+            {
+              "_id": "6a6304d33ecb5b436339654f",
+              "type": "text",
+              "title": "Text Column",
+              "width": 0,
+              "deleted": false,
+              "required": true
+            },
+            {
+              "_id": "6a6304d5b2d676265439cfff",
+              "type": "dropdown",
+              "title": "Dropdown Column",
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a6304d58be9a86161c8b657",
+                  "value": "Yes",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a6304d5969509d7a9b0f07c",
+                  "value": "No",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a6304d5ed09526aee04b88e",
+                  "value": "N/A",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304d5b2d676265439cfff"
+            },
+            {
+              "_id": "6a6304d7c5310ba46917323d",
+              "type": "multiSelect",
+              "title": "MultiSelect Column",
+              "deleted": false,
+              "width": 0,
+              "options": [
+                {
+                  "_id": "6a6304d72f25df625dbf7780",
+                  "value": "Option 1",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a6304d79172b659b510f2fc",
+                  "value": "Option 2",
+                  "deleted": false
+                },
+                {
+                  "_id": "6a6304d7dab270ac3827c2dd",
+                  "value": "Option 3",
+                  "deleted": false
+                }
+              ],
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304d7c5310ba46917323d"
+            },
+            {
+              "_id": "6a6304d932c0246a9449fb6c",
+              "type": "image",
+              "title": "Image Column",
+              "deleted": false,
+              "width": 0,
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304d932c0246a9449fb6c"
+            },
+            {
+              "_id": "6a6304daa8c379c01628d40f",
+              "type": "number",
+              "title": "Number Column",
+              "deleted": false,
+              "width": 0,
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304daa8c379c01628d40f"
+            },
+            {
+              "_id": "6a6304dc290e19953d95981b",
+              "type": "date",
+              "title": "Date Column",
+              "deleted": false,
+              "width": 0,
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304dc290e19953d95981b"
+            },
+            {
+              "_id": "6a6304de08b4509988e3ae88",
+              "type": "signature",
+              "title": "Signature Column",
+              "width": 0,
+              "deleted": false,
+              "identifier": "6a6304d09b40c4f73c013cd8_column_6a6304de08b4509988e3ae88"
+            }
+          ]
+        }
+      },
+      "identifier": "field_6a6304d09b40c4f73c013cd8"
     }
   ],
   "_id": "695e36f2ec467a1860e1cac8",
@@ -290,6 +468,33 @@
         "rowHeight": 1
       },
       "pages": [
+        {
+          "_id": "6a6304bacc735a050e6f96ff",
+          "name": "Page 1",
+          "width": 816,
+          "height": 1056,
+          "rowHeight": 8,
+          "cols": 8,
+          "fieldPositions": [
+            {
+              "_id": "6a6304d074d76133f2a8e4c6",
+              "type": "collection",
+              "displayType": "original",
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 36,
+              "field": "6a6304d09b40c4f73c013cd8"
+            }
+          ],
+          "layout": "grid",
+          "presentation": "normal",
+          "padding": 24,
+          "deletable": true,
+          "copyable": [
+            "with-values"
+          ]
+        },
         {
           "layout": "grid",
           "height": 1056,
@@ -340,6 +545,7 @@
         }
       ],
       "pageOrder": [
+        "6a6304bacc735a050e6f96ff",
         "695e375da819cd4e2da9161f"
       ],
       "views": [],

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
@@ -544,4 +544,118 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
         let rowIndexForDocument = updatedRowsFromDocumentEditor?.firstIndex(where: {$0.id == "68575bb9cdb3707c78d6b2ff"})
         XCTAssertEqual(rowIndexForDocument, 3, "Value should be equal")
     }
+
+    // MARK: - bulkEdit(changes:) — regression coverage for RUID 5ZYFSV
+    // The reported crash was in CollectionViewModel.bulkEdit, which keyed row edits by
+    // column *index* and read arrays out of bounds. These lock in the columnID-keyed path.
+
+    private let rootTextColumnID = "684c3fedb0afd867adaeb3b4"
+    private let rootRowA = "68575bb9cdb3707c78d6b2ff"
+    private let rootRowB = "685765dcf190077e95796c41"
+    private let rootRowUnselected = "68582dd76e0e93dd2017372a"
+
+    private func cellText(_ documentEditor: DocumentEditor, row: String, column: String) -> String? {
+        documentEditor.field(fieldID: tableFieldID)?.valueToValueElements?
+            .first(where: { $0.id == row })?.cells?[column]?.text
+    }
+
+    private func cellValue(_ documentEditor: DocumentEditor, row: String, column: String) -> ValueUnion? {
+        documentEditor.field(fieldID: tableFieldID)?.valueToValueElements?
+            .first(where: { $0.id == row })?.cells?[column]
+    }
+
+    // Core of the fix: changes are keyed by columnID, so each entry must land in its
+    // own root column across every type in the switch, on all selected rows.
+    func testBulkEdit_mapsEachColumnIDToItsOwnColumnAcrossTypes() async throws {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = try await createCollectionViewModel(documentEditor: documentEditor)
+        sleep(10)
+
+        let dropdownColumnID = "684c3fed52b1d1145f1e2790"
+        let numberColumnID   = "685753044b333dd442ea29d4"
+        let multiColumnID    = "6857530158fb7edb102344fa"
+        let barcodeColumnID  = "68575312d8c5679a05ee29e0"
+        let dropdownOptionID = "684c3fedf47cc0fea6bca947"          // "No D1"
+        let multiOptionIDs   = ["68575301e490d0ce22ae5e7b", "685767dae7cf2193a50ff550"]
+
+        viewModel.tableDataModel.selectedRows = [rootRowA, rootRowB]
+
+        await viewModel.bulkEdit(changes: [
+            rootTextColumnID: .string("BulkText"),
+            dropdownColumnID: .string(dropdownOptionID),
+            numberColumnID:   .double(42),
+            multiColumnID:    .array(multiOptionIDs),
+            barcodeColumnID:  .string("BC-123"),
+        ])
+        waitForMainQueueToDrain()
+
+        for row in [rootRowA, rootRowB] {
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: rootTextColumnID)?.text, "BulkText", "text column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: dropdownColumnID)?.text, dropdownOptionID, "dropdown column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: numberColumnID)?.number, 42, "number column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: multiColumnID)?.multiSelector, multiOptionIDs, "multiSelect column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: barcodeColumnID)?.text, "BC-123", "barcode column on \(row)")
+        }
+    }
+
+    func testBulkEdit_appliesValueToAllSelectedRows() async throws {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = try await createCollectionViewModel(documentEditor: documentEditor)
+        sleep(10)
+
+        let unselectedBefore = cellText(documentEditor, row: rootRowUnselected, column: rootTextColumnID)
+        viewModel.tableDataModel.selectedRows = [rootRowA, rootRowB]
+
+        await viewModel.bulkEdit(changes: [rootTextColumnID: .string("Testing")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rootRowA, column: rootTextColumnID), "Testing", "Selected root row A should get the bulk value")
+        XCTAssertEqual(cellText(documentEditor, row: rootRowB, column: rootTextColumnID), "Testing", "Selected root row B should get the bulk value")
+        XCTAssertEqual(cellText(documentEditor, row: rootRowUnselected, column: rootTextColumnID), unselectedBefore, "Unselected root row must be untouched")
+    }
+
+    func testBulkEdit_unknownColumnID_isNoOpAndDoesNotCrash() async throws {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = try await createCollectionViewModel(documentEditor: documentEditor)
+        sleep(10)
+
+        let before = cellText(documentEditor, row: rootRowA, column: rootTextColumnID)
+        viewModel.tableDataModel.selectedRows = [rootRowA, rootRowB]
+
+        await viewModel.bulkEdit(changes: ["nonexistent-column-id": .string("ShouldNotApply")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rootRowA, column: rootTextColumnID), before, "An unknown columnID must not mutate any cell")
+    }
+
+    func testBulkEdit_emptyChanges_isNoOp() async throws {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = try await createCollectionViewModel(documentEditor: documentEditor)
+        sleep(10)
+
+        let before = cellText(documentEditor, row: rootRowA, column: rootTextColumnID)
+        viewModel.tableDataModel.selectedRows = [rootRowA, rootRowB]
+
+        await viewModel.bulkEdit(changes: [:])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rootRowA, column: rootTextColumnID), before, "Empty changes must be a no-op")
+    }
+
+    func testBulkEdit_rowWithFewerCellsThanColumns_doesNotCrash() async throws {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = try await createCollectionViewModel(documentEditor: documentEditor)
+        sleep(10)
+
+        guard let idx = viewModel.tableDataModel.filteredcellModels.firstIndex(where: { $0.rowID == rootRowA }) else {
+            return XCTFail("Row \(rootRowA) not found in filteredcellModels")
+        }
+        viewModel.tableDataModel.selectedRows = [rootRowA]
+        viewModel.tableDataModel.filteredcellModels[idx].cells = []
+
+        await viewModel.bulkEdit(changes: [rootTextColumnID: .string("Testing")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rootRowA, column: rootTextColumnID), "Testing", "bulkEdit must complete and persist despite a truncated cells array")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/CollectionViewModelDocumentEditorDelegateTests.swift
@@ -550,6 +550,7 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
     // column *index* and read arrays out of bounds. These lock in the columnID-keyed path.
 
     private let rootTextColumnID = "684c3fedb0afd867adaeb3b4"
+    private let rootDateColumnID = "68575306e1f4dc7da46e671b"
     private let rootRowA = "68575bb9cdb3707c78d6b2ff"
     private let rootRowB = "685765dcf190077e95796c41"
     private let rootRowUnselected = "68582dd76e0e93dd2017372a"
@@ -577,6 +578,7 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
         let barcodeColumnID  = "68575312d8c5679a05ee29e0"
         let dropdownOptionID = "684c3fedf47cc0fea6bca947"          // "No D1"
         let multiOptionIDs   = ["68575301e490d0ce22ae5e7b", "685767dae7cf2193a50ff550"]
+        let dateEpochMillis: Double = 1749000000000
 
         viewModel.tableDataModel.selectedRows = [rootRowA, rootRowB]
 
@@ -586,6 +588,7 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
             numberColumnID:   .double(42),
             multiColumnID:    .array(multiOptionIDs),
             barcodeColumnID:  .string("BC-123"),
+            rootDateColumnID: .double(dateEpochMillis),
         ])
         waitForMainQueueToDrain()
 
@@ -595,6 +598,9 @@ final class CollectionViewModelDocumentEditorDelegateTests: XCTestCase {
             XCTAssertEqual(cellValue(documentEditor, row: row, column: numberColumnID)?.number, 42, "number column on \(row)")
             XCTAssertEqual(cellValue(documentEditor, row: row, column: multiColumnID)?.multiSelector, multiOptionIDs, "multiSelect column on \(row)")
             XCTAssertEqual(cellValue(documentEditor, row: row, column: barcodeColumnID)?.text, "BC-123", "barcode column on \(row)")
+            // Exercises makeChangeDict's multi-row timezone-conversion path for .date columns.
+            // Source and target timezone are both TimeZone.current here, so the value round-trips unchanged.
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: rootDateColumnID)?.number, dateEpochMillis, "date column on \(row)")
         }
     }
 

--- a/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
+++ b/JoyfillSwiftUIExample/JoyfillTests/OnChangeHandler/TableViewModelDocumentEditorDelegateTests.swift
@@ -674,4 +674,113 @@ final class TableViewModelDocumentEditorDelegateTests: XCTestCase {
 
         _ = cancellable
     }
+
+    // MARK: - bulkEdit(changes:) — regression coverage for RUID 5ZYFSV
+    // The crash keyed row edits by column *index*; these lock in the columnID-keyed path.
+
+    private let textColumnID = "684c3fedce82027a49234dd3"
+    private let rowA = "684c3fedfed2b76677110b19"
+    private let rowB = "68575b4059f586b81549fc07"
+    private let rowUnselected = "68575b41d49ad2d821193a3d"
+
+    private func cellText(_ documentEditor: DocumentEditor, row: String, column: String) -> String? {
+        documentEditor.field(fieldID: tableFieldID)?.valueToValueElements?
+            .first(where: { $0.id == row })?.cells?[column]?.text
+    }
+
+    private func cellValue(_ documentEditor: DocumentEditor, row: String, column: String) -> ValueUnion? {
+        documentEditor.field(fieldID: tableFieldID)?.valueToValueElements?
+            .first(where: { $0.id == row })?.cells?[column]
+    }
+
+    // Core of the fix: changes are keyed by columnID, so each entry must land in its
+    // own column across every type in the switch, on all selected rows.
+    func testBulkEdit_mapsEachColumnIDToItsOwnColumnAcrossTypes() async {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        let dropdownColumnID = "684c3feda4ab2268f6ac00c8"
+        let numberColumnID   = "685752cf6a8d05a425d48836"
+        let multiColumnID    = "685752c9b183f6583d205cc6"
+        let barcodeColumnID  = "685752d672047e707b378e18"
+        let dropdownOptionID = "684c3fed30e4ee677ad0defe"          // "No D1"
+        let multiOptionIDs   = ["685752c91cb4780a9fb7382a", "685752c903c9a5c96e9a4549"]
+
+        viewModel.tableDataModel.selectedRows = [rowA, rowB]
+
+        await viewModel.bulkEdit(changes: [
+            textColumnID:     .string("BulkText"),
+            dropdownColumnID: .string(dropdownOptionID),
+            numberColumnID:   .double(42),
+            multiColumnID:    .array(multiOptionIDs),
+            barcodeColumnID:  .string("BC-123"),
+        ])
+        waitForMainQueueToDrain()
+
+        for row in [rowA, rowB] {
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: textColumnID)?.text, "BulkText", "text column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: dropdownColumnID)?.text, dropdownOptionID, "dropdown column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: numberColumnID)?.number, 42, "number column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: multiColumnID)?.multiSelector, multiOptionIDs, "multiSelect column on \(row)")
+            XCTAssertEqual(cellValue(documentEditor, row: row, column: barcodeColumnID)?.text, "BC-123", "barcode column on \(row)")
+        }
+    }
+
+    func testBulkEdit_appliesValueToAllSelectedRows() async {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        let unselectedBefore = cellText(documentEditor, row: rowUnselected, column: textColumnID)
+        viewModel.tableDataModel.selectedRows = [rowA, rowB]
+
+        await viewModel.bulkEdit(changes: [textColumnID: .string("Testing")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rowA, column: textColumnID), "Testing", "Selected row A should get the bulk value")
+        XCTAssertEqual(cellText(documentEditor, row: rowB, column: textColumnID), "Testing", "Selected row B should get the bulk value")
+        XCTAssertEqual(cellText(documentEditor, row: rowUnselected, column: textColumnID), unselectedBefore, "Unselected row must be untouched")
+    }
+
+    func testBulkEdit_unknownColumnID_isNoOpAndDoesNotCrash() async {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        let before = cellText(documentEditor, row: rowA, column: textColumnID)
+        viewModel.tableDataModel.selectedRows = [rowA, rowB]
+
+        await viewModel.bulkEdit(changes: ["nonexistent-column-id": .string("ShouldNotApply")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rowA, column: textColumnID), before, "An unknown columnID must not mutate any cell")
+    }
+
+    func testBulkEdit_emptyChanges_isNoOp() async {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        let before = cellText(documentEditor, row: rowA, column: textColumnID)
+        viewModel.tableDataModel.selectedRows = [rowA, rowB]
+
+        await viewModel.bulkEdit(changes: [:])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rowA, column: textColumnID), before, "Empty changes must be a no-op")
+    }
+
+    func testBulkEdit_rowWithFewerCellsThanColumns_doesNotCrash() async {
+        let documentEditor = DocumentEditor(document: createTestDocument(), validateSchema: false)
+        let viewModel = createTableViewModel(documentEditor: documentEditor)
+
+        XCTAssertGreaterThan(viewModel.tableDataModel.tableColumns.count, 0, "Fixture must have columns for this test to be meaningful")
+        guard let idx = viewModel.tableDataModel.cellModels.firstIndex(where: { $0.rowID == rowA }) else {
+            return XCTFail("Row \(rowA) not found in cellModels")
+        }
+        viewModel.tableDataModel.cellModels[idx].cells = []
+        viewModel.tableDataModel.selectedRows = [rowA]
+
+        await viewModel.bulkEdit(changes: [textColumnID: .string("Testing")])
+        waitForMainQueueToDrain()
+
+        XCTAssertEqual(cellText(documentEditor, row: rowA, column: textColumnID), "Testing", "bulkEdit must complete and persist despite a truncated cells array")
+    }
 }

--- a/JoyfillSwiftUIExample/JoyfillUITests/Navigation Goto tests/NavigationGotoUITests.swift
+++ b/JoyfillSwiftUIExample/JoyfillUITests/Navigation Goto tests/NavigationGotoUITests.swift
@@ -110,4 +110,50 @@ final class NavigationGotoUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["1 row selected"].exists)
 
     }
+
+    func testGotoNavigateAndFillCollectionTextFields() throws {
+        app.buttons["SubmitValidateButtonIdentifier"].tap()
+
+        let upButton = app.buttons["UpperNavigationIdentifier"].firstMatch
+        XCTAssertTrue(upButton.waitForExistence(timeout: 5), "Validation navigation did not appear")
+
+        for _ in 0..<4 {
+            guard upButton.isEnabled else { break }
+            upButton.tap()
+            _ = spinRunloop(0.4)
+        }
+
+        var filled = 0
+        var safety = 0
+        while filled < 5 && safety < 12 {
+            guard upButton.isEnabled else { break }
+            upButton.tap()
+            if fillTextCell() { filled += 1 }
+            _ = spinRunloop(0.4)
+            safety += 1
+        }
+
+        XCTAssertEqual(filled, 5, "Expected to fill all five page-1 collection text cells")
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 3),
+                      "App should stay alive through the collection bulk edit")
+    }
+
+    @discardableResult
+    private func fillTextCell() -> Bool {
+        let textField = app.textFields["EditRowsTextFieldIdentifier"].firstMatch
+        if textField.waitForExistence(timeout: 3), textField.isHittable {
+            textField.tap()
+            textField.typeText("Test")
+            app.dismissKeyboardIfVisible()
+            return true
+        }
+        let textView = app.textViews["EditRowsTextFieldIdentifier"].firstMatch
+        if textView.exists, textView.isHittable {
+            textView.tap()
+            textView.typeText("Test")
+            app.dismissKeyboardIfVisible()
+            return true
+        }
+        return false
+    }
 }

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionModalTopNavigationView.swift
@@ -277,7 +277,7 @@ struct CollectionModalTopNavigationView: View {
 struct CollectionEditMultipleRowsSheetView: View {
     @ObservedObject var viewModel: CollectionViewModel
     @Environment(\.presentationMode) var presentationMode
-    @State var changes = [Int: ValueUnion]()
+    @State var changes = [String: ValueUnion]()
     @State private var isLoading = false
     @State private var viewID = UUID() // Unique ID for the view
     @State private var debounceTask: Task<Void, Never>?
@@ -288,6 +288,10 @@ struct CollectionEditMultipleRowsSheetView: View {
 
     private func refreshViewID() {
         viewID = UUID()
+    }
+
+    private func resetChanges() {
+        changes = [:]
     }
     
     @ViewBuilder
@@ -333,7 +337,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                         if !viewModel.tableDataModel.navigationIntent.rowFormOpenedViaGoto {
                             Button(action: {
                                 viewModel.selectUpperRow()
-                                changes = [:]
+                                resetChanges()
                             }, label: {
                                 ZStack {
                                     RoundedRectangle(cornerRadius: 6)
@@ -351,7 +355,7 @@ struct CollectionEditMultipleRowsSheetView: View {
                             
                             Button(action: {
                                 viewModel.selectBelowRow()
-                                changes = [:]
+                                resetChanges()
                             }, label: {
                                 ZStack {
                                     RoundedRectangle(cornerRadius: 6)
@@ -490,6 +494,7 @@ struct CollectionEditMultipleRowsSheetView: View {
             }
         }
         .onChange(of: viewModel.tableDataModel.selectedRows.first ){ _ in
+            resetChanges()
             refreshViewID()
         }
         .onChange(of: viewModel.uuid) { _ in
@@ -514,13 +519,14 @@ struct CollectionEditMultipleRowsSheetView: View {
         let header = viewModel.getHeaderForSelectedRows()
         ForEach(Array(header.columns.enumerated()), id: \.offset) { colIndex, col in
             let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
+            let columnID = col.id ?? ""
             VStack(alignment: .leading, spacing: 16) {
                 if let row = viewModel.tableDataModel.selectedRows.first {
                     let selectedRow = viewModel.tableDataModel.getRowByID(rowID: row)
                     let isUsedForBulkEdit = !(viewModel.tableDataModel.selectedRows.count == 1)
                     if let cell = viewModel.tableDataModel.getDummyNestedCell(col: colIndex, isBulkEdit: isUsedForBulkEdit, rowID: row) {
                         var cellModel = TableCellModel(rowID: row,
-                                                       timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells[colIndex].timezoneId,
+                                                       timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells.first(where: { $0.data.id == columnID })?.timezoneId,
                                                        data: cell,
                                                        documentEditor: viewModel.tableDataModel.documentEditor,
                                                        fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
@@ -533,97 +539,98 @@ struct CollectionEditMultipleRowsSheetView: View {
                             case .text:
                                 if isUsedForBulkEdit {
                                     if !cellDataModel.title.isEmpty {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                    self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                 }
                             case .dropdown:
                                 if isUsedForBulkEdit {
                                     if let dropdownSelectedId = cellDataModel.defaultDropdownSelectedId, !dropdownSelectedId.isEmpty {
-                                        self.changes[colIndex] = ValueUnion.string(dropdownSelectedId)
+                                        self.changes[columnID] = ValueUnion.string(dropdownSelectedId)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = ValueUnion.string(cellDataModel.defaultDropdownSelectedId ?? "")
+                                    self.changes[columnID] = ValueUnion.string(cellDataModel.defaultDropdownSelectedId ?? "")
                                 }
                                 
                             case .date:
                                 if isUsedForBulkEdit {
                                     if let date = cellDataModel.date {
-                                        self.changes[colIndex] = ValueUnion.double(date)
+                                        self.changes[columnID] = ValueUnion.double(date)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = cellDataModel.date.map(ValueUnion.double) ?? .null
+                                    self.changes[columnID] = cellDataModel.date.map(ValueUnion.double) ?? .null
                                 }
                             case .number:
                                 if isUsedForBulkEdit {
                                     if let number = cellDataModel.number {
-                                        self.changes[colIndex] = ValueUnion.double(number)
+                                        self.changes[columnID] = ValueUnion.double(number)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = cellDataModel.number.map(ValueUnion.double) ?? .null
+                                    self.changes[columnID] = cellDataModel.number.map(ValueUnion.double) ?? .null
                                 }
                             case .multiSelect:
                                 if isUsedForBulkEdit {
                                     if let multiSelectValues = cellDataModel.multiSelectValues, !multiSelectValues.isEmpty {
-                                        self.changes[colIndex] = ValueUnion.array(multiSelectValues)
+                                        self.changes[columnID] = ValueUnion.array(multiSelectValues)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = cellDataModel.multiSelectValues.map(ValueUnion.array) ?? .null
+                                    self.changes[columnID] = cellDataModel.multiSelectValues.map(ValueUnion.array) ?? .null
                                 }
                             case .barcode:
                                 if isUsedForBulkEdit {
                                     if !cellDataModel.title.isEmpty {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                    self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                 }
                             case .image:
                                 if isUsedForBulkEdit {
                                     if cellDataModel.valueElements != [] {
-                                        self.changes[colIndex] = ValueUnion.valueElementArray(cellDataModel.valueElements)
+                                        self.changes[columnID] = ValueUnion.valueElementArray(cellDataModel.valueElements)
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = ValueUnion.valueElementArray(cellDataModel.valueElements)
+                                    self.changes[columnID] = ValueUnion.valueElementArray(cellDataModel.valueElements)
                                 }
                             case .signature:
                                 if isUsedForBulkEdit {
                                     if !cellDataModel.title.isEmpty {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title ?? "")
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title ?? "")
                                     } else {
-                                        self.changes.removeValue(forKey: colIndex)
+                                        self.changes.removeValue(forKey: columnID)
                                     }
                                 } else {
-                                    self.changes[colIndex] = ValueUnion.string(cellDataModel.title ?? "")
+                                    self.changes[columnID] = ValueUnion.string(cellDataModel.title ?? "")
                                 }
                                 
                             default:
                                 break
                             }
-                            Task {
+                            Task { @MainActor in
                                 if !isUsedForBulkEdit {
                                     await viewModel.bulkEdit(changes: changes)
+                                    resetChanges()
                                 }
                             }
                         }
                         
                         var isFilledBasedOnChange: Bool {
-                            guard isUsedForBulkEdit, let changeValue = changes[colIndex] else {
+                            guard isUsedForBulkEdit, let changeValue = changes[columnID] else {
                                 return false
                             }
                             

--- a/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/CollectionView/CollectionViewModel.swift
@@ -1784,8 +1784,17 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
 
         for rowId in tableDataModel.selectedRows {
             guard let rowIndex = rowIndexMap[rowId] else { continue }
+            guard rowIndex < updatedCellModels.count,
+                  rowIndex < tableDataModel.filteredcellModels.count else {
+                Log("updateBulkLocalCellModels: rowIndex \(rowIndex) out of bounds (rows: \(updatedCellModels.count)) for row \(rowId)", type: .warning)
+                continue
+            }
             var rowDataModel = tableDataModel.filteredcellModels[rowIndex]
             tableColumns.enumerated().forEach { colIndex, column in
+                guard colIndex < rowDataModel.cells.count else {
+                    Log("updateBulkLocalCellModels: column index \(colIndex) exceeds cell count \(rowDataModel.cells.count) for row \(rowId)", type: .warning)
+                    return
+                }
                 var cellDataModel = rowDataModel.cells[colIndex].data
                 guard let change = newChanges[rowId]?[column.id ?? ""] else { return }
                 switch cellDataModel.type {
@@ -1820,7 +1829,7 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
     }
     
     @MainActor
-    func bulkEdit(changes: [Int: ValueUnion]) async {
+    func bulkEdit(changes: [String: ValueUnion]) async {
         if changes.count == 0 { return }
         isBulkLoading = true
         let tableColumns = self.getTableColumnsForSelectedRows()
@@ -1837,14 +1846,8 @@ class CollectionViewModel: ObservableObject, TableDataViewModelProtocol {
                     tableDataModel.filteredcellModels.enumerated().map { ($1.rowID, $0) }
                 )
 
-                var columnIDChanges = [String: ValueUnion]()
-                changes.forEach { (colIndex: Int, value: ValueUnion) in
-                    guard let cellDataModelId = tableColumns[colIndex].id else { return }
-                    columnIDChanges[cellDataModelId] = value
-                }
-
                 var newChanges: [String: [String: ValueUnion]] = [:]
-                self.makeChangeDict(&newChanges, columnIDChanges, tableColumns, rowIndexMap: rowIndexMap, tableDataModel: tableDataModel)
+                self.makeChangeDict(&newChanges, changes, tableColumns, rowIndexMap: rowIndexMap, tableDataModel: tableDataModel)
 
                 self.updateJSON(newChanges, tableDataModel: tableDataModel)
 

--- a/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableModalTopNavigationView.swift
@@ -223,12 +223,16 @@ struct TableModalTopNavigationView: View {
 struct EditMultipleRowsSheetView: View {
     @ObservedObject var viewModel: TableViewModel
     @Environment(\.presentationMode)  var presentationMode
-    @State var changes = [Int: ValueUnion]()
+    @State var changes = [String: ValueUnion]()
     @State private var viewID = UUID() // Unique ID for the view
     @State private var debounceTask: Task<Void, Never>?
 
     init(viewModel: TableViewModel) {
         self.viewModel =  viewModel
+    }
+
+    private func resetChanges() {
+        changes = [:]
     }
 
     private func refreshViewID() {
@@ -267,7 +271,7 @@ struct EditMultipleRowsSheetView: View {
                             if !viewModel.tableDataModel.navigationIntent.rowFormOpenedViaGoto {
                                 Button(action: {
                                     viewModel.selectUpperRow()
-                                    changes = [:]
+                                    resetChanges()
                                 }, label: {
                                     ZStack {
                                         RoundedRectangle(cornerRadius: 6)
@@ -285,7 +289,7 @@ struct EditMultipleRowsSheetView: View {
                                 
                                 Button(action: {
                                     viewModel.selectBelowRow()
-                                    changes = [:]
+                                    resetChanges()
                                 }, label: {
                                     ZStack {
                                         RoundedRectangle(cornerRadius: 6)
@@ -400,13 +404,14 @@ struct EditMultipleRowsSheetView: View {
             VStack(alignment: .leading, spacing: 16) {
                 ForEach(Array(viewModel.tableDataModel.tableColumns.enumerated()), id: \.offset) { colIndex, col in
                     let isFocused = col.id == viewModel.tableDataModel.navigationIntent.focusColumnId
+                    let columnID = col.id ?? ""
                     VStack(alignment: .leading, spacing: 16) {
                     if let row = viewModel.tableDataModel.selectedRows.first {
                         let selectedRow = viewModel.tableDataModel.getRowByID(rowID: row)
                         let isUsedForBulkEdit = !(viewModel.tableDataModel.selectedRows.count == 1)
                         if let cell = viewModel.tableDataModel.getDummyNestedCell(col: colIndex, isBulkEdit: isUsedForBulkEdit, rowID: row) {
                         var cellModel = TableCellModel(rowID: row,
-                                                       timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells[colIndex].timezoneId,
+                                                       timezoneId: isUsedForBulkEdit ?  nil : selectedRow?.cells.first(where: { $0.data.id == columnID })?.timezoneId,
                                                        data: cell,
                                                        documentEditor: viewModel.tableDataModel.documentEditor,
                                                        fieldIdentifier: viewModel.tableDataModel.fieldIdentifier,
@@ -419,82 +424,82 @@ struct EditMultipleRowsSheetView: View {
                                 case .text:
                                     if isUsedForBulkEdit {
                                         if !cellDataModel.title.isEmpty {
-                                            self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                            self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                     }
                                 case .dropdown:
                                     if isUsedForBulkEdit {
                                         if let dropdownSelectedId = cellDataModel.defaultDropdownSelectedId, !dropdownSelectedId.isEmpty {
-                                            self.changes[colIndex] = ValueUnion.string(dropdownSelectedId)
+                                            self.changes[columnID] = ValueUnion.string(dropdownSelectedId)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.defaultDropdownSelectedId ?? "")
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.defaultDropdownSelectedId ?? "")
                                     }
                                 case .date:
                                     if isUsedForBulkEdit {
                                         if let date = cellDataModel.date {
-                                            self.changes[colIndex] = ValueUnion.double(date)
+                                            self.changes[columnID] = ValueUnion.double(date)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = cellDataModel.date.map(ValueUnion.double) ?? .null
+                                        self.changes[columnID] = cellDataModel.date.map(ValueUnion.double) ?? .null
                                     }
                                 case .number:
                                     if isUsedForBulkEdit {
                                         if let number = cellDataModel.number {
-                                            self.changes[colIndex] = ValueUnion.double(number)
+                                            self.changes[columnID] = ValueUnion.double(number)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = cellDataModel.number.map(ValueUnion.double) ?? .null
+                                        self.changes[columnID] = cellDataModel.number.map(ValueUnion.double) ?? .null
                                     }
                                 case .multiSelect:
                                     if isUsedForBulkEdit {
                                         if let multiSelectValues = cellDataModel.multiSelectValues, !multiSelectValues.isEmpty {
-                                            self.changes[colIndex] = ValueUnion.array(multiSelectValues)
+                                            self.changes[columnID] = ValueUnion.array(multiSelectValues)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = cellDataModel.multiSelectValues.map(ValueUnion.array) ?? .null
+                                        self.changes[columnID] = cellDataModel.multiSelectValues.map(ValueUnion.array) ?? .null
                                     }
                                 case .barcode:
                                     if isUsedForBulkEdit {
                                         if !cellDataModel.title.isEmpty {
-                                            self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                            self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title)
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title)
                                     }
                                 case .image:
                                     if isUsedForBulkEdit {
                                         if cellDataModel.valueElements != [] {
-                                            self.changes[colIndex] = ValueUnion.valueElementArray(cellDataModel.valueElements)
+                                            self.changes[columnID] = ValueUnion.valueElementArray(cellDataModel.valueElements)
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = ValueUnion.valueElementArray(cellDataModel.valueElements)
+                                        self.changes[columnID] = ValueUnion.valueElementArray(cellDataModel.valueElements)
                                     }
                                 case .signature:
                                     if isUsedForBulkEdit {
                                         if !cellDataModel.title.isEmpty {
-                                            self.changes[colIndex] = ValueUnion.string(cellDataModel.title ?? "")
+                                            self.changes[columnID] = ValueUnion.string(cellDataModel.title ?? "")
                                         } else {
-                                            self.changes.removeValue(forKey: colIndex)
+                                            self.changes.removeValue(forKey: columnID)
                                         }
                                     } else {
-                                        self.changes[colIndex] = ValueUnion.string(cellDataModel.title ?? "")
+                                        self.changes[columnID] = ValueUnion.string(cellDataModel.title ?? "")
                                     }
                                 default:
                                     break
@@ -502,11 +507,12 @@ struct EditMultipleRowsSheetView: View {
                                 Task { @MainActor in
                                     if !isUsedForBulkEdit {
                                         await viewModel.bulkEdit(changes: changes)
+                                        resetChanges()
                                     }
                                 }
                             }
                             var isFilledBasedOnChange: Bool {
-                                guard isUsedForBulkEdit, let changeValue = changes[colIndex] else {
+                                guard isUsedForBulkEdit, let changeValue = changes[columnID] else {
                                     return false
                                 }
                                 
@@ -640,6 +646,7 @@ struct EditMultipleRowsSheetView: View {
             }
         }
         .onChange(of: viewModel.tableDataModel.selectedRows.first ){ _ in
+            resetChanges()
             refreshViewID()
         }
         .onChange(of: viewModel.uuid) { _ in

--- a/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
+++ b/Sources/JoyfillUI/View/Fields/TableView/TableViewModel.swift
@@ -430,7 +430,7 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
     }
     
     @MainActor
-    func bulkEdit(changes: [Int: ValueUnion]) async {
+    func bulkEdit(changes: [String: ValueUnion]) async {
         if changes.count == 0 { return }
         isBulkLoading = true
         let tableDataModel = self.tableDataModel
@@ -442,17 +442,13 @@ class TableViewModel: ObservableObject, TableDataViewModelProtocol {
                     cont.resume(returning: (nil, []))
                     return
                 }
-                var columnIDChanges = [String: ValueUnion]()
-                changes.forEach { (colIndex: Int, value: ValueUnion) in
-                    guard let cellDataModelId = tableDataModel.getColumnIDAtIndex(index: colIndex) else { return }
-                    columnIDChanges[cellDataModelId] = value
-                }
+                
                 let rowIndexMap = Dictionary(uniqueKeysWithValues:
                     tableDataModel.cellModels.enumerated().map { ($1.rowID, $0) }
                 )
                 
                 var newChanges: [String: [String: ValueUnion]] = [:]
-                self.makeChangeDict(&newChanges, columnIDChanges, tableDataModel.tableColumns, rowIndexMap: rowIndexMap, tableDataModel: tableDataModel)
+                self.makeChangeDict(&newChanges, changes, tableDataModel.tableColumns, rowIndexMap: rowIndexMap, tableDataModel: tableDataModel)
 
                 let result = tableDataModel.documentEditor?.bulkEdit(changes: newChanges, selectedRows: tableDataModel.selectedRows, fieldIdentifier: tableDataModel.fieldIdentifier, fieldData: tableDataModel.valueToValueElements ?? [])
                 


### PR DESCRIPTION
## Context
Editing a single collection/table row through the goto validation flow (Up/Down navigation into a row form) could crash (RUID 5ZYFSV) in the bulk-edit path. The row form buffered edits keyed by **column index**, but when it renders a nested schema — whose column set and ordering differ from the parent — those indexes no longer line up with the target table's columns, so an edit either lands on the wrong column or reads past the end of the cell array.

## What changed
- **`CollectionEditMultipleRowsSheetView` / `TableEditMultipleRowsSheetView`** (`CollectionModalTopNavigationView.swift`, `TableModalTopNavigationView.swift`): the in-flight `changes` buffer is now `[String: ValueUnion]` keyed by `columnID` instead of `[Int: ValueUnion]` keyed by column index. Added a `resetChanges()` helper and reset the buffer when the selected row changes.
- **`CollectionViewModel.bulkEdit` / `TableViewModel.bulkEdit`**: signature changed from `[Int: ValueUnion]` to `[String: ValueUnion]`; dropped the now-unnecessary index→columnID remap. Added bounds guards in `updateBulkLocalCellModels` (rowIndex and colIndex) that log and skip instead of trapping.
- **Tests**: unit tests (`CollectionViewModelDocumentEditorDelegateTests`, `TableViewModelDocumentEditorDelegateTests`) for columnID keying and the out-of-bounds path; a UI test (`NavigationGotoUITests.testGotoNavigateAndFillCollectionTextFields`) plus a `footer-form.json` fixture with a nested-schema collection.

## Decisions
- **Key by `columnID`, not index.** Column identity is stable across schemas; index is not. Keying by ID removes the fragile index↔column remap entirely rather than patching it.
- **Guard-and-skip over guard-and-crash.** The bounds checks `Log(.warning)` and `continue`/`return` so a stale index degrades to a no-op edit instead of a trap.

## Public API / docs
None. Both `bulkEdit(changes:)` methods are `internal`; the signature change is not part of the public SDK surface, so no docs update is required.

## Test coverage
- Unit: columnID-keyed bulkEdit and out-of-bounds row/column indexes (no crash).
- UI: goto navigation into the nested-schema collection, filling all five page-1 text cells via the live single-row bulkEdit, asserting the app stays alive — passes on iPad Pro 13-inch (M5).
- Covered in this PR; no follow-up tests planned.

## Notes for reviewer
- The UI test deliberately skips the first four Up landings (Number/table/collection1) and fills only the page-1 collection's text cells — that is the schema that triggered the original crash.
- No screen recording embedded here; the XCUITest run video is in the test's `.xcresult` if needed.