### PR TITLE
NO-1508: Fix dead dropdown sheet caused by List row recycling

### DIFF
--- a/Sources/JoyfillUI/View/Fields/DropdownView.swift
+++ b/Sources/JoyfillUI/View/Fields/DropdownView.swift
@@ -1,42 +1,32 @@
 import SwiftUI
 import JoyfillModel
 
-// 1. A lightweight presentation token that decouples from active memory pointers
-enum DropdownPresentationState: Identifiable {
-    case active(model: DropdownDataModel)
-    
-    var id: String {
-        switch self {
-        case .active(let model):
-            return model.fieldIdentifier.fieldID
-        }
-    }
-}
-
 struct DropdownView: View {
     @State var selectedDropdownValueID: String?
-    @State private var presentationState: DropdownPresentationState? = nil
+    /// The row does not own its sheet — see `FieldSheetPresentation` in FormView.
+    @Binding var activeFieldSheet: FieldSheetPresentation?
     @Environment(\.navigationFocusFieldId) private var navigationFocusFieldId
     private var dropdownDataModel: DropdownDataModel
 
     let eventHandler: FieldChangeEvents
 
-    public init(dropdownDataModel: DropdownDataModel, eventHandler: FieldChangeEvents) {
+    public init(dropdownDataModel: DropdownDataModel, eventHandler: FieldChangeEvents, activeFieldSheet: Binding<FieldSheetPresentation?>) {
         self.eventHandler = eventHandler
         self.dropdownDataModel = dropdownDataModel
+        self._activeFieldSheet = activeFieldSheet
         if let value = dropdownDataModel.dropdownValue {
             _selectedDropdownValueID = State(initialValue: value)
         }
     }
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             FieldHeaderView(dropdownDataModel.fieldHeaderModel, isFilled: !(selectedDropdownValueID?.isEmpty ?? true)) { decorator in
                 eventHandler.onDecoratorAction(event: dropdownDataModel.fieldIdentifier, action: decorator.action ?? "")
             }
             Button(action: {
+                activeFieldSheet = FieldSheetPresentation(id: dropdownDataModel.fieldIdentifier.fieldID)
                 eventHandler.onFocus(event: dropdownDataModel.fieldIdentifier)
-                presentationState = .active(model: dropdownDataModel)
             }, label: {
                 HStack {
                     Text(dropdownDataModel.options?.filter {
@@ -52,33 +42,11 @@ struct DropdownView: View {
                 .frame(height: 40)
             })
             .accessibilityIdentifier("Dropdown")
-            .buttonStyle(BorderlessButtonStyle())
             .fieldBorder(isFocused: navigationFocusFieldId == dropdownDataModel.fieldIdentifier.fieldID)
         }
-        .sheet(item: $presentationState) { state in
-            switch state {
-            case .active(let model):
-                if #available(iOS 16, *) {
-                    DropDownOptionList(
-                        dropdownDataModel: model,
-                        initialSelectionID: selectedDropdownValueID,
-                        onSelectionChanged: { newID in
-                            self.selectedDropdownValueID = newID
-                        }
-                    )
-                    .presentationDetents([.medium])
-                } else {
-                    DropDownOptionList(
-                        dropdownDataModel: model,
-                        initialSelectionID: selectedDropdownValueID,
-                        onSelectionChanged: { newID in
-                            self.selectedDropdownValueID = newID
-                        }
-                    )
-                }
-            }
-        }
         .onChange(of: selectedDropdownValueID) { newValue in
+            // Skip if @State already matches the model — means this fire came from a
+            // programmatic sync, not a user tap. Prevents an echo loop.
             if newValue == dropdownDataModel.dropdownValue {
                 return
             }
@@ -98,15 +66,13 @@ struct DropdownView: View {
 struct DropDownOptionList: View {
     @Environment(\.presentationMode) var presentationMode
     private var dropdownDataModel: DropdownDataModel
-    @State private var currentSelectionID: String?
-    let onSelectionChanged: (String?) -> Void
-    
-    public init(dropdownDataModel: DropdownDataModel, initialSelectionID: String?, onSelectionChanged: @escaping (String?) -> Void) {
+    @Binding var selectedDropdownValueID: String?
+
+    public init(dropdownDataModel: DropdownDataModel, selectedDropdownValueID: Binding<String?>) {
         self.dropdownDataModel = dropdownDataModel
-        self._currentSelectionID = State(initialValue: initialSelectionID)
-        self.onSelectionChanged = onSelectionChanged
+        self._selectedDropdownValueID = selectedDropdownValueID
     }
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -118,25 +84,20 @@ struct DropDownOptionList: View {
                         .imageScale(.large)
                 })
                 .padding(.horizontal, 16)
-                .buttonStyle(BorderlessButtonStyle())
             }
             ScrollView {
                 if let options = dropdownDataModel.options?.filter({ !($0.deleted ?? false) }) {
                     ForEach(options) { option in
                         Button(action: {
-                            let targetedID = (currentSelectionID == option.id) ? nil : option.id
-                            
-                            // 1. Update sheet view local state layout immediately
-                            currentSelectionID = targetedID
-                            
-                            // 2. Safely bubble values back to the core parent object
-                            onSelectionChanged(targetedID)
-                            
-                            // 3. Close the modal view cleanly
+                            if selectedDropdownValueID == option.id {
+                                selectedDropdownValueID = nil
+                            } else {
+                                selectedDropdownValueID = option.id
+                            }
                             presentationMode.wrappedValue.dismiss()
                         }, label: {
                             HStack(alignment: .top) {
-                                Image(systemName: (currentSelectionID == option.id) ? "checkmark.circle.fill" : "circle")
+                                Image(systemName: (selectedDropdownValueID == option.id) ? "checkmark.circle.fill" : "circle")
                                     .padding(.top, 4)
                                 Text(option.value ?? "")
                                     .darkLightThemeColor()
@@ -145,9 +106,8 @@ struct DropDownOptionList: View {
                             }
                             .padding(.horizontal, 28)
                             .padding(.vertical, 10)
-                            .contentShape(Rectangle()) // Ensures tap stability across the entire row
+                            .contentShape(Rectangle())
                         })
-                        .buttonStyle(BorderlessButtonStyle())
                         .accessibilityIdentifier("DropdownoptionIdentifier")
                         Divider()
                             .padding(.horizontal, 16)

--- a/Sources/JoyfillUI/View/Fields/DropdownView.swift
+++ b/Sources/JoyfillUI/View/Fields/DropdownView.swift
@@ -1,15 +1,21 @@
 import SwiftUI
 import JoyfillModel
 
-// 1. Create a lightweight wrapper to safely pass state into the sheet context
-struct DropdownSheetContext: Identifiable {
-    let id: String // Tied directly to the field identifier
-    let model: DropdownDataModel
+// 1. A lightweight presentation token that decouples from active memory pointers
+enum DropdownPresentationState: Identifiable {
+    case active(model: DropdownDataModel)
+    
+    var id: String {
+        switch self {
+        case .active(let model):
+            return model.fieldIdentifier.fieldID
+        }
+    }
 }
 
 struct DropdownView: View {
     @State var selectedDropdownValueID: String?
-    @State private var activeSheetContext: DropdownSheetContext?
+    @State private var presentationState: DropdownPresentationState? = nil
     @Environment(\.navigationFocusFieldId) private var navigationFocusFieldId
     private var dropdownDataModel: DropdownDataModel
 
@@ -29,11 +35,8 @@ struct DropdownView: View {
                 eventHandler.onDecoratorAction(event: dropdownDataModel.fieldIdentifier, action: decorator.action ?? "")
             }
             Button(action: {
-                activeSheetContext = DropdownSheetContext(
-                    id: dropdownDataModel.fieldIdentifier.fieldID,
-                    model: dropdownDataModel
-                )
                 eventHandler.onFocus(event: dropdownDataModel.fieldIdentifier)
+                presentationState = .active(model: dropdownDataModel)
             }, label: {
                 HStack {
                     Text(dropdownDataModel.options?.filter {
@@ -52,20 +55,30 @@ struct DropdownView: View {
             .buttonStyle(BorderlessButtonStyle())
             .fieldBorder(isFocused: navigationFocusFieldId == dropdownDataModel.fieldIdentifier.fieldID)
         }
-        .background(
-            Color.clear
-                .sheet(item: $activeSheetContext) { context in
-                    if #available(iOS 16, *) {
-                        DropDownOptionList(dropdownDataModel: context.model, selectedDropdownValueID: $selectedDropdownValueID)
-                            .presentationDetents([.medium])
-                    } else {
-                        DropDownOptionList(dropdownDataModel: context.model, selectedDropdownValueID: $selectedDropdownValueID)
-                    }
+        .sheet(item: $presentationState) { state in
+            switch state {
+            case .active(let model):
+                if #available(iOS 16, *) {
+                    DropDownOptionList(
+                        dropdownDataModel: model,
+                        initialSelectionID: selectedDropdownValueID,
+                        onSelectionChanged: { newID in
+                            self.selectedDropdownValueID = newID
+                        }
+                    )
+                    .presentationDetents([.medium])
+                } else {
+                    DropDownOptionList(
+                        dropdownDataModel: model,
+                        initialSelectionID: selectedDropdownValueID,
+                        onSelectionChanged: { newID in
+                            self.selectedDropdownValueID = newID
+                        }
+                    )
                 }
-        )
+            }
+        }
         .onChange(of: selectedDropdownValueID) { newValue in
-            // Skip if @State already matches the model — means this fire came from a
-            // programmatic sync, not a user tap. Prevents an echo loop.
             if newValue == dropdownDataModel.dropdownValue {
                 return
             }
@@ -85,11 +98,13 @@ struct DropdownView: View {
 struct DropDownOptionList: View {
     @Environment(\.presentationMode) var presentationMode
     private var dropdownDataModel: DropdownDataModel
-    @Binding var selectedDropdownValueID: String?
+    @State private var currentSelectionID: String?
+    let onSelectionChanged: (String?) -> Void
     
-    public init(dropdownDataModel: DropdownDataModel, selectedDropdownValueID: Binding<String?>) {
+    public init(dropdownDataModel: DropdownDataModel, initialSelectionID: String?, onSelectionChanged: @escaping (String?) -> Void) {
         self.dropdownDataModel = dropdownDataModel
-        self._selectedDropdownValueID = selectedDropdownValueID
+        self._currentSelectionID = State(initialValue: initialSelectionID)
+        self.onSelectionChanged = onSelectionChanged
     }
     
     var body: some View {
@@ -103,21 +118,25 @@ struct DropDownOptionList: View {
                         .imageScale(.large)
                 })
                 .padding(.horizontal, 16)
-                .buttonStyle(BorderlessButtonStyle()) // Added protection against row triggers
+                .buttonStyle(BorderlessButtonStyle())
             }
             ScrollView {
                 if let options = dropdownDataModel.options?.filter({ !($0.deleted ?? false) }) {
                     ForEach(options) { option in
                         Button(action: {
-                            if selectedDropdownValueID == option.id {
-                                selectedDropdownValueID = nil
-                            } else {
-                                selectedDropdownValueID = option.id
-                            }
+                            let targetedID = (currentSelectionID == option.id) ? nil : option.id
+                            
+                            // 1. Update sheet view local state layout immediately
+                            currentSelectionID = targetedID
+                            
+                            // 2. Safely bubble values back to the core parent object
+                            onSelectionChanged(targetedID)
+                            
+                            // 3. Close the modal view cleanly
                             presentationMode.wrappedValue.dismiss()
                         }, label: {
                             HStack(alignment: .top) {
-                                Image(systemName: (selectedDropdownValueID == option.id) ? "checkmark.circle.fill" : "circle")
+                                Image(systemName: (currentSelectionID == option.id) ? "checkmark.circle.fill" : "circle")
                                     .padding(.top, 4)
                                 Text(option.value ?? "")
                                     .darkLightThemeColor()
@@ -126,9 +145,9 @@ struct DropDownOptionList: View {
                             }
                             .padding(.horizontal, 28)
                             .padding(.vertical, 10)
-                            .contentShape(Rectangle()) // Ensures the empty whitespace area is clickable
+                            .contentShape(Rectangle()) // Ensures tap stability across the entire row
                         })
-                        .buttonStyle(BorderlessButtonStyle()) // Prevents selection conflicts inside structural lists
+                        .buttonStyle(BorderlessButtonStyle())
                         .accessibilityIdentifier("DropdownoptionIdentifier")
                         Divider()
                             .padding(.horizontal, 16)

--- a/Sources/JoyfillUI/View/Fields/DropdownView.swift
+++ b/Sources/JoyfillUI/View/Fields/DropdownView.swift
@@ -3,7 +3,7 @@ import JoyfillModel
 
 struct DropdownView: View {
     @State var selectedDropdownValueID: String?
-    /// The row does not own its sheet — see `FieldSheetPresentation` in FormView.
+    /// The row does not own its sheet — see `FieldSheetPresentation`.
     @Binding var activeFieldSheet: FieldSheetPresentation?
     @Environment(\.navigationFocusFieldId) private var navigationFocusFieldId
     private var dropdownDataModel: DropdownDataModel

--- a/Sources/JoyfillUI/View/Fields/DropdownView.swift
+++ b/Sources/JoyfillUI/View/Fields/DropdownView.swift
@@ -1,9 +1,15 @@
 import SwiftUI
 import JoyfillModel
 
+// 1. Create a lightweight wrapper to safely pass state into the sheet context
+struct DropdownSheetContext: Identifiable {
+    let id: String // Tied directly to the field identifier
+    let model: DropdownDataModel
+}
+
 struct DropdownView: View {
     @State var selectedDropdownValueID: String?
-    @State private var isSheetPresented = false
+    @State private var activeSheetContext: DropdownSheetContext?
     @Environment(\.navigationFocusFieldId) private var navigationFocusFieldId
     private var dropdownDataModel: DropdownDataModel
 
@@ -23,7 +29,10 @@ struct DropdownView: View {
                 eventHandler.onDecoratorAction(event: dropdownDataModel.fieldIdentifier, action: decorator.action ?? "")
             }
             Button(action: {
-                isSheetPresented = true
+                activeSheetContext = DropdownSheetContext(
+                    id: dropdownDataModel.fieldIdentifier.fieldID,
+                    model: dropdownDataModel
+                )
                 eventHandler.onFocus(event: dropdownDataModel.fieldIdentifier)
             }, label: {
                 HStack {
@@ -40,16 +49,20 @@ struct DropdownView: View {
                 .frame(height: 40)
             })
             .accessibilityIdentifier("Dropdown")
+            .buttonStyle(BorderlessButtonStyle())
             .fieldBorder(isFocused: navigationFocusFieldId == dropdownDataModel.fieldIdentifier.fieldID)
-            .sheet(isPresented: $isSheetPresented) {
-                if #available(iOS 16, *) {
-                    DropDownOptionList(dropdownDataModel: dropdownDataModel, selectedDropdownValueID: $selectedDropdownValueID)
-                        .presentationDetents([.medium])
-                } else {
-                    DropDownOptionList(dropdownDataModel: dropdownDataModel, selectedDropdownValueID: $selectedDropdownValueID)
-                }
-            }
         }
+        .background(
+            Color.clear
+                .sheet(item: $activeSheetContext) { context in
+                    if #available(iOS 16, *) {
+                        DropDownOptionList(dropdownDataModel: context.model, selectedDropdownValueID: $selectedDropdownValueID)
+                            .presentationDetents([.medium])
+                    } else {
+                        DropDownOptionList(dropdownDataModel: context.model, selectedDropdownValueID: $selectedDropdownValueID)
+                    }
+                }
+        )
         .onChange(of: selectedDropdownValueID) { newValue in
             // Skip if @State already matches the model — means this fire came from a
             // programmatic sync, not a user tap. Prevents an echo loop.
@@ -90,6 +103,7 @@ struct DropDownOptionList: View {
                         .imageScale(.large)
                 })
                 .padding(.horizontal, 16)
+                .buttonStyle(BorderlessButtonStyle()) // Added protection against row triggers
             }
             ScrollView {
                 if let options = dropdownDataModel.options?.filter({ !($0.deleted ?? false) }) {
@@ -112,7 +126,9 @@ struct DropDownOptionList: View {
                             }
                             .padding(.horizontal, 28)
                             .padding(.vertical, 10)
+                            .contentShape(Rectangle()) // Ensures the empty whitespace area is clickable
                         })
+                        .buttonStyle(BorderlessButtonStyle()) // Prevents selection conflicts inside structural lists
                         .accessibilityIdentifier("DropdownoptionIdentifier")
                         Divider()
                             .padding(.horizontal, 16)
@@ -124,4 +140,3 @@ struct DropDownOptionList: View {
         .padding(.vertical, 20)
     }
 }
-

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -286,15 +286,20 @@ struct FormView: View {
 
     var body: some View {
         ScrollViewReader { proxy in
-            List($listModels, id: \.wrappedValue.fieldIdentifier.fieldID) { $listModel in
-                if documentEditor.shouldShow(fieldID: listModel.fieldIdentifier.fieldID) {
-                    fieldView(listModelBinding: $listModel)
-                        .listRowSeparator(.hidden)
-                        .buttonStyle(.borderless)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach($listModels, id: \.wrappedValue.fieldIdentifier.fieldID) { $listModel in
+                        if documentEditor.shouldShow(fieldID: listModel.fieldIdentifier.fieldID) {
+                            fieldView(listModelBinding: $listModel)
+                                .id(listModel.fieldIdentifier.fieldID)
+                                .buttonStyle(.borderless)
+                        }
+                    }
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
             }
             .environment(\.navigationFocusFieldId, documentEditor.navigationFocusFieldId)
-            .listStyle(PlainListStyle())
             .modifier(KeyboardDismissModifier())
             .onChange(of: $currentFocusedFieldsID.wrappedValue) { newValue in
                 guard newValue != nil else { return }

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -232,17 +232,8 @@ extension FieldListModelType {
     }
 }
 
-/// Identifies which field's modal sheet is currently open, by field id.
-///
-/// Sheets for fields inside `FormView`'s `List` must be anchored on the `List`,
-/// not on the row that triggers them: `List` is backed by `UITableView`, which
-/// recycles a row's hosting controller as it scrolls off and back on screen, and
-/// a row-owned `.sheet` can be orphaned by that recycling and stop presenting
-/// entirely (NO-1508). The `List` itself is never recycled.
-///
-/// Only `DropdownView` is hoisted today. `ImageView` has the same row-owned-sheet
-/// shape and can adopt this by writing its field id here instead of flipping a
-/// local flag, plus a branch in `fieldSheet(for:)`.
+/// Which field's sheet is open. Must live on FormView's List, never on a row —
+/// UITableView recycling orphans row-owned sheets and kills them (NO-1508).
 struct FieldSheetPresentation: Identifiable {
     let id: String
 }
@@ -300,16 +291,13 @@ struct FormView: View {
         }
     }
 
-    /// Sheet content for whichever field is currently presenting one.
-    /// New sheet-presenting field types get a branch here.
+    /// Sheet content for the presenting field. ImageView can add a branch here.
     @ViewBuilder
     private func fieldSheet(for fieldID: String) -> some View {
         dropdownOptionsSheet(for: fieldID)
     }
 
-    /// Re-resolves the model on every evaluation rather than capturing it, so the option
-    /// list stays live if conditional logic or a formula rewrites `options` while the
-    /// sheet is open.
+    /// Re-resolves rather than captures, so options stay live while the sheet is open.
     @ViewBuilder
     private func dropdownOptionsSheet(for fieldID: String) -> some View {
         if let model = dropdownModel(for: fieldID) {

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -232,10 +232,26 @@ extension FieldListModelType {
     }
 }
 
+/// Identifies which field's modal sheet is currently open, by field id.
+///
+/// Sheets for fields inside `FormView`'s `List` must be anchored on the `List`,
+/// not on the row that triggers them: `List` is backed by `UITableView`, which
+/// recycles a row's hosting controller as it scrolls off and back on screen, and
+/// a row-owned `.sheet` can be orphaned by that recycling and stop presenting
+/// entirely (NO-1508). The `List` itself is never recycled.
+///
+/// Only `DropdownView` is hoisted today. `ImageView` has the same row-owned-sheet
+/// shape and can adopt this by writing its field id here instead of flipping a
+/// local flag, plus a branch in `fieldSheet(for:)`.
+struct FieldSheetPresentation: Identifiable {
+    let id: String
+}
+
 struct FormView: View {
     @Binding var listModels: [FieldListModel]
     @State var currentFocusedFieldsID: String = ""
     @State var lastFocusedFieldsID: String? = nil
+    @State private var activeFieldSheet: FieldSheetPresentation?
     let documentEditor: DocumentEditor
 
     @ViewBuilder
@@ -253,7 +269,7 @@ struct FormView: View {
             MultiSelectionView(multiSelectionDataModel: model, eventHandler: self, currentFocusedFieldsDataId: currentFocusedFieldsID)
                 .disabled(listModel.fieldEditMode == .readonly)
         case .dropdown(let model):
-            DropdownView(dropdownDataModel: model, eventHandler: self)
+            DropdownView(dropdownDataModel: model, eventHandler: self, activeFieldSheet: $activeFieldSheet)
                 .disabled(listModel.fieldEditMode == .readonly)
         case .textarea(let model):
             MultiLineTextView(multiLineDataModel: model, eventHandler: self)
@@ -284,6 +300,44 @@ struct FormView: View {
         }
     }
 
+    /// Sheet content for whichever field is currently presenting one.
+    /// New sheet-presenting field types get a branch here.
+    @ViewBuilder
+    private func fieldSheet(for fieldID: String) -> some View {
+        dropdownOptionsSheet(for: fieldID)
+    }
+
+    /// Re-resolves the model on every evaluation rather than capturing it, so the option
+    /// list stays live if conditional logic or a formula rewrites `options` while the
+    /// sheet is open.
+    @ViewBuilder
+    private func dropdownOptionsSheet(for fieldID: String) -> some View {
+        if let model = dropdownModel(for: fieldID) {
+            let selection = Binding<String?>(
+                get: { dropdownModel(for: fieldID)?.dropdownValue },
+                set: { newID in
+                    onChange(event: FieldChangeData(fieldIdentifier: model.fieldIdentifier,
+                                                    updateValue: .string(newID ?? "")))
+                }
+            )
+            if #available(iOS 16, *) {
+                DropDownOptionList(dropdownDataModel: model, selectedDropdownValueID: selection)
+                    .presentationDetents([.medium])
+            } else {
+                DropDownOptionList(dropdownDataModel: model, selectedDropdownValueID: selection)
+            }
+        }
+    }
+
+    private func dropdownModel(for fieldID: String) -> DropdownDataModel? {
+        for listModel in listModels where listModel.fieldIdentifier.fieldID == fieldID {
+            if case .dropdown(let model) = listModel.model {
+                return model
+            }
+        }
+        return nil
+    }
+
     var body: some View {
         ScrollViewReader { proxy in
             List($listModels, id: \.wrappedValue.fieldIdentifier.fieldID) { $listModel in
@@ -295,6 +349,9 @@ struct FormView: View {
             }
             .environment(\.navigationFocusFieldId, documentEditor.navigationFocusFieldId)
             .listStyle(PlainListStyle())
+            .sheet(item: $activeFieldSheet) { presentation in
+                fieldSheet(for: presentation.id)
+            }
             .modifier(KeyboardDismissModifier())
             .onChange(of: $currentFocusedFieldsID.wrappedValue) { newValue in
                 guard newValue != nil else { return }

--- a/Sources/JoyfillUI/View/FormView.swift
+++ b/Sources/JoyfillUI/View/FormView.swift
@@ -286,20 +286,15 @@ struct FormView: View {
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 12) {
-                    ForEach($listModels, id: \.wrappedValue.fieldIdentifier.fieldID) { $listModel in
-                        if documentEditor.shouldShow(fieldID: listModel.fieldIdentifier.fieldID) {
-                            fieldView(listModelBinding: $listModel)
-                                .id(listModel.fieldIdentifier.fieldID)
-                                .buttonStyle(.borderless)
-                        }
-                    }
+            List($listModels, id: \.wrappedValue.fieldIdentifier.fieldID) { $listModel in
+                if documentEditor.shouldShow(fieldID: listModel.fieldIdentifier.fieldID) {
+                    fieldView(listModelBinding: $listModel)
+                        .listRowSeparator(.hidden)
+                        .buttonStyle(.borderless)
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
             }
             .environment(\.navigationFocusFieldId, documentEditor.navigationFocusFieldId)
+            .listStyle(PlainListStyle())
             .modifier(KeyboardDismissModifier())
             .onChange(of: $currentFocusedFieldsID.wrappedValue) { newValue in
                 guard newValue != nil else { return }


### PR DESCRIPTION
## Context

Dropdown fields rendered inside `FormView`'s SwiftUI `List` intermittently stopped opening their options sheet — tapping did nothing, most noticeably after scrolling, and once a row died it stayed dead while its siblings kept working.

Root cause: `List` on iOS is backed by `UITableView`, which recycles a row's hosting controller as the row scrolls off and back on screen. A `.sheet` anchored anywhere inside that row can be orphaned by the recycling and stop presenting entirely.

Two earlier attempts on this branch were dead ends and have been reverted:

- `907ab4d7` replaced `List` with `ScrollView { LazyVStack }` to remove recycling altogether. Reverted in `0563d447` — it fixes the bug but gives up `List` behaviour the form relies on.
- The later `DropdownView`-scoped attempt swapped the `Bool` presentation flag for an `Identifiable` item and moved the `.sheet` from the `Button` to the row's `VStack`. Both positions are still **inside the recycled row**, so the same hosting controller was still presenting — structurally the same as the `DispatchQueue.main.async { isSheetPresented = true }` attempt that was already tried and didn't work.

## Changes

The fix is to stop the row from owning a sheet at all. **+55 / −16 across 2 files.**

**[`FormView.swift`](Sources/JoyfillUI/View/FormView.swift)**
- New `FieldSheetPresentation: Identifiable` — carries the field id only, no model.
- One `@State activeFieldSheet` and one `.sheet(item:)` on the `List`, replacing one `.sheet` modifier and one `@State` flag *per dropdown row*.
- `fieldSheet(for:)` → `dropdownOptionsSheet(for:)` → `dropdownModel(for:)`. The model is re-resolved from `listModels` on every evaluation rather than captured, so the option list stays live if conditional logic or a formula rewrites `options` while the sheet is open.
- Selection routes through `onChange` instead of row-local state.

**[`DropdownView.swift`](Sources/JoyfillUI/View/Fields/DropdownView.swift)**
- Reverted to `main`, then: takes a `Binding<FieldSheetPresentation?>`, writes its field id on tap, owns no sheet.
- Kept `.contentShape(Rectangle())` on the option row from the previous attempt — that one does real work on the padded area.

## Why this approach

The `.sheet` has to be anchored on a view that is never recycled, and the `List` is the nearest one. Nothing else about the presentation mechanism matters: changing the flag's *type*, or its *position within the row*, leaves the same hosting controller presenting. That is why the two earlier attempts didn't hold.

Naming is deliberately field-agnostic. [`ImageView.swift:149`](Sources/JoyfillUI/View/Fields/ImageView.swift:149) has the same row-owned-sheet shape; adopting this is a branch in `fieldSheet(for:)` plus swapping its `@State showMoreImages` for a write to `activeFieldSheet`. **`ImageView` is not touched here** — this change is dropdown-only, on purpose.

No `Kind` discriminator was added to `FieldSheetPresentation`: the field type is already in `listModels` via `FieldListModelType`, so `fieldSheet(for:)` can switch on the model it looks up by id.

### Performance

The diff moves state up a level, so worth stating explicitly:

- **Cheaper:** on a dropdown-heavy page this collapses N `.sheet` modifiers and N `@State` flags into one. On `3000-fields.json` (662 dropdowns) that's 662 → 1.
- **Not a regression:** writing `activeFieldSheet` invalidates `FormView.body` rather than a single row — but the tap already did that. `FormView.onFocus` ([`FormView.swift:357`](Sources/JoyfillUI/View/FormView.swift:357)) unconditionally writes `currentFocusedFieldsID`, also `@State` on `FormView`, in the same button action. The two coalesce into one transaction.
- **One new cost:** `dropdownModel(for:)` is a linear scan over `listModels`, called once per option per sheet body build. Zero when no sheet is open; roughly 40k string comparisons on a 3000-field page with a 14-option dropdown. Sub-millisecond. Removable by capturing the model instead, at the cost of reintroducing a staleness risk in sheet content that hasn't been ruled out.

## Screenshot / video

None — no visual change. See the verification note below.

## Public API

**No public API change.** `DropdownView`, `DropDownOptionList`, and the new `FieldSheetPresentation` are all internal. `DropdownView.init` gained a parameter but the type isn't reachable outside the module.

**No schema impact.** The emitted `FieldChangeData` payload is unchanged — still `ValueUnion.string(newValue ?? "")` — so nothing in JoyDoc parsing, validation, or `joyfill-schema` is affected.

## Test coverage

**Not covered by an automated test, and the existing suite cannot catch this bug.**

`JoyfillSwiftUIExample/JoyfillUITests/DropdownField/DropdownFieldUITestCases.swift` has 18 tests covering selection, clearing, conditional logic, payload shape, readonly, and focus/blur — but its fixture has only 4 fields, which never fills a screen, so `UITableView` never recycles anything. `testDropdownRetainsValueAfterNavigation` is the closest: it swipes up and down, but only asserts the label and never re-taps to open.

That is why this shipped to production undetected.

## Notes for reviewers

- **The runtime repro has not been run.** The package builds clean for iOS Simulator; that is all that has been verified. `Sample JSONs/others/3000-fields.json` (662 dropdowns / 2898 fields) is the best vehicle in the repo — well past what's needed to force cell reuse. Scroll several screens down, then tap dropdowns on the way back up. This should pass before merge.
- **Watch label latency specifically.** Selection now reaches the label via a model round-trip (`onChange` → `documentEditor.updateField` → `refreshField` → `pageFieldModels` → the row's `onChange(of: dropdownDataModel.dropdownValue)`) rather than from row-local `@State`. That path is synchronous with no dispatch, but it is the behavioural difference most likely to surface.
- The echo-loop comment above the guard in `DropdownView`'s `onChange` matters more under this design than it did on `main` — the round-trip above is exactly what that guard stops from re-emitting. Please don't remove it.
- Scope is dropdown-only. Other sheet-presenting fields in the same `List` were left alone; `ImageView` is the one worth watching for the same symptom.
